### PR TITLE
SEPARATOR typo fix

### DIFF
--- a/packages/search/lib/commands/CREATE.spec.ts
+++ b/packages/search/lib/commands/CREATE.spec.ts
@@ -101,15 +101,15 @@ describe('CREATE', () => {
                     });
                 });
 
-                it('with SEPERATOR', () => {
+                it('with SEPARATOR', () => {
                     assert.deepEqual(
                         transformArguments('index', {
                             field: {
                                 type: SchemaFieldTypes.TAG,
-                                SEPERATOR: 'seperator'
+                                SEPERATOR: 'separator'
                             }
                         }),
-                        ['FT.CREATE', 'index', 'SCHEMA', 'field', 'TAG', 'SEPERATOR', 'seperator']
+                        ['FT.CREATE', 'index', 'SCHEMA', 'field', 'TAG', 'SEPERATOR', 'separator']
                     );
                 });
 

--- a/packages/search/lib/commands/index.ts
+++ b/packages/search/lib/commands/index.ts
@@ -200,7 +200,7 @@ type CreateSchemaNumericField = CreateSchemaField<SchemaFieldTypes.NUMERIC>;
 type CreateSchemaGeoField = CreateSchemaField<SchemaFieldTypes.GEO>;
 
 type CreateSchemaTagField = CreateSchemaField<SchemaFieldTypes.TAG, {
-    SEPERATOR?: string;
+    SEPARATOR?: string;
     CASESENSITIVE?: true;
 }>;
 

--- a/packages/search/lib/commands/index.ts
+++ b/packages/search/lib/commands/index.ts
@@ -248,8 +248,8 @@ export function pushSchema(args: RedisCommandArguments, schema: CreateSchema) {
             //     break;
 
             case 'TAG':
-                if (fieldOptions.SEPERATOR) {
-                    args.push('SEPERATOR', fieldOptions.SEPERATOR);
+                if (fieldOptions.SEPARATOR) {
+                    args.push('SEPARATOR', fieldOptions.SEPERATOR);
                 }
 
                 if (fieldOptions.CASESENSITIVE) {


### PR DESCRIPTION
### Description

https://github.com/redis/node-redis/issues/1821

Just a small typo in the CreateSchemaTagField interface