### PR TITLE
Handle hscan reply as an object

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,8 @@ function handle_detect_buffers_reply (reply, command, buffer_args) {
 
     if (command === 'hgetall') {
         reply = utils.reply_to_object(reply);
+    } else if (command === 'hscan') {
+        reply[1] = utils.reply_to_object(reply[1]);
     }
     return reply;
 }
@@ -305,6 +307,8 @@ RedisClient.prototype.create_stream = function () {
 RedisClient.prototype.handle_reply = function (reply, command) {
     if (command === 'hgetall') {
         reply = utils.reply_to_object(reply);
+    } else if (command === 'hscan') {
+        reply[1] = utils.reply_to_object(reply[1]);
     }
     return reply;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// hgetall converts its replies to an Object. If the reply is empty, null is returned.
+// hgetall and hscan convert their replies to an Object. If the reply is empty, null is returned.
 // These function are only called with internal data and have therefore always the same instanceof X
 function replyToObject (reply) {
     // The reply might be a string or a buffer if this is called in a transaction (multi)

--- a/test/commands/hscan.spec.js
+++ b/test/commands/hscan.spec.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var config = require('../lib/config');
+var helper = require('../helper');
+var assert = require('assert');
+var redis = config.redis;
+
+describe("The 'hscan' method", function () {
+
+    helper.allTests(function (parser, ip, args) {
+
+        describe('using ' + parser + ' and ' + ip, function () {
+            var client;
+
+            beforeEach(function (done) {
+                client = redis.createClient.apply(null, args);
+                client.once('ready', function () {
+                    client.flushdb(done);
+                });
+            });
+
+            it('return values', function (done) {
+                if (helper.redisProcess().spawnFailed()) this.skip();
+                helper.serverVersionAtLeast.call(this, client, [2, 8, 0]);
+                var hash = {};
+                for (var i = 0; i < 500; i++) {
+                    hash['key_' + i] = 'value_' + i;
+                }
+                client.hmset('hash:1', hash);
+                client.zscan('hash:1', 0, 'MATCH', 'key_*', 'COUNT', 500, function (err, res) {
+                    assert(!err);
+                    assert.strictEqual(res.length, 2);
+                    console.log(res[1]);
+                    assert.strictEqual(res[1].key_42, 'value_42');
+                    done();
+                });
+            });
+
+            afterEach(function () {
+                client.end(true);
+            });
+        });
+    });
+
+});


### PR DESCRIPTION
### Pull Request check-list
- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
### Description of change

Handle the results of `HSCAN` as an object, as node_redis does for `HGETALL`
