### PR TITLE
Allow EVAL KEYS and ARGS to be passed as an array/ Parse ZRANGE WITHSCORES as object (FIXES #97)

### DIFF
--- a/examples/eval.js
+++ b/examples/eval.js
@@ -12,3 +12,39 @@ client.eval([ "return 100.5", 0 ], function (err, res) {
     console.dir(err);
     console.dir(res);
 });
+
+
+client.eval("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}", ["a", "b"], ["c", "d"], function (err, res) {
+	console.dir(err);
+	console.dir(res);
+});
+
+ //test {EVAL - Allow variadic KEYS and ARGS to be passed to script in array format}
+client.eval(["return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}", ["a", "b"], ["c", "d"]], function (err, res) {
+    console.dir(err);
+    console.dir(res);
+});
+
+//test {EVAL - Script with no arguments}
+client.eval("return 1", function (err, res) {
+    console.dir(err);
+    console.dir(res);
+});
+
+//test {EVAL - Script with no arguments in array format}
+client.eval(["return 1"], function (err, res) {
+    console.dir(err);
+    console.dir(res);
+});
+
+//test {EVAL - Script with only KEYS}
+client.eval("return {KEYS[1], KEYS[2]}", ["key1", "key2"], function (err, res) {
+    console.dir(err);
+    console.dir(res);
+});
+
+//test {EVAL - Script with only KEYS in array format}
+client.eval(["return {KEYS[1], KEYS[2]}", ["key1", "key2"]], function (err, res) {
+    console.dir(err);
+    console.dir(res);
+});

--- a/index.js
+++ b/index.js
@@ -678,7 +678,7 @@ RedisClient.prototype.return_reply = function (reply) {
             }
 
             // TODO - confusing and error-prone that hgetall is special cased in two places
-            if (reply && command_obj.replyAsObject()) {
+            if (reply && command_obj.replyWithObject()) {
                 reply = reply_to_object(reply);
             }
 
@@ -733,7 +733,6 @@ RedisClient.prototype.return_reply = function (reply) {
 // This Command constructor is ever so slightly faster than using an object literal, but more importantly, using
 // a named constructor helps it show up meaningfully in the V8 CPU profiler and in heap snapshots.
 function Command(command, args, sub_command, buffer_args, callback) {
-	console.log('New command', command, args, sub_command, buffer_args, callback);
     this.command = command;
     this.args = args;
     this.sub_command = sub_command;
@@ -741,7 +740,7 @@ function Command(command, args, sub_command, buffer_args, callback) {
     this.callback = callback;
 }
 
-Command.replyAsObject = function (command, args) {
+Command.replyWithObject = function (command, args) {
 	switch(command.toLowerCase()) {
 		case 'hgetall':
 			return true;
@@ -752,8 +751,8 @@ Command.replyAsObject = function (command, args) {
 	return false;
 };
 
-Command.prototype.replyAsObject = function () {
-	return Command.replyAsObject(this.command, this.args);
+Command.prototype.replyWithObject = function () {
+	return Command.replyWithObject(this.command, this.args);
 }
 
 RedisClient.prototype.send_command = function (command, args, callback) {
@@ -1172,7 +1171,7 @@ Multi.prototype.exec = function (callback) {
                 args = self.queue[i];
 
                 // TODO - confusing and error-prone that hgetall is special cased in two places
-                if (reply && Command.replyAsObject(args[0], args.slice(1))) {
+                if (reply && Command.replyWithObject(args[0], args.slice(1))) {
                     replies[i - 1] = reply = reply_to_object(reply);
                 }
 

--- a/test.js
+++ b/test.js
@@ -495,6 +495,51 @@ tests.EVAL_1 = function () {
         assert.strictEqual("c", res[2], name);
         assert.strictEqual("d", res[3], name);
     });
+    
+    //test {EVAL - Allow variadic KEYS and ARGS to be passed to script}
+    client.eval("return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}", ["a", "b"], ["c", "d"], function (err, res) {
+        assert.strictEqual(4, res.length, name);
+        assert.strictEqual("a", res[0], name);
+        assert.strictEqual("b", res[1], name);
+        assert.strictEqual("c", res[2], name);
+        assert.strictEqual("d", res[3], name);
+    });
+    
+     //test {EVAL - Allow variadic KEYS and ARGS to be passed to script in array format}
+    client.eval(["return {KEYS[1],KEYS[2],ARGV[1],ARGV[2]}", ["a", "b"], ["c", "d"]], function (err, res) {
+        assert.strictEqual(4, res.length, name);
+        assert.strictEqual("a", res[0], name);
+        assert.strictEqual("b", res[1], name);
+        assert.strictEqual("c", res[2], name);
+        assert.strictEqual("d", res[3], name);
+    });
+    
+    //test {EVAL - Script with no arguments}
+    client.eval("return 1", function (err, res) {
+        assert.strictEqual(1, res, name);
+    });
+    
+    //test {EVAL - Script with no arguments in array format}
+    client.eval(["return 1"], function (err, res) {
+        assert.strictEqual(1, res, name);
+    });
+    
+    //test {EVAL - Script with only KEYS}
+    client.eval("return {KEYS[1], KEYS[2]}", ["key1", "key2"], function (err, res) {
+        assert.strictEqual(2, res.length, name);
+        assert.strictEqual(res[0], "key1", name);
+        assert.strictEqual(res[1], "key2", name);
+    });
+    
+    //test {EVAL - Script with only KEYS in array format}
+    client.eval(["return {KEYS[1], KEYS[2]}", ["key1", "key2"]], function (err, res) {
+        assert.strictEqual(2, res.length, name);
+        assert.strictEqual(res[0], "key1", name);
+        assert.strictEqual(res[1], "key2", name);
+    });
+    
+    
+    
 
     // prepare sha sum for evalsha cache test
     var source = "return redis.call('get', 'sha test')",


### PR DESCRIPTION
`redis.eval` requires that the client know the KEYS and ARGS that will be passed to the Lua script.
I am using Lua scripts that manipulate a variable number of KEYS and have to use the following code:

`var args = [script, keys.length].concat(keys);`
`redis.eval(args, function (err, res) {
  //
});
`

redis.eval should allow calls of the forms (callback optional):
`redis.eval(script, keys, args);`
`redis.eval(script, keys);`
`redis.eval(script); //no args`

To give a concrete example, this function increments the KEYS passed to the script and returns the new values in an array. 

```
function incrementAgentCount (groupIds, domain) {
    var groupKeys = groupIds.map(function (groupId) {
        return groupId + '@' + domain;
    }),
        script = "local updated = {};for i = 1, #KEYS do  local k = KEYS[i];  updated[i] = redis.call('hincrby', k, 'agents:online', 1); 
          end;return updated;",
        args = [script, groupKeys.length].concat(groupKeys);

    mRedis.eval(args, function (err, res) {
        //res 
    });

}
```

Although this can be done with a `multi-exec`, the same script also does some comparisons and increments a second key, which I have omitted. 
