### PR TITLE
Support COMMAND GETKEYSANDFLAGS

### DIFF
--- a/packages/client/lib/client/commands.ts
+++ b/packages/client/lib/client/commands.ts
@@ -32,6 +32,7 @@ import * as CLUSTER_SETSLOT from '../commands/CLUSTER_SETSLOT';
 import * as CLUSTER_SLOTS from '../commands/CLUSTER_SLOTS';
 import * as COMMAND_COUNT from '../commands/COMMAND_COUNT';
 import * as COMMAND_GETKEYS from '../commands/COMMAND_GETKEYS';
+import * as COMMAND_GETKEYSANDFLAGS from '../commands/COMMAND_GETKEYSANDFLAGS';
 import * as COMMAND_INFO from '../commands/COMMAND_INFO';
 import * as COMMAND_LIST from '../commands/COMMAND_LIST';
 import * as COMMAND from '../commands/COMMAND';
@@ -150,6 +151,8 @@ export default {
     commandCount: COMMAND_COUNT,
     COMMAND_GETKEYS,
     commandGetKeys: COMMAND_GETKEYS,
+    COMMAND_GETKEYSANDFLAGS,
+    commandGetKeysAndFlags: COMMAND_GETKEYSANDFLAGS,
     COMMAND_INFO,
     commandInfo: COMMAND_INFO,
     COMMAND_LIST,

--- a/packages/client/lib/commands/COMMAND_GETKEYSANDFLAGS.spec.ts
+++ b/packages/client/lib/commands/COMMAND_GETKEYSANDFLAGS.spec.ts
@@ -1,0 +1,24 @@
+import { strict as assert } from 'assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './COMMAND_GETKEYSANDFLAGS';
+
+describe.only('COMMAND GETKEYSANDFLAGS', () => {
+    it('transformArguments', () => {
+        assert.deepEqual(
+            transformArguments(['GET', 'key']),
+            ['COMMAND', 'GETKEYSANDFLAGS', 'GET', 'key']
+        );
+    });
+
+    testUtils.isVersionGreaterThanHook([7, 0]);
+    
+    testUtils.testWithClient('client.commandGetKeysAndFlags', async client => {
+        assert.deepEqual(
+            await client.commandGetKeysAndFlags(['GET', 'key']),
+            [{
+                key: 'key',
+                flags: ['RO', 'access']
+            }]
+        );
+    }, GLOBAL.SERVERS.OPEN);
+});

--- a/packages/client/lib/commands/COMMAND_GETKEYSANDFLAGS.ts
+++ b/packages/client/lib/commands/COMMAND_GETKEYSANDFLAGS.ts
@@ -1,0 +1,25 @@
+import { RedisCommandArgument, RedisCommandArguments } from '.';
+
+export const IS_READ_ONLY = true;
+
+export function transformArguments(args: Array<RedisCommandArgument>): RedisCommandArguments {
+    return ['COMMAND', 'GETKEYSANDFLAGS', ...args];
+}
+
+type KeysAndFlagsRawReply = [RedisCommandArgument, RedisCommandArguments];
+
+type KeysAndFlagsReply = {
+    key: RedisCommandArgument;
+    flags: RedisCommandArguments;
+};
+
+export function transformReply(reply: Array<KeysAndFlagsRawReply>): Array<KeysAndFlagsReply> {
+    return reply.map(KeyAndFlags => {
+        return {
+            // key: String(KeyAndFlags[0]),
+            // flags: KeyAndFlags[1].map(String)
+            key: KeyAndFlags[0],
+            flags: KeyAndFlags[1]
+        };
+    });
+}


### PR DESCRIPTION
### Description

[COMMAND GETKEYSANDFLAGS](https://redis.io/commands/command-getkeysandflags)
Closes #1981 

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

