### PR TITLE
Allow passing CURSOR to async scan iterators

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -187,7 +187,8 @@ You can override the default options by providing a configuration object:
 client.scanIterator({
   TYPE: 'string', // `SCAN` only
   MATCH: 'patter*',
-  COUNT: 100
+  COUNT: 100,
+  CURSOR: 123,
 });
 ```
 

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -53,6 +53,10 @@ export interface ClientCommandOptions extends QueueCommandOptions {
     isolated?: boolean;
 }
 
+export interface ScanCursor {
+    CURSOR?: number;
+}
+
 type ClientLegacyCallback = (err: Error | null, reply?: RedisCommandRawReply) => void;
 
 export type ClientLegacyCommandArguments = LegacyCommandArguments | [...LegacyCommandArguments, ClientLegacyCallback];
@@ -528,8 +532,8 @@ export default class RedisClient<M extends RedisModules, S extends RedisScripts>
         return promise;
     }
 
-    async* scanIterator(options?: ScanCommandOptions): AsyncIterable<string> {
-        let cursor = 0;
+    async* scanIterator(options?: ScanCommandOptions & ScanCursor): AsyncIterable<string> {
+        let cursor = options?.CURSOR ?? 0;
         do {
             const reply = await (this as any).scan(cursor, options);
             cursor = reply.cursor;
@@ -539,8 +543,8 @@ export default class RedisClient<M extends RedisModules, S extends RedisScripts>
         } while (cursor !== 0);
     }
 
-    async* hScanIterator(key: string, options?: ScanOptions): AsyncIterable<HScanTuple> {
-        let cursor = 0;
+    async* hScanIterator(key: string, options?: ScanOptions & ScanCursor): AsyncIterable<HScanTuple> {
+        let cursor = options?.CURSOR ?? 0;
         do {
             const reply = await (this as any).hScan(key, cursor, options);
             cursor = reply.cursor;
@@ -550,8 +554,8 @@ export default class RedisClient<M extends RedisModules, S extends RedisScripts>
         } while (cursor !== 0);
     }
 
-    async* sScanIterator(key: string, options?: ScanOptions): AsyncIterable<string> {
-        let cursor = 0;
+    async* sScanIterator(key: string, options?: ScanOptions & ScanCursor): AsyncIterable<string> {
+        let cursor = options?.CURSOR ?? 0;
         do {
             const reply = await (this as any).sScan(key, cursor, options);
             cursor = reply.cursor;
@@ -561,8 +565,8 @@ export default class RedisClient<M extends RedisModules, S extends RedisScripts>
         } while (cursor !== 0);
     }
 
-    async* zScanIterator(key: string, options?: ScanOptions): AsyncIterable<ZMember> {
-        let cursor = 0;
+    async* zScanIterator(key: string, options?: ScanOptions & ScanCursor): AsyncIterable<ZMember> {
+        let cursor = options?.CURSOR ?? 0;
         do {
             const reply = await (this as any).zScan(key, cursor, options);
             cursor = reply.cursor;


### PR DESCRIPTION
### Description

At the moment iterators always start from `0`. I'm rebuilding my [redis-gui](https://github.com/ekvedaras/redis-gui) app using the new version and I have a use case where I want to start scanning from the specified cursor.
The app has a keys list on the left which by default loads only 100 keys matching the given pattern. If 100 keys were found during the scan but the cursor is still not `0`, that means there are more to scan. In such a case, it shows a _load more_ button, which should scan for another 100 keys starting from where it left the last time. I would really like to use iterators but I need to be able to pass the starting cursor.

This PR adds a new `ScanCursor` interface which is used to intersect with the `ScanOptions` interface on those iterator functions. If the optional `options.CURSOR` is not provided it defaults to `0` as before so this is all backwards compatible.

---

### Checklist

- [ ] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
