### PR TITLE
byteLength fix

### DIFF
--- a/packages/client/lib/commander.ts
+++ b/packages/client/lib/commander.ts
@@ -96,7 +96,7 @@ export function* encodeCommand(args: RedisCommandArguments): IterableIterator<st
         stringsLength = 0;
     for (const arg of args) {
         const isString = typeof arg === 'string',
-            byteLength = Buffer.byteLength(arg);
+            byteLength = Buffer.byteLength(isString ? arg : '');
         strings += `$${byteLength}${DELIMITER}`;
 
         if (isString) {

--- a/packages/client/lib/commander.ts
+++ b/packages/client/lib/commander.ts
@@ -96,7 +96,7 @@ export function* encodeCommand(args: RedisCommandArguments): IterableIterator<st
         stringsLength = 0;
     for (const arg of args) {
         const isString = typeof arg === 'string',
-            byteLength = isString ? arg.length : Buffer.byteLength(arg);
+            byteLength = Buffer.byteLength(arg);
         strings += `$${byteLength}${DELIMITER}`;
 
         if (isString) {

--- a/packages/client/lib/commander.ts
+++ b/packages/client/lib/commander.ts
@@ -96,7 +96,7 @@ export function* encodeCommand(args: RedisCommandArguments): IterableIterator<st
         stringsLength = 0;
     for (const arg of args) {
         const isString = typeof arg === 'string',
-            byteLength = isString ? Buffer.byteLength(arg): arg.length;
+            byteLength = isString ? arg.length : Buffer.byteLength(arg);
         strings += `$${byteLength}${DELIMITER}`;
 
         if (isString) {


### PR DESCRIPTION
byteLength = string.length if string, Buffer.byteLength(arg) otherwise

### Description

Ran into a bug when an argument other than a string was passed (number), cannot read length of number.

Realized the evaluation of the ternary was flipped.

byteLength would be the length of a string, or the measured byteLength, for all other types. 

Opposite doesn't make sense (unless I'm missing something)

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
