### PR TITLE
Fixed `zScanIterator` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ This works with `HSCAN`, `SSCAN`, and `ZSCAN` too:
 ```typescript
 for await (const { field, value } of client.hScanIterator('hash')) {}
 for await (const member of client.sScanIterator('set')) {}
-for await (const { score, member } of client.zScanIterator('sorted-set')) {}
+for await (const { score, value } of client.zScanIterator('sorted-set')) {}
 ```
 
 You can override the default options by providing a configuration object:


### PR DESCRIPTION
The example for `zScanIterator` had the wrong values in the `for` loop.

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
