### PR TITLE
fix defineScript types

### DIFF
--- a/packages/client/lib/lua-script.ts
+++ b/packages/client/lib/lua-script.ts
@@ -10,7 +10,7 @@ export interface SHA1 {
     SHA1: string;
 }
 
-export function defineScript(script: RedisScriptConfig): typeof script & SHA1 {
+export function defineScript<TScript extends RedisScriptConfig>(script: TScript): TScript & SHA1 {
     return {
         ...script,
         SHA1: scriptSha1(script.SCRIPT)


### PR DESCRIPTION
### Description

Use more specific script type as return type of `defineScript` so that the correct argument and return type can be inferred on the redis client.

Previously:
![image](https://user-images.githubusercontent.com/3729287/146446556-1cfb65b2-a7e1-4a2f-a3b3-da32f431ab47.png)

After change:
![image](https://user-images.githubusercontent.com/3729287/146446618-c79053a9-00d4-4549-a616-3f2bd951db0b.png)

