### PR TITLE
Use process.nextTick to uncork

### DIFF
--- a/index.js
+++ b/index.js
@@ -437,8 +437,9 @@ RedisClient.prototype.on_ready = function () {
         self.pipeline = false;
         self.fire_strings = true;
         if (self.stream.uncork) {
-            // TODO: Consider using next tick here. See https://github.com/NodeRedis/node_redis/issues/1033
-            self.stream.uncork();
+            process.nextTick(function () {
+                self.stream.uncork();
+            });
         }
     };
 

--- a/test/multi.spec.js
+++ b/test/multi.spec.js
@@ -674,7 +674,9 @@ describe("The 'multi' method", function () {
                     // The commands should still be fired, no matter that the socket is destroyed on the same tick
                     client.multi().set('foo', 'bar').get('foo').exec();
                     // Abort connection before the value returned
-                    client.stream.destroy();
+                    process.nextTick(function () {
+                        client.stream.destroy();
+                    });
                 });
 
                 it('indivdual commands work properly with multi', function (done) {

--- a/test/node_redis.spec.js
+++ b/test/node_redis.spec.js
@@ -1112,7 +1112,9 @@ describe('The node_redis client', function () {
                             }
                             multi.exec();
                             assert.equal(client.command_queue_length, 15);
-                            helper.killConnection(client);
+                            process.nextTick(function () {
+                                helper.killConnection(client);
+                            });
                         });
 
                         var end = helper.callFuncAfter(done, 3);
@@ -1203,7 +1205,9 @@ describe('The node_redis client', function () {
                             }
                             multi.exec();
                             assert.equal(client.command_queue.length, 15);
-                            helper.killConnection(client);
+                            process.nextTick(function () {
+                                helper.killConnection(client);
+                            });
                         });
 
                         var end = helper.callFuncAfter(done, 3);

--- a/test/pubsub.spec.js
+++ b/test/pubsub.spec.js
@@ -491,18 +491,19 @@ describe('publish/subscribe', function () {
                     });
                     sub2.on('ready', function () {
                         sub2.batch().psubscribe('*', helper.isString('*')).exec();
-                        sub2.subscribe('/foo');
+                        sub2.subscribe('/foo', function () {
+                            pub.pubsub('numsub', '/foo', function (err, res) {
+                                assert.deepEqual(res, ['/foo', 2]);
+                            });
+                            // sub2 is counted twice as it subscribed with psubscribe and subscribe
+                            pub.publish('/foo', 'hello world', helper.isNumber(3));
+                        });
                         sub2.on('pmessage', function (pattern, channel, message) {
                             assert.strictEqual(pattern.inspect(), new Buffer('*').inspect());
                             assert.strictEqual(channel.inspect(), new Buffer('/foo').inspect());
                             assert.strictEqual(message.inspect(), new Buffer('hello world').inspect());
                             sub2.quit(done);
                         });
-                        pub.pubsub('numsub', '/foo', function (err, res) {
-                            assert.deepEqual(res, ['/foo', 2]);
-                        });
-                        // sub2 is counted twice as it subscribed with psubscribe and subscribe
-                        pub.publish('/foo', 'hello world', helper.isNumber(3));
                     });
                 });
 


### PR DESCRIPTION
### Pull Request check-list
- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
### Description of change

Uncork should be used in a nextTick to keep the process in JS.

Currently this seems to be a subtle breaking change.
If the connection is lost / the connection is closed / ended in-between the fired multi / batch and the uncork, the commands will fail without being send to Redis. Former the commands were definitely send to Redis and it was not possible to end the connection in-between.
