### PR TITLE
Fix #1870: TypeError in PubSub

### DIFF
--- a/packages/client/lib/client/commands-queue.ts
+++ b/packages/client/lib/client/commands-queue.ts
@@ -369,7 +369,8 @@ export default class RedisCommandsQueue {
     #setReturnBuffers() {
         this.#parser.setReturnBuffers(
             !!this.#waitingForReply.head?.value.returnBuffers ||
-            !!this.#pubSubState?.subscribed
+            !!this.#pubSubState?.subscribed ||
+            !!this.#pubSubState?.subscribing
         );
     }
 

--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -683,6 +683,21 @@ describe('Client', () => {
             }
         }, GLOBAL.SERVERS.OPEN);
 
+        testUtils.testWithClient('should not fail when message arrives right after subscribe', async publisher => {
+            const subscriber = publisher.duplicate();
+
+            await subscriber.connect();
+
+            try {
+                await assert.doesNotReject(Promise.all([
+                    subscriber.subscribe('channel', () => {}),
+                    publisher.publish('channel', 'message')
+                ]));
+            } finally {
+                await subscriber.disconnect();
+            }
+        }, GLOBAL.SERVERS.OPEN);
+
         testUtils.testWithClient('should be able to quit in PubSub mode', async client => {
             await client.subscribe('channel', () => {
                 // noop


### PR DESCRIPTION
### Description

Fix race that causes #1870.

The root cause of that issue is a race in updating PubSubState that causes the parser to be in string mode instead of buffer mode when a PubSub 'message' event arrives from the server in the same data chunk as the 'subscribe' reply arrives.

The sequence of events triggering the issue:
1. Application code calls `.subscribe()` on the client object
2. The redis server returns single chunk containing both 'subscribe' and 'message' replies in the same buffer that goes into [`RedisCommandsQueue.parseResponse`](https://github.com/redis/node-redis/blob/ac7d50c7313fe1158131e13b0e3b11d982697123/packages/client/lib/client/commands-queue.ts#L376-L379)
3. The parser calls [`returnReply`](https://github.com/redis/node-redis/blob/ac7d50c7313fe1158131e13b0e3b11d982697123/packages/client/lib/client/commands-queue.ts#L113-L137) with the reply 'subscribe'. This goes to this line: https://github.com/redis/node-redis/blob/ac7d50c7313fe1158131e13b0e3b11d982697123/packages/client/lib/client/commands-queue.ts#L135
4. [`shiftWaitingForReply`](https://github.com/redis/node-redis/blob/ac7d50c7313fe1158131e13b0e3b11d982697123/packages/client/lib/client/commands-queue.ts#L381-L388) removes the 'subscribe' message from `this.#waitingForReply`, then calls `#setReturnBuffers`. Since `this.#waitingForReply` is now empty and `this.#pubSubState.subscribed` hasn't been updated yet, it turns buffer mode off (switches to string mode)
5. Once `shiftWaitingForReply` returns, `.resolve()` gets called here: https://github.com/redis/node-redis/blob/ac7d50c7313fe1158131e13b0e3b11d982697123/packages/client/lib/client/commands-queue.ts#L135 This sets `this.#pubSubState.subscribed` to 1 here: https://github.com/redis/node-redis/blob/ac7d50c7313fe1158131e13b0e3b11d982697123/packages/client/lib/client/commands-queue.ts#L305
6. The parser calls [`returnReply`](https://github.com/redis/node-redis/blob/ac7d50c7313fe1158131e13b0e3b11d982697123/packages/client/lib/client/commands-queue.ts#L113-L137) again with the reply 'message', but it's now in string mode, so this `Buffer.equals()` call throws: https://github.com/redis/node-redis/blob/ac7d50c7313fe1158131e13b0e3b11d982697123/packages/client/lib/client/commands-queue.ts#L115

If the 'subscribe' and 'message' replies come in separate chunks, the 'message' reply will turn buffer mode back on through this line, preventing the problem: https://github.com/redis/node-redis/blob/ac7d50c7313fe1158131e13b0e3b11d982697123/packages/client/lib/client/commands-queue.ts#L377

The fix is to also enable buffer mode on the parser in `setReturnBuffers` if `this.#pubSubState.subscribing` is nonzero, which avoids this race. As far as I can tell this is correct behavior.

I have added a test which passes reliably with this patch, and (on my machine) fails without the patch. Since it is testing for a race, it may sometimes pass even without this patch.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
