### PR TITLE
Mihration guide 

### DIFF
--- a/docs/v3-to-v4.md
+++ b/docs/v3-to-v4.md
@@ -4,6 +4,7 @@ Version 4 of Node Redis is a major refactor. While we have tried to maintain bac
 
 ## All of the Breaking Changes
 
+If using typescript set the target to ES2015 (ES6) or higher, ES5 and bellow are not supported due to the usage of private class functions.
 See the [Change Log](../CHANGELOG.md).
 
 ### Promises


### PR DESCRIPTION
### Description

Discussed in #2006 targeting a version of ecmascript older than 2015 will cause you errors.
Not a breaking change but as the user suggested im adding it to the migration guide.

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested? (No changes were made)
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?