### PR TITLE
Client: Export errors

### DIFF
--- a/packages/client/index.ts
+++ b/packages/client/index.ts
@@ -3,6 +3,8 @@ import RedisCluster from './lib/cluster';
 
 export { RedisClientType, RedisClientOptions } from './lib/client';
 
+export { RedisModules, RedisScripts } from './lib/commands';
+
 export const createClient = RedisClient.create;
 
 export const commandOptions = RedisClient.commandOptions;

--- a/packages/client/index.ts
+++ b/packages/client/index.ts
@@ -12,3 +12,5 @@ export { RedisClusterType, RedisClusterOptions } from './lib/cluster';
 export const createCluster = RedisCluster.create;
 
 export { defineScript } from './lib/lua-script';
+
+export * from './lib/errors';


### PR DESCRIPTION
Currently it is not possible to check thrown error's type - eg. if it is a `WatchError` which is crucial information for retrying. 