### PR TITLE
Adding send_command_buf function sending reply as Buffers instead of Strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ client.get("missingkey", function(err, reply) {
 });
 ```
 
+If you want receive reply as Buffers instead of Strings just add "b_" prefix before command name:
+
+```js
+client.b_get("some key", function(err, buf) {});
+```
+
 For a list of Redis commands, see [Redis Command Reference](http://redis.io/commands)
 
 Minimal parsing is done on the replies. Commands that return a integer return JavaScript Numbers, arrays return JavaScript Array. `HGETALL` returns an Object keyed by the hash keys. All strings will either be returned as string or as buffer depending on your setting.
@@ -665,6 +671,10 @@ you can use `send_command()` to send arbitrary commands to Redis.
 The command_name has to be lower case.
 
 All commands are sent as multi-bulk commands. `args` can either be an Array of arguments, or omitted / set to undefined.
+
+## client.send_command_buf(command_name[, [args][, callback]])
+
+The same as client.send_command but is sending reply as Buffers instead of Strings.
 
 ## client.connected
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -2,12 +2,12 @@
 
 var betterStackTraces = /development/i.test(process.env.NODE_ENV) || /\bredis\b/i.test(process.env.NODE_DEBUG);
 
-function Command (command, args, callback, call_on_write) {
+function Command (command, args, callback, call_on_write, buffer_reply) {
     this.command = command;
     this.args = args;
-    this.buffer_args = false;
     this.callback = callback;
     this.call_on_write = call_on_write;
+    this.buffer_reply = buffer_reply;
     if (betterStackTraces) {
         this.error = new Error();
     }

--- a/lib/commands.js
+++ b/lib/commands.js
@@ -1,5 +1,6 @@
 'use strict';
 
+require('./individualCommands'); // We should define individual commands before adding standard commands
 var commands = require('redis-commands');
 var Multi = require('./multi');
 var RedisClient = require('../').RedisClient;
@@ -17,6 +18,8 @@ var changeFunctionName = (function () {
     }
 }());
 
+var parseArgs_arr, parseArgs_callback;
+
 // TODO: Rewrite this including the invidual commands into a Commands class
 // that provided a functionality to add new commands to the client
 
@@ -26,88 +29,110 @@ commands.list.forEach(function (command) {
     // Convert those to a underscore to prevent using invalid function names
     var commandName = command.replace(/(?:^([0-9])|[^a-zA-Z0-9_$])/g, '_$1');
 
+    // Adding "b_" prefixed functions.
+    // Multi and batch should not be prefixed because you should add prefixes directly to commands you calling, for example client.multi().b_get().exec();
+    if (command !== 'multi' && command !== 'batch' && command !== 'exec') {
+        if (!RedisClient.prototype['b_' + command]) {
+            // When function already exists we can not call internal_send_command
+            if (RedisClient.prototype[command]) {
+                RedisClient.prototype['b_' + command] = function () {
+                    try {
+                        this.cur_command_ret_buf++;
+                        return this[command].apply(this, arguments);
+                    } finally {
+                        this.cur_command_ret_buf--;
+                    }
+                };
+            }else{
+                RedisClient.prototype['b_' + command] = function () {
+                    parseArgs(arguments);
+                    return this.internal_send_command(new Command(command, parseArgs_arr, parseArgs_callback, undefined, true));
+                };
+            }
+            changeName(RedisClient, 'b_' + command, 'b_' + commandName);
+        }
+
+        if (!Multi.prototype['b_' + command]) {
+            // When function already exists we can not just call this.queue_push only
+            if (Multi.prototype[command]) {
+                Multi.prototype['b_' + command] = function () {
+                    try {
+                        this.cur_command_ret_buf++;
+                        return this[command].apply(this, arguments);
+                    } finally {
+                        this.cur_command_ret_buf--;
+                    }
+                };
+            }else{
+                Multi.prototype['b_' + command] = function () {
+                    parseArgs(arguments);
+                    this.queue_push(new Command(command, parseArgs_arr, parseArgs_callback, undefined, true));
+                    return this;
+                };
+            }
+            changeName(Multi, 'b_' + command, 'b_' + commandName);
+        }
+    }
+
     // Do not override existing functions
     if (!RedisClient.prototype[command]) {
         RedisClient.prototype[command.toUpperCase()] = RedisClient.prototype[command] = function () {
-            var arr;
-            var len = arguments.length;
-            var callback;
-            var i = 0;
-            if (Array.isArray(arguments[0])) {
-                arr = arguments[0];
-                if (len === 2) {
-                    callback = arguments[1];
-                }
-            } else if (len > 1 && Array.isArray(arguments[1])) {
-                if (len === 3) {
-                    callback = arguments[2];
-                }
-                len = arguments[1].length;
-                arr = new Array(len + 1);
-                arr[0] = arguments[0];
-                for (; i < len; i += 1) {
-                    arr[i + 1] = arguments[1][i];
-                }
-            } else {
-                // The later should not be the average use case
-                if (len !== 0 && (typeof arguments[len - 1] === 'function' || typeof arguments[len - 1] === 'undefined')) {
-                    len--;
-                    callback = arguments[len];
-                }
-                arr = new Array(len);
-                for (; i < len; i += 1) {
-                    arr[i] = arguments[i];
-                }
-            }
-            return this.internal_send_command(new Command(command, arr, callback));
+            parseArgs(arguments);
+            return this.internal_send_command(new Command(command, parseArgs_arr, parseArgs_callback));
         };
-        if (changeFunctionName) {
-            Object.defineProperty(RedisClient.prototype[command], 'name', {
-                value: commandName
-            });
-        }
+        changeName(RedisClient, command, commandName);
     }
 
     // Do not override existing functions
     if (!Multi.prototype[command]) {
         Multi.prototype[command.toUpperCase()] = Multi.prototype[command] = function () {
-            var arr;
-            var len = arguments.length;
-            var callback;
-            var i = 0;
-            if (Array.isArray(arguments[0])) {
-                arr = arguments[0];
-                if (len === 2) {
-                    callback = arguments[1];
-                }
-            } else if (len > 1 && Array.isArray(arguments[1])) {
-                if (len === 3) {
-                    callback = arguments[2];
-                }
-                len = arguments[1].length;
-                arr = new Array(len + 1);
-                arr[0] = arguments[0];
-                for (; i < len; i += 1) {
-                    arr[i + 1] = arguments[1][i];
-                }
-            } else {
-                // The later should not be the average use case
-                if (len !== 0 && (typeof arguments[len - 1] === 'function' || typeof arguments[len - 1] === 'undefined')) {
-                    len--;
-                    callback = arguments[len];
-                }
-                arr = new Array(len);
-                for (; i < len; i += 1) {
-                    arr[i] = arguments[i];
-                }
-            }
-            this.queue.push(new Command(command, arr, callback));
+            parseArgs(arguments);
+            this.queue_push(new Command(command, parseArgs_arr, parseArgs_callback));
             return this;
         };
-        if (changeFunctionName) {
-            Object.defineProperty(Multi.prototype[command], 'name', {
-                value: commandName
-            });
-        }
+        changeName(Multi, command, commandName);
     }
 });
+
+function parseArgs(args) {
+    var arr;
+    var len = args.length;
+    var callback;
+    var i = 0;
+    if (Array.isArray(args[0])) {
+        arr = args[0];
+        if (len === 2) {
+            callback = args[1];
+        }
+    } else if (len > 1 && Array.isArray(args[1])) {
+        if (len === 3) {
+            callback = args[2];
+        }
+        len = args[1].length;
+        arr = new Array(len + 1);
+        arr[0] = args[0];
+        for (; i < len; i += 1) {
+            arr[i + 1] = args[1][i];
+        }
+    } else {
+        // The later should not be the average use case
+        if (len !== 0 && (typeof args[len - 1] === 'function' || typeof args[len - 1] === 'undefined')) {
+            len--;
+            callback = args[len];
+        }
+        arr = new Array(len);
+        for (; i < len; i += 1) {
+            arr[i] = args[i];
+        }
+    }
+    parseArgs_arr = arr;
+    parseArgs_callback = callback;
+}
+
+function changeName(lib, command, commandName) {
+    if (changeFunctionName) {
+        Object.defineProperty(lib.prototype[command], 'name', {
+            value: commandName
+        });
+    }
+}

--- a/lib/extendedApi.js
+++ b/lib/extendedApi.js
@@ -10,6 +10,18 @@ var noop = function () {};
 All documented and exposed API belongs in here
 **********************************************/
 
+RedisClient.prototype.send_command_buf = function (command, args, callback) {
+    try {
+        // After increment this.cur_command_ret_buf all internal_send_command calls will send reply as Buffers instead of Strings.
+        // Increment instead of setting to true is needed to return buffers in all subcommands even subcommands are calling several times in a row.
+        // If some subcommands are calling in process.nextTick then they must check this.cur_command_ret_buf property before process.nextTick and decide to use "b_" prefix by themselves.
+        this.cur_command_ret_buf++;
+        return this.send_command(command, args, callback);
+    } finally {
+        this.cur_command_ret_buf--; // Decrease even if internal_send_command has not been called or throw. Decrement is before return. Exceptions will be thrown up.
+    }
+};
+
 // Redirect calls to the appropriate function and use to send arbitrary / not supported commands
 RedisClient.prototype.send_command = RedisClient.prototype.sendCommand = function (command, args, callback) {
     // Throw to fail early instead of relying in order in this case
@@ -32,7 +44,7 @@ RedisClient.prototype.send_command = RedisClient.prototype.sendCommand = functio
 
     // Using the raw multi command is only possible with this function
     // If the command is not yet added to the client, the internal function should be called right away
-    // Otherwise we need to redirect the calls to make sure the interal functions don't get skipped
+    // Otherwise we need to redirect the calls to make sure the internal functions don't get skipped
     // The internal functions could actually be used for any non hooked function
     // but this might change from time to time and at the moment there's no good way to distinguishe them
     // from each other, so let's just do it do it this way for the time being
@@ -109,4 +121,16 @@ RedisClient.prototype.duplicate = function (options, callback) {
         return;
     }
     return client;
+};
+
+// Creates buffer version of individual command
+require('../').create_individual_command_buf = function (command) {
+    RedisClient.prototype['b_' + command] = function () {
+        try {
+            this.cur_command_ret_buf++;
+            return this[command].apply(this, arguments);
+        } finally {
+            this.cur_command_ret_buf--;
+        }
+    };
 };

--- a/lib/extendedApi.js
+++ b/lib/extendedApi.js
@@ -43,18 +43,18 @@ RedisClient.prototype.send_command = RedisClient.prototype.sendCommand = functio
     }
 
     // Using the raw multi command is only possible with this function
-    // If the command is not yet added to the client, the internal function should be called right away
-    // Otherwise we need to redirect the calls to make sure the internal functions don't get skipped
+    // If the command is added to the client we need to redirect the calls to make sure the internal functions don't get skipped
+    // Otherwise we should call internal_send_command
     // The internal functions could actually be used for any non hooked function
     // but this might change from time to time and at the moment there's no good way to distinguishe them
     // from each other, so let's just do it do it this way for the time being
-    if (command === 'multi' || typeof this[command] !== 'function') {
-        return this.internal_send_command(new Command(command, args, callback));
+    if (typeof this[command] === 'function' && command !== 'multi') {
+        if (typeof callback === 'function') {
+            args = args.concat([callback]); // Prevent manipulating the input array
+        }
+        return this[command].apply(this, args);
     }
-    if (typeof callback === 'function') {
-        args = args.concat([callback]); // Prevent manipulating the input array
-    }
-    return this[command].apply(this, args);
+    return this.internal_send_command(new Command(command, args, callback));
 };
 
 RedisClient.prototype.end = function (flush) {

--- a/lib/individualCommands.js
+++ b/lib/individualCommands.js
@@ -47,7 +47,7 @@ RedisClient.prototype.select = RedisClient.prototype.SELECT = function select (d
 };
 
 Multi.prototype.select = Multi.prototype.SELECT = function select (db, callback) {
-    this.queue.push(new Command('select', [db], select_callback(this._client, db, callback)));
+    this.queue_push(new Command('select', [db], select_callback(this._client, db, callback)));
     return this;
 };
 
@@ -70,7 +70,7 @@ Multi.prototype.monitor = Multi.prototype.MONITOR = function monitor (callback) 
         var call_on_write = function () {
             self._client.monitoring = true;
         };
-        this.queue.push(new Command('monitor', [], callback, call_on_write));
+        this.queue_push(new Command('monitor', [], callback, call_on_write));
         return this;
     }
     // Set multi monitoring to indicate the exec that it should abort
@@ -117,7 +117,7 @@ Multi.prototype.QUIT = Multi.prototype.quit = function quit (callback) {
         self.closing = true;
         self.ready = false;
     };
-    this.queue.push(new Command('quit', [], quit_callback(self, callback), call_on_write));
+    this.queue_push(new Command('quit', [], quit_callback(self, callback), call_on_write));
     return this;
 };
 
@@ -176,7 +176,7 @@ Multi.prototype.info = Multi.prototype.INFO = function info (section, callback) 
     } else if (section !== undefined) {
         args = Array.isArray(section) ? section : [section];
     }
-    this.queue.push(new Command('info', args, info_callback(this._client, callback)));
+    this.queue_push(new Command('info', args, info_callback(this._client, callback)));
     return this;
 };
 
@@ -218,7 +218,7 @@ Multi.prototype.auth = Multi.prototype.AUTH = function auth (pass, callback) {
 
     // Stash auth for connect and reconnect.
     this.auth_pass = pass;
-    this.queue.push(new Command('auth', [pass], auth_callback(this._client, callback)));
+    this.queue_push(new Command('auth', [pass], auth_callback(this._client, callback)));
     return this;
 };
 
@@ -309,7 +309,7 @@ Multi.prototype.client = Multi.prototype.CLIENT = function client () {
             };
         }
     }
-    this.queue.push(new Command('client', arr, callback, call_on_write));
+    this.queue_push(new Command('client', arr, callback, call_on_write));
     return this;
 };
 
@@ -388,7 +388,7 @@ Multi.prototype.hmset = Multi.prototype.HMSET = function hmset () {
             arr[i] = arguments[i];
         }
     }
-    this.queue.push(new Command('hmset', arr, callback));
+    this.queue_push(new Command('hmset', arr, callback));
     return this;
 };
 
@@ -443,7 +443,7 @@ Multi.prototype.subscribe = Multi.prototype.SUBSCRIBE = function subscribe () {
     var call_on_write = function () {
         self.pub_sub_mode = self.pub_sub_mode || self.command_queue.length + 1;
     };
-    this.queue.push(new Command('subscribe', arr, callback, call_on_write));
+    this.queue_push(new Command('subscribe', arr, callback, call_on_write));
     return this;
 };
 
@@ -500,7 +500,7 @@ Multi.prototype.unsubscribe = Multi.prototype.UNSUBSCRIBE = function unsubscribe
         // Pub sub has to be activated even if not in pub sub mode, as the return value is manipulated in the callback
         self.pub_sub_mode = self.pub_sub_mode || self.command_queue.length + 1;
     };
-    this.queue.push(new Command('unsubscribe', arr, callback, call_on_write));
+    this.queue_push(new Command('unsubscribe', arr, callback, call_on_write));
     return this;
 };
 
@@ -555,7 +555,7 @@ Multi.prototype.psubscribe = Multi.prototype.PSUBSCRIBE = function psubscribe ()
     var call_on_write = function () {
         self.pub_sub_mode = self.pub_sub_mode || self.command_queue.length + 1;
     };
-    this.queue.push(new Command('psubscribe', arr, callback, call_on_write));
+    this.queue_push(new Command('psubscribe', arr, callback, call_on_write));
     return this;
 };
 
@@ -612,6 +612,6 @@ Multi.prototype.punsubscribe = Multi.prototype.PUNSUBSCRIBE = function punsubscr
         // Pub sub has to be activated even if not in pub sub mode, as the return value is manipulated in the callback
         self.pub_sub_mode = self.pub_sub_mode || self.command_queue.length + 1;
     };
-    this.queue.push(new Command('punsubscribe', arr, callback, call_on_write));
+    this.queue_push(new Command('punsubscribe', arr, callback, call_on_write));
     return this;
 };

--- a/lib/multi.js
+++ b/lib/multi.js
@@ -7,6 +7,7 @@ var Command = require('./command');
 function Multi (client, args) {
     this._client = client;
     this.queue = new Queue();
+    this.cur_command_ret_buf = 0;
     var command, tmp_args;
     if (args) { // Either undefined or an array. Fail hard if it's not an array
         for (var i = 0; i < args.length; i++) {
@@ -34,8 +35,8 @@ function pipeline_transaction_command (self, command_obj, index) {
             self.errors.push(err);
         }
         // Keep track of who wants buffer responses:
-        // By the time the callback is called the command_obj got the buffer_args attribute attached
-        self.wants_buffers[index] = command_obj.buffer_args;
+        // By the time the callback is called the command_obj got the buffer_reply attribute attached
+        self.wants_buffers[index] = command_obj.buffer_reply;
     };
     self._client.internal_send_command(command_obj);
 }
@@ -181,6 +182,17 @@ Multi.prototype.exec = Multi.prototype.EXEC = Multi.prototype.exec_batch = funct
     }
     self._client.uncork();
     return !self._client.should_buffer;
+};
+
+// Analogue of internal_send_command for multi and batch
+Multi.prototype.queue_push = function(command_obj) {
+    if (this.cur_command_ret_buf) {
+        command_obj.buffer_reply = true; // Needed for individual commands
+        // Here is no more checks because internal_send_command will be called
+        // That also means that "b_" is checked immediately but other checks are produced on exec()
+    }
+
+    this.queue.push(command_obj);
 };
 
 module.exports = Multi;

--- a/lib/multi.js
+++ b/lib/multi.js
@@ -187,10 +187,10 @@ Multi.prototype.exec = Multi.prototype.EXEC = Multi.prototype.exec_batch = funct
 // Analogue of internal_send_command for multi and batch
 Multi.prototype.queue_push = function(command_obj) {
     if (this.cur_command_ret_buf) {
-        command_obj.buffer_reply = true; // Needed for individual commands
-        // Here is no more checks because internal_send_command will be called
-        // That also means that "b_" is checked immediately but other checks are produced on exec()
+        // Needed for overwritten individual commands with "b_" prefix
+        command_obj.buffer_reply = true;
     }
+    // Here is no more checks because internal_send_command will be called later for every pushed command
 
     this.queue.push(command_obj);
 };

--- a/test/buffer_commands.spec.js
+++ b/test/buffer_commands.spec.js
@@ -1,0 +1,641 @@
+'use strict';
+
+var assert = require('assert');
+var config = require('./lib/config');
+var redisLib = require('../');
+var RedisClient = redisLib.RedisClient;
+var Command = require('../lib/command');
+var helper = require('./helper');
+var redis = config.redis;
+var client;
+
+
+describe('buffer commands', function () {
+    helper.allTests(function (parser, ip, basicArgs) {
+        describe('using ' + parser + ' and ' + ip, function () {
+            oneParser(parser, ip, basicArgs);
+        });
+    });
+});
+
+
+function oneParser(parser, ip, basicArgs) {
+    [false].forEach(function (many_inits) {
+        describe(many_inits ? 'using many inits' : 'using one init', function () {
+            var clientConfig = config.configureClient(parser, ip, {
+                return_buffers: false,
+                detect_buffers: basicArgs[2].detect_buffers,
+            });
+            oneMode(clientConfig, many_inits);
+        });
+    });
+}
+
+
+function oneMode(clientConfig, many_inits) {
+    global[many_inits ? 'beforeEach' : 'before'](function (done) {
+        createClient(clientConfig, function () {
+            client.set('string key 1', 'string value');
+            client.hmset('hash key 2', 'key 1', 'val 1', 'key 2', 'val 2');
+            done();
+        });
+    });
+    
+    describe('get', test_get);
+    describe('multi.get', test_multi_get);
+    describe('batch.get', test_batch_get);
+    describe('select', test_select);
+    describe('superGet', test_superGet);
+    describe('other test', otherTests);
+}
+
+
+function test_get() {
+    describe('returns a string', function () {
+        it('when command is not prefixed', function (done) {
+            client.get('string key 1', assertString(done));
+        });
+
+        it('when using send_command', function (done) {
+            client.send_command('get', ['string key 1'], assertString(done));
+        });
+
+        it('when using internal_send_command', function (done) {
+            client.internal_send_command(new Command('get', ['string key 1'], assertString(done)));
+        });
+    });
+
+    describe('returns a buffer', function () {
+        it('when command is "b_" prefixed', function (done) {
+            client.b_get('string key 1', assertBuffer(done));
+        });
+
+        it('when using send_command with "b_" prefixed command', function (done) {
+            client.send_command('b_get', ['string key 1'], assertBuffer(done));
+        });
+
+        it('when using send_command_buf', function (done) {
+            client.send_command_buf('get', ['string key 1'], assertBuffer(done));
+        });
+
+        it('when using send_command_buf with "b_" prefixed command', function (done) {
+            client.send_command_buf('b_get', ['string key 1'], assertBuffer(done));
+        });
+
+        it('returns a buffer when using internal_send_command_buf', function (done) {
+            client.internal_send_command_buf(new Command('get', ['string key 1'], assertBuffer(done)));
+        });
+    });
+
+    describe('returns error', function () {
+        it('when using internal_send_command with "b_" prefixed command', function (done) {
+            client.internal_send_command(new Command('b_get', ['string key 1'], function (err) { done(!err); })); //should be err => done(!err)
+        });
+
+        it('when using internal_send_command_buf with "b_" prefixed command', function (done) {
+            client.internal_send_command_buf(new Command('b_get', ['string key 1'], function (err) { done(!err); })); //should be err => done(!err)
+        });
+    });
+
+    describe('works fine', function () {
+        it('when using get and b_get at the same time', function (done) {
+            var left = 3, decLeft = function () { --left || done(); };
+            client.get('string key 1', assertString(decLeft));
+            client.b_get('string key 1', assertBuffer(decLeft));
+            client.get('string key 1', assertString(decLeft));
+        });
+
+        it('when using get and send_command with "b_" prefixed command at the same time', function (done) {
+            var left = 3, decLeft = function () { --left || done(); };
+            client.get('string key 1', assertString(decLeft));
+            client.send_command_buf('b_get', ['string key 1'], assertBuffer(decLeft));
+            client.get('string key 1', assertString(decLeft));
+        });
+
+        it('when using get and send_command_buf at the same time', function (done) {
+            var left = 3, decLeft = function () { --left || done(); };
+            client.get('string key 1', assertString(decLeft));
+            client.send_command_buf('get', ['string key 1'], assertBuffer(decLeft));
+            client.get('string key 1', assertString(decLeft));
+        });
+
+        it('when using get and send_command_buf with "b_" prefixed command at the same time', function (done) {
+            var left = 3, decLeft = function () { --left || done(); };
+            client.get('string key 1', assertString(decLeft));
+            client.send_command_buf('get', ['string key 1'], assertBuffer(decLeft));
+            client.get('string key 1', assertString(decLeft));
+        });
+
+        it('when using send_command and b_get at the same time', function (done) {
+            var left = 3, decLeft = function () { --left || done(); };
+            client.send_command('get', ['string key 1'], assertString(decLeft));
+            client.b_get('string key 1', assertBuffer(decLeft));
+            client.send_command('get', ['string key 1'], assertString(decLeft));
+        });
+
+        it('when using get and send_command with "b_" prefixed command at the same time', function (done) {
+            var left = 3, decLeft = function () { --left || done(); };
+            client.send_command('get', ['string key 1'], assertString(decLeft));
+            client.send_command_buf('b_get', ['string key 1'], assertBuffer(decLeft));
+            client.send_command('get', ['string key 1'], assertString(decLeft));
+        });
+
+        it('when using get and send_command_buf at the same time', function (done) {
+            var left = 3, decLeft = function () { --left || done(); };
+            client.send_command('get', ['string key 1'], assertString(decLeft));
+            client.send_command_buf('get', ['string key 1'], assertBuffer(decLeft));
+            client.send_command('get', ['string key 1'], assertString(decLeft));
+        });
+
+        it('when using get and send_command_buf with "b_" prefixed command at the same time', function (done) {
+            var left = 3, decLeft = function () { --left || done(); };
+            client.send_command('get', ['string key 1'], assertString(decLeft));
+            client.send_command_buf('get', ['string key 1'], assertBuffer(decLeft));
+            client.send_command('get', ['string key 1'], assertString(decLeft));
+        });
+    });
+}
+
+
+function test_multi_get() {
+    it('returns strings when get + get', function (done) {
+        client.multi().get('string key 1').get('string key 1').exec(function (err, reply) {
+            assert.strictEqual(2, reply.length);
+            assert.strictEqual('string value', reply[0]);
+            assert.strictEqual('string value', reply[1]);
+            return done(err);
+        });
+    });
+
+    it('returns string + buffer when get + b_get', function (done) {
+        client.multi().get('string key 1').b_get('string key 1').exec(function (err, reply) {
+            assert.strictEqual(2, reply.length);
+            assert.strictEqual('string value', reply[0]);
+            assert.strictEqual(true, Buffer.isBuffer(reply[1]));
+            assert.strictEqual('<Buffer 73 74 72 69 6e 67 20 76 61 6c 75 65>', reply[1].inspect());
+            return done(err);
+        });
+    });
+
+    it('returns buffer + string when b_get + get', function (done) {
+        client.multi().b_get('string key 1').get('string key 1').exec(function (err, reply) {
+            assert.strictEqual(2, reply.length);
+            assert.strictEqual(true, Buffer.isBuffer(reply[0]));
+            assert.strictEqual('<Buffer 73 74 72 69 6e 67 20 76 61 6c 75 65>', reply[0].inspect());
+            assert.strictEqual('string value', reply[1]);
+            return done(err);
+        });
+    });
+
+    it('returns buffers when b_get + b_get', function (done) {
+        client.multi().b_get('string key 1').b_get('string key 1').exec(function (err, reply) {
+            assert.strictEqual(2, reply.length);
+            assert.strictEqual(true, Buffer.isBuffer(reply[0]));
+            assert.strictEqual('<Buffer 73 74 72 69 6e 67 20 76 61 6c 75 65>', reply[0].inspect());
+            assert.strictEqual(true, Buffer.isBuffer(reply[1]));
+            assert.strictEqual('<Buffer 73 74 72 69 6e 67 20 76 61 6c 75 65>', reply[1].inspect());
+            return done(err);
+        });
+    });
+}
+
+
+function test_batch_get() {
+    it('returns strings when get + get', function (done) {
+        client.batch().get('string key 1').get('string key 1').exec(function (err, reply) {
+            assert.strictEqual(2, reply.length);
+            assert.strictEqual('string value', reply[0]);
+            assert.strictEqual('string value', reply[1]);
+            return done(err);
+        });
+    });
+
+    it('returns string + buffer when get + b_get', function (done) {
+        client.batch().get('string key 1').b_get('string key 1').exec(function (err, reply) {
+            assert.strictEqual(2, reply.length);
+            assert.strictEqual('string value', reply[0]);
+            assert.strictEqual(true, Buffer.isBuffer(reply[1]));
+            assert.strictEqual('<Buffer 73 74 72 69 6e 67 20 76 61 6c 75 65>', reply[1].inspect());
+            return done(err);
+        });
+    });
+
+    it('returns buffer + string when b_get + get', function (done) {
+        client.batch().b_get('string key 1').get('string key 1').exec(function (err, reply) {
+            assert.strictEqual(2, reply.length);
+            assert.strictEqual(true, Buffer.isBuffer(reply[0]));
+            assert.strictEqual('<Buffer 73 74 72 69 6e 67 20 76 61 6c 75 65>', reply[0].inspect());
+            assert.strictEqual('string value', reply[1]);
+            return done(err);
+        });
+    });
+
+    it('returns buffers when b_get + b_get', function (done) {
+        client.batch().b_get('string key 1').b_get('string key 1').exec(function (err, reply) {
+            assert.strictEqual(2, reply.length);
+            assert.strictEqual(true, Buffer.isBuffer(reply[0]));
+            assert.strictEqual('<Buffer 73 74 72 69 6e 67 20 76 61 6c 75 65>', reply[0].inspect());
+            assert.strictEqual(true, Buffer.isBuffer(reply[1]));
+            assert.strictEqual('<Buffer 73 74 72 69 6e 67 20 76 61 6c 75 65>', reply[1].inspect());
+            return done(err);
+        });
+    });
+}
+
+
+function test_select() {
+    beforeEach(function (done) {
+        client.select(1, function (err, reply) {
+            assert.strictEqual(reply, 'OK');
+            done(err);
+        });
+    });
+
+    var assertDb1 = function (done) {
+        assert.strictEqual(client.selected_db, 1);
+        client.eval('return #redis.call("KEYS", "*");', 0, function (err, reply) {
+            if (err) throw err;
+            assert.strictEqual(reply, 0);
+            done();
+        });
+    };
+
+    var assertDb0 = function (buf, done) {
+        return function (err, reply) {
+            if (err) throw err;
+            if (buf) {
+                assert.strictEqual(true, Buffer.isBuffer(reply));
+                assert.strictEqual('<Buffer 4f 4b>', reply.inspect());
+            }else{
+                assert.strictEqual(reply, 'OK');
+            }
+            assert.strictEqual(client.selected_db, 0);
+
+            client.eval('return #redis.call("KEYS", "*");', 0, function (err, reply) {
+                if (err) throw err;
+                assert(typeof(reply) === 'number' && reply > 0);
+                done && done();
+            });
+        };
+    };
+
+    it('works with "b_" prefix', function (done) {
+        assertDb1(function () {
+            client.b_select(0, assertDb0(true, done));
+        });
+    });
+
+    it('works with send_command', function (done) {
+        assertDb1(function () {
+            client.send_command('select', [0], assertDb0(false, done));
+        });
+    });
+
+    it('works with send_command and "b_" prefix', function (done) {
+        assertDb1(function () {
+            client.send_command('b_select', [0], assertDb0(true, done));
+        });
+    });
+
+    it('works with send_command_buf', function (done) {
+        assertDb1(function () {
+            client.send_command_buf('select', [0], assertDb0(true, done));
+        });
+    });
+
+    it('works with send_command_buf and "b_" prefix', function (done) {
+        assertDb1(function () {
+            client.send_command_buf('b_select', [0], assertDb0(true, done));
+        });
+    });
+
+    it('works with multi and "b_" prefix', function (done) {
+        assertDb1(function () {
+            client.multi().b_select(0, assertDb0(done)).exec(function (err, reply) {
+                assert.strictEqual(1, reply.length);
+                assert.strictEqual(true, Buffer.isBuffer(reply[0]));
+                assert.strictEqual('<Buffer 4f 4b>', reply[0].inspect());
+                return done(err);
+            });
+        });
+    });
+
+    it('works with batch and "b_" prefix', function (done) {
+        assertDb1(function () {
+            client.batch().b_select(0, assertDb0(done)).exec(function (err, reply) {
+                assert.strictEqual(1, reply.length);
+                assert.strictEqual(true, Buffer.isBuffer(reply[0]));
+                assert.strictEqual('<Buffer 4f 4b>', reply[0].inspect());
+                return done(err);
+            });
+        });
+    });
+}
+
+
+function test_superGet() {
+    before(function () {
+        RedisClient.prototype.superGet = function (key, callback) {
+            var left = 3, error = null;
+            var ans = [];
+
+            this.get(key, decLeft);
+            this.send_command('get', [key], decLeft);
+            this.internal_send_command(new Command('get', [key], decLeft));
+
+            function decLeft(err, data) {
+                if (err) error = err;
+                ans.push(data);
+                if (--left === 0) callback && callback(error, error ? null : ans);
+            }
+        };
+
+        redisLib.create_individual_command_buf('superGet');
+    });
+
+    var assertStrings = function (done) {
+        return function (err, reply) {
+            if (err) throw err;
+            assert.deepEqual(['string value', 'string value', 'string value'], reply);
+            done();
+        };
+    };
+
+    var assertBuffers = function (done) {
+        return function (err, reply) {
+            if (err) throw err;
+            assert.strictEqual(3, reply.length);
+            assert.strictEqual('<Buffer 73 74 72 69 6e 67 20 76 61 6c 75 65>', reply[0].inspect());
+            assert.strictEqual('<Buffer 73 74 72 69 6e 67 20 76 61 6c 75 65>', reply[1].inspect());
+            assert.strictEqual('<Buffer 73 74 72 69 6e 67 20 76 61 6c 75 65>', reply[2].inspect());
+            done();
+        };
+    };
+
+    describe('returns strings', function () {
+        it('when command is not prefixed', function (done) {
+            client.superGet('string key 1', assertStrings(done));
+        });
+
+        it('when using send_command', function (done) {
+            client.send_command('superGet', ['string key 1'], assertStrings(done));
+        });
+    });
+
+    describe('returns buffers', function () {
+        it('when command is "b_" prefixed', function (done) {
+            client.b_superGet('string key 1', assertBuffers(done));
+        });
+
+        it('when using send_command with "b_" prefixed command', function (done) {
+            client.send_command('b_superGet', ['string key 1'], assertBuffers(done));
+        });
+
+        it('when using send_command_buf', function (done) {
+            client.send_command_buf('superGet', ['string key 1'], assertBuffers(done));
+        });
+
+        it('when using send_command_buf with "b_" prefixed command', function (done) {
+            client.send_command_buf('b_superGet', ['string key 1'], assertBuffers(done));
+        });
+    });
+}
+
+
+// Most of these tests are copied from detect_buffers
+function otherTests() {
+    describe('multi.hget', function () {
+        it('returns buffers and one string', function (done) {
+            client.multi()
+                .b_hget('hash key 2', 'key 1')
+                .b_hget('hash key 2', 'key 1')
+                .hget('hash key 2', 'key 2')
+                .b_hget('hash key 2', 'key 2')
+                .exec(function (err, reply) {
+                    assert.strictEqual(true, Array.isArray(reply));
+                    assert.strictEqual(4, reply.length);
+                    assert.strictEqual('<Buffer 76 61 6c 20 31>', reply[0].inspect());
+                    assert.strictEqual(true, Buffer.isBuffer(reply[1]));
+                    assert.strictEqual('<Buffer 76 61 6c 20 31>', reply[1].inspect());
+                    assert.strictEqual('val 2', reply[2]);
+                    assert.strictEqual(true, Buffer.isBuffer(reply[3]));
+                    assert.strictEqual('<Buffer 76 61 6c 20 32>', reply[3].inspect());
+                    return done(err);
+                });
+        });
+    });
+
+    describe('batch.hget', function () {
+        it('returns buffers and one string', function (done) {
+            client.batch()
+                .b_hget('hash key 2', 'key 1')
+                .b_hget('hash key 2', 'key 1')
+                .hget('hash key 2', 'key 2')
+                .b_hget('hash key 2', 'key 2')
+                .exec(function (err, reply) {
+                    assert.strictEqual(true, Array.isArray(reply));
+                    assert.strictEqual(4, reply.length);
+                    assert.strictEqual('<Buffer 76 61 6c 20 31>', reply[0].inspect());
+                    assert.strictEqual(true, Buffer.isBuffer(reply[1]));
+                    assert.strictEqual('<Buffer 76 61 6c 20 31>', reply[1].inspect());
+                    assert.strictEqual('val 2', reply[2]);
+                    assert.strictEqual(true, Buffer.isBuffer(reply[3]));
+                    assert.strictEqual('<Buffer 76 61 6c 20 32>', reply[3].inspect());
+                    return done(err);
+                });
+        });
+    });
+
+    describe('hmget', function () {
+        describe('using send_command_buf', function () {
+            it('returns buffers for keys requested', function (done) {
+                client.send_command_buf('hmget', ['hash key 2', 'key 1', 'key 2'], function (err, reply) {
+                    assert.strictEqual(true, Array.isArray(reply));
+                    assert.strictEqual(2, reply.length);
+                    assert.strictEqual(true, Buffer.isBuffer(reply[0]));
+                    assert.strictEqual(true, Buffer.isBuffer(reply[1]));
+                    assert.strictEqual('<Buffer 76 61 6c 20 31>', reply[0].inspect());
+                    assert.strictEqual('<Buffer 76 61 6c 20 32>', reply[1].inspect());
+                    return done(err);
+                });
+            });
+
+            it('returns buffers for keys requested', function (done) {
+                client.send_command('b_hmget', ['hash key 2', 'key 1', 'key 2'], function (err, reply) {
+                    assert.strictEqual(true, Array.isArray(reply));
+                    assert.strictEqual(2, reply.length);
+                    assert.strictEqual(true, Buffer.isBuffer(reply[0]));
+                    assert.strictEqual(true, Buffer.isBuffer(reply[1]));
+                    assert.strictEqual('<Buffer 76 61 6c 20 31>', reply[0].inspect());
+                    assert.strictEqual('<Buffer 76 61 6c 20 32>', reply[1].inspect());
+                    return done(err);
+                });
+            });
+
+            it('returns strings for keys requested', function (done) {
+                client.send_command('hmget', ['hash key 2', 'key 1', 'key 2'], function (err, reply) {
+                    assert.strictEqual(true, Array.isArray(reply));
+                    assert.strictEqual(2, reply.length);
+                    assert.strictEqual('val 1', reply[0]);
+                    assert.strictEqual('val 2', reply[1]);
+                    return done(err);
+                });
+            });
+        });
+
+        describe('using b_hmget', function () {
+            it('handles array of strings with undefined values in transaction (repro #344)', function (done) {
+                client.multi().b_hmget('hash key 2', 'key 3', 'key 4').exec(function (err, reply) {
+                    assert.strictEqual(true, Array.isArray(reply));
+                    assert.strictEqual(1, reply.length);
+                    assert.strictEqual(2, reply[0].length);
+                    assert.equal(null, reply[0][0]);
+                    assert.equal(null, reply[0][1]);
+                    return done(err);
+                });
+            });
+
+            it('returns buffers for keys requested', function (done) {
+                client.b_hmget('hash key 2', 'key 1', 'key 2', function (err, reply) {
+                    assert.strictEqual(true, Array.isArray(reply));
+                    assert.strictEqual(2, reply.length);
+                    assert.strictEqual(true, Buffer.isBuffer(reply[0]));
+                    assert.strictEqual(true, Buffer.isBuffer(reply[1]));
+                    assert.strictEqual('<Buffer 76 61 6c 20 31>', reply[0].inspect());
+                    assert.strictEqual('<Buffer 76 61 6c 20 32>', reply[1].inspect());
+                    return done(err);
+                });
+            });
+
+            it('returns strings for keys requested', function (done) {
+                client.hmget('hash key 2', 'key 1', 'key 2', function (err, reply) {
+                    assert.strictEqual(true, Array.isArray(reply));
+                    assert.strictEqual(2, reply.length);
+                    assert.strictEqual('val 1', reply[0]);
+                    assert.strictEqual('val 2', reply[1]);
+                    return done(err);
+                });
+            });
+
+            it('returns buffers for keys requested in transaction', function (done) {
+                client.multi().b_hmget('hash key 2', 'key 1', 'key 2').exec(function (err, reply) {
+                    assert.strictEqual(true, Array.isArray(reply));
+                    assert.strictEqual(1, reply.length);
+                    assert.strictEqual(2, reply[0].length);
+                    assert.strictEqual(true, Buffer.isBuffer(reply[0][0]));
+                    assert.strictEqual(true, Buffer.isBuffer(reply[0][1]));
+                    assert.strictEqual('<Buffer 76 61 6c 20 31>', reply[0][0].inspect());
+                    assert.strictEqual('<Buffer 76 61 6c 20 32>', reply[0][1].inspect());
+                    return done(err);
+                });
+            });
+
+            it('returns buffers for keys requested in .batch', function (done) {
+                client.batch().b_hmget('hash key 2', 'key 1', 'key 2').exec(function (err, reply) {
+                    assert.strictEqual(true, Array.isArray(reply));
+                    assert.strictEqual(1, reply.length);
+                    assert.strictEqual(2, reply[0].length);
+                    assert.strictEqual(true, Buffer.isBuffer(reply[0][0]));
+                    assert.strictEqual(true, Buffer.isBuffer(reply[0][1]));
+                    assert.strictEqual('<Buffer 76 61 6c 20 31>', reply[0][0].inspect());
+                    assert.strictEqual('<Buffer 76 61 6c 20 32>', reply[0][1].inspect());
+                    return done(err);
+                });
+            });
+        });
+    });
+
+    describe('hgetall', function (done) {
+        describe('using send_command_buf', function (done) {
+            it('returns buffer values', function (done) {
+                client.send_command_buf('hgetall', ['hash key 2'], function (err, reply) {
+                    assert.strictEqual('object', typeof reply);
+                    assert.strictEqual(2, Object.keys(reply).length);
+                    assert.strictEqual('<Buffer 76 61 6c 20 31>', reply['key 1'].inspect());
+                    assert.strictEqual('<Buffer 76 61 6c 20 32>', reply['key 2'].inspect());
+                    return done(err);
+                });
+            });
+
+            it('returns buffer values', function (done) {
+                client.send_command('b_hgetall', ['hash key 2'], function (err, reply) {
+                    assert.strictEqual('object', typeof reply);
+                    assert.strictEqual(2, Object.keys(reply).length);
+                    assert.strictEqual('<Buffer 76 61 6c 20 31>', reply['key 1'].inspect());
+                    assert.strictEqual('<Buffer 76 61 6c 20 32>', reply['key 2'].inspect());
+                    return done(err);
+                });
+            });
+        });
+
+        describe('using b_hgetall', function (done) {
+            it('returns buffer values', function (done) {
+                client.b_hgetall('hash key 2', function (err, reply) {
+                    assert.strictEqual('object', typeof reply);
+                    assert.strictEqual(2, Object.keys(reply).length);
+                    assert.strictEqual('<Buffer 76 61 6c 20 31>', reply['key 1'].inspect());
+                    assert.strictEqual('<Buffer 76 61 6c 20 32>', reply['key 2'].inspect());
+                    return done(err);
+                });
+            });
+
+            it('returns buffer values when executed in transaction', function (done) {
+                client.multi().b_hgetall('hash key 2').exec(function (err, reply) {
+                    assert.strictEqual(1, reply.length);
+                    assert.strictEqual('object', typeof reply[0]);
+                    assert.strictEqual(2, Object.keys(reply[0]).length);
+                    assert.strictEqual('<Buffer 76 61 6c 20 31>', reply[0]['key 1'].inspect());
+                    assert.strictEqual('<Buffer 76 61 6c 20 32>', reply[0]['key 2'].inspect());
+                    return done(err);
+                });
+            });
+
+            it('returns buffer values when executed in .batch', function (done) {
+                client.batch().b_hgetall('hash key 2').exec(function (err, reply) {
+                    assert.strictEqual(1, reply.length);
+                    assert.strictEqual('object', typeof reply[0]);
+                    assert.strictEqual(2, Object.keys(reply[0]).length);
+                    assert.strictEqual('<Buffer 76 61 6c 20 31>', reply[0]['key 1'].inspect());
+                    assert.strictEqual('<Buffer 76 61 6c 20 32>', reply[0]['key 2'].inspect());
+                    return done(err);
+                });
+            });
+        });
+    });
+}
+
+
+//=== functions ===
+
+
+function assertString(done) {
+    return function (err, reply) {
+        if (err) throw err;
+        assert.strictEqual('string value', reply);
+        done();
+    };
+};
+
+
+function assertBuffer(done) {
+    return function (err, reply) {
+        if (err) throw err;
+        assert.strictEqual(true, Buffer.isBuffer(reply));
+        assert.strictEqual('<Buffer 73 74 72 69 6e 67 20 76 61 6c 75 65>', reply.inspect());
+        done();
+    };
+};
+
+
+function createClient(clientConfig, callback) {
+    client = redis.createClient.apply(null, clientConfig);
+    client.once('error', function (err) {
+        throw err;
+    });
+    client.once('connect', function () {
+        client.flushdb(function (err) {
+            if (err) throw err;
+            callback();
+        });
+    });
+}


### PR DESCRIPTION
Adding send_command_buf function. The same as send_command but reply will be sent to callbacks as Buffers instead of Strings.
