### PR TITLE
chore: restrict the list of published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,5 +33,8 @@
   "bugs": {
     "url": "https://github.com/redis/node-redis/issues"
   },
-  "homepage": "https://github.com/redis/node-redis"
+  "homepage": "https://github.com/redis/node-redis",
+  "files": [
+    "dist/"
+  ]
 }


### PR DESCRIPTION
### Description

The `4.0.0` version contains some useless files:

```
$ ls -l node_modules/redis/
total 44
drwxrwxr-x 2   4096 Nov 29 00:26 dist/
-rw-rw-r-- 1     92 Oct 26  1985 dump.rdb
drwxrwxr-x 2   4096 Nov 29 00:26 .idea/
-rw-rw-r-- 1   1089 Oct 26  1985 LICENSE
-rw-rw-r-- 1   2407 Nov 29 00:26 package.json
-rw-rw-r-- 1  11466 Oct 26  1985 README.md
drwxrwxr-x 3   4096 Nov 29 00:26 scripts/

```

> Describe your pull request here

Reference: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#files

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested? (tested with `npm pack`)
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
