### PR TITLE
Support BIT|BYTE option

### DIFF
--- a/packages/client/lib/commands/BITCOUNT.spec.ts
+++ b/packages/client/lib/commands/BITCOUNT.spec.ts
@@ -20,6 +20,17 @@ describe('BITCOUNT', () => {
                 ['BITCOUNT', 'key', '0', '1']
             );
         });
+
+        it('with bit range', () => {
+            assert.deepEqual(
+                transformArguments('key', {
+                    start: 0,
+                    end: 1,
+                    bit: true
+                }),
+                ['BITCOUNT', 'key', '0', '1', 'BIT']
+            );
+        });
     });
 
     testUtils.testWithClient('client.bitCount', async client => {

--- a/packages/client/lib/commands/BITCOUNT.ts
+++ b/packages/client/lib/commands/BITCOUNT.ts
@@ -7,11 +7,12 @@ export const IS_READ_ONLY = true;
 interface BitCountRange {
     start: number;
     end: number;
+    bit?: boolean;
 }
 
 export function transformArguments(
     key: RedisCommandArgument,
-    range?: BitCountRange
+    range?: BitCountRange,
 ): RedisCommandArguments {
     const args = ['BITCOUNT', key];
 
@@ -20,6 +21,10 @@ export function transformArguments(
             range.start.toString(),
             range.end.toString()
         );
+
+        if (range?.bit) {
+            args.push('BIT')
+        }
     }
 
     return args;

--- a/packages/client/lib/commands/BITPOS.spec.ts
+++ b/packages/client/lib/commands/BITPOS.spec.ts
@@ -18,10 +18,17 @@ describe('BITPOS', () => {
             );
         });
 
-        it('with start, end', () => {
+        it('with start and end', () => {
             assert.deepEqual(
                 transformArguments('key', 1, 1, -1),
                 ['BITPOS', 'key', '1', '1', '-1']
+            );
+        });
+
+        it('with start, end and bit', () => {
+            assert.deepEqual(
+                transformArguments('key', 1, 1, -1, true),
+                ['BITPOS', 'key', '1', '1', '-1', 'BIT']
             );
         });
     });

--- a/packages/client/lib/commands/BITPOS.ts
+++ b/packages/client/lib/commands/BITPOS.ts
@@ -9,7 +9,8 @@ export function transformArguments(
     key: RedisCommandArgument,
     bit: BitValue,
     start?: number,
-    end?: number
+    end?: number,
+    bitRange?: boolean
 ): RedisCommandArguments {
     const args = ['BITPOS', key, bit.toString()];
 
@@ -19,6 +20,10 @@ export function transformArguments(
 
     if (typeof end === 'number') {
         args.push(end.toString());
+    }
+
+    if (bitRange) {
+        args.push('BIT');
     }
 
     return args;


### PR DESCRIPTION
### Description

Two commands that support now range by a bit:
1. [BITPOS](https://redis.io/commands/bitpos)
2. [BITCOUNT](https://redis.io/commands/bitcount)

closes #1905 , closes #1907 
---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
