### PR TITLE
Adds example of how to escape punctuation when searching.

### DIFF
--- a/examples/search-json.js
+++ b/examples/search-json.js
@@ -21,6 +21,10 @@ async function searchJSON() {
       '$.coins': {
         type: SchemaFieldTypes.NUMERIC,
         AS: 'coins'
+      },
+      '$.email': {
+        type: SchemaFieldTypes.TAG,
+        AS: 'email'
       }
     }, {
       ON: 'JSON',
@@ -41,12 +45,14 @@ async function searchJSON() {
     client.json.set('noderedis:users:1', '$', {
       name: 'Alice',
       age: 32,
-      coins: 100
+      coins: 100,
+      email: 'alice@nonexist.com'
     }),
     client.json.set('noderedis:users:2', '$', {
       name: 'Bob',
       age: 23,
-      coins: 15
+      coins: 15,
+      email: 'bob@somewhere.gov'
     })
   ]);
 
@@ -54,37 +60,85 @@ async function searchJSON() {
   console.log('Users under 30 years old:');
   console.log(
     // https://oss.redis.com/redisearch/Commands/#ftsearch
-    await client.ft.search('idx:users', '@age:[0 30]')
+    JSON.stringify(
+      await client.ft.search('idx:users', '@age:[0 30]'), 
+      null, 
+      2
+    )
   );
   // {
-  //   total: 1,
-  //   documents: [ { id: 'noderedis:users:2', value: [Object] } ]
+  //   "total": 1,
+  //   "documents": [
+  //     {
+  //       "id": "noderedis:users:2",
+  //       "value": {
+  //         "name": "Bob",
+  //         "age": 23,
+  //         "coins": 15,
+  //         "email": "bob@somewhere.gov"
+  //       }
+  //     }
+  //   ]
+  // }
+
+  // Find a user by email - note we need to escape . and @ characters
+  // in the email address.  This applies for other punctuation too.
+  // https://oss.redis.com/redisearch/Tags/#including_punctuation_in_tags
+  console.log('Users with email "bob@somewhere.gov":');
+  const emailAddress = 'bob@somewhere.gov'.replace(/\./g, '\\.').replace(/\@/g, '\\@');
+  console.log(
+    JSON.stringify(
+      await client.ft.search('idx:users', `@email:{${emailAddress}}`), 
+      null, 
+      2
+    )
+  );
+  // {
+  //   "total": 1,
+  //   "documents": [
+  //     {
+  //       "id": "noderedis:users:2",
+  //       "value": {
+  //         "name": "Bob",
+  //         "age": 23,
+  //         "coins": 15,
+  //         "email": "bob@somewhere.gov"
+  //       }
+  //     }
+  //   ]
   // }
 
   // Some aggregrations, what's the average age and total number of coins...
   // https://oss.redis.com/redisearch/Commands/#ftaggregate
+  console.log('Aggregation Demo:');
   console.log(
-    await client.ft.aggregate('idx:users', '*', {
-      STEPS: [{
-        type: AggregateSteps.GROUPBY,
-        REDUCE: [{
-          type: AggregateGroupByReducers.AVG,
-          property: 'age',
-          AS: 'averageAge'
-        }, {
-          type: AggregateGroupByReducers.SUM,
-          property: 'coins',
-          AS: 'totalCoins'
+    JSON.stringify(
+      await client.ft.aggregate('idx:users', '*', {
+        STEPS: [{
+          type: AggregateSteps.GROUPBY,
+          REDUCE: [{
+            type: AggregateGroupByReducers.AVG,
+            property: 'age',
+            AS: 'averageAge'
+          }, {
+            type: AggregateGroupByReducers.SUM,
+            property: 'coins',
+            AS: 'totalCoins'
+          }]
         }]
-      }]
-    })
+      }), 
+      null, 
+      2
+    )
   );
   // {
-  //   total: 2,
-  //   results: [{
-  //     averageAge: '27.5',
-  //     totalCoins: '115'
-  //   }]
+  //   "total": 1,
+  //   "results": [
+  //     {
+  //       "averageAge": "27.5",
+  //       "totalCoins": "115"
+  //     }
+  //   ]
   // }
 
   await client.quit();


### PR DESCRIPTION
Amends the existing JSON search example to show how to escape punctuation when searching, as searching for email addresses in tag fields is a common issue we see people having difficulty with.  Also tidies up the output of this example with `JSON.stringify`.

Closes #2025 