### PR TITLE
update tls type to be boolean instead of "true" (RedisTlsSocketOptions)

### DIFF
--- a/packages/client/lib/client/socket.ts
+++ b/packages/client/lib/client/socket.ts
@@ -13,15 +13,15 @@ export interface RedisSocketCommonOptions {
     reconnectStrategy?(retries: number): number | Error;
 }
 
-export interface RedisNetSocketOptions extends Partial<net.SocketConnectOpts>, RedisSocketCommonOptions {
+type RedisNetSocketOptions = Partial<net.SocketConnectOpts> & {
     tls: false;
-}
+};
 
-export interface RedisTlsSocketOptions extends tls.ConnectionOptions, RedisSocketCommonOptions {
+export interface RedisTlsSocketOptions extends tls.ConnectionOptions {
     tls: true;
 }
 
-export type RedisSocketOptions = RedisNetSocketOptions | RedisTlsSocketOptions;
+export type RedisSocketOptions = RedisSocketCommonOptions & (RedisNetSocketOptions | RedisTlsSocketOptions);
 
 interface CreateSocketReturn<T> {
     connectEvent: string;

--- a/packages/client/lib/client/socket.ts
+++ b/packages/client/lib/client/socket.ts
@@ -16,7 +16,7 @@ export interface RedisSocketCommonOptions {
 export type RedisNetSocketOptions = Partial<net.SocketConnectOpts>;
 
 export interface RedisTlsSocketOptions extends RedisSocketCommonOptions, tls.ConnectionOptions {
-    tls: true;
+    tls: boolean;
 }
 
 export type RedisSocketOptions = RedisSocketCommonOptions & (RedisNetSocketOptions | RedisTlsSocketOptions);

--- a/packages/client/lib/client/socket.ts
+++ b/packages/client/lib/client/socket.ts
@@ -13,13 +13,15 @@ export interface RedisSocketCommonOptions {
     reconnectStrategy?(retries: number): number | Error;
 }
 
-export type RedisNetSocketOptions = Partial<net.SocketConnectOpts>;
-
-export interface RedisTlsSocketOptions extends RedisSocketCommonOptions, tls.ConnectionOptions {
-    tls: boolean;
+export interface RedisNetSocketOptions extends Partial<net.SocketConnectOpts>, RedisSocketCommonOptions {
+    tls: false;
 }
 
-export type RedisSocketOptions = RedisSocketCommonOptions & (RedisNetSocketOptions | RedisTlsSocketOptions);
+export interface RedisTlsSocketOptions extends tls.ConnectionOptions, RedisSocketCommonOptions {
+    tls: true;
+}
+
+export type RedisSocketOptions = RedisNetSocketOptions | RedisTlsSocketOptions;
 
 interface CreateSocketReturn<T> {
     connectEvent: string;

--- a/packages/client/lib/client/socket.ts
+++ b/packages/client/lib/client/socket.ts
@@ -14,7 +14,7 @@ export interface RedisSocketCommonOptions {
 }
 
 type RedisNetSocketOptions = Partial<net.SocketConnectOpts> & {
-    tls: false;
+    tls?: false;
 };
 
 export interface RedisTlsSocketOptions extends tls.ConnectionOptions {


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

RedisTlsSocketOptions - tls - has type of true instead of boolean
---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
