### PR TITLE
Support ZINTERCARD and SINTERCARD

### DIFF
--- a/packages/client/lib/cluster/commands.ts
+++ b/packages/client/lib/cluster/commands.ts
@@ -98,6 +98,7 @@ import * as SETEX from '../commands/SETEX';
 import * as SETNX from '../commands/SETNX';
 import * as SETRANGE from '../commands/SETRANGE';
 import * as SINTER from '../commands/SINTER';
+import * as SINTERCARD from '../commands/SINTERCARD';
 import * as SINTERSTORE from '../commands/SINTERSTORE';
 import * as SISMEMBER from '../commands/SISMEMBER';
 import * as SMEMBERS from '../commands/SMEMBERS';
@@ -149,6 +150,7 @@ import * as ZDIFFSTORE from '../commands/ZDIFFSTORE';
 import * as ZINCRBY from '../commands/ZINCRBY';
 import * as ZINTER_WITHSCORES from '../commands/ZINTER_WITHSCORES';
 import * as ZINTER from '../commands/ZINTER';
+import * as ZINTERCARD from '../commands/ZINTERCARD';
 import * as ZINTERSTORE from '../commands/ZINTERSTORE';
 import * as ZLEXCOUNT from '../commands/ZLEXCOUNT';
 import * as ZMSCORE from '../commands/ZMSCORE';
@@ -366,6 +368,8 @@ export default {
     sDiffStore: SDIFFSTORE,
     SINTER,
     sInter: SINTER,
+    SINTERCARD,
+    sInterCard: SINTERCARD,
     SINTERSTORE,
     sInterStore: SINTERSTORE,
     SET,
@@ -478,6 +482,8 @@ export default {
     zInterWithScores: ZINTER_WITHSCORES,
     ZINTER,
     zInter: ZINTER,
+    ZINTERCARD,
+    zInterCard: ZINTERCARD,
     ZINTERSTORE,
     zInterStore: ZINTERSTORE,
     ZLEXCOUNT,

--- a/packages/client/lib/commands/SINTERCARD.spec.ts
+++ b/packages/client/lib/commands/SINTERCARD.spec.ts
@@ -8,15 +8,15 @@ describe('SINTERCARD', () => {
     describe('transformArguments', () => {
         it('simple', () => {
             assert.deepEqual(
-                transformArguments(['set1', 'set2']),
-                ['SINTERCARD', '2', 'set1', 'set2']
+                transformArguments(['1', '2']),
+                ['SINTERCARD', '2', '1', '2']
             );
         });
 
         it('with limit', () => {
             assert.deepEqual(
-                transformArguments(['set1', 'set2'], 1),
-                ['SINTERCARD', '2', 'set1', 'set2', 'LIMIT', '1']
+                transformArguments(['1', '2'], 1),
+                ['SINTERCARD', '2', '1', '2', 'LIMIT', '1']
             );
         });
     });

--- a/packages/client/lib/commands/SINTERCARD.spec.ts
+++ b/packages/client/lib/commands/SINTERCARD.spec.ts
@@ -1,0 +1,30 @@
+import { strict as assert } from 'assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './SINTERCARD';
+
+describe('SINTERCARD', () => {
+    testUtils.isVersionGreaterThanHook([7, 0]);
+
+    describe('transformArguments', () => {
+        it('simple', () => {
+            assert.deepEqual(
+                transformArguments(['set1', 'set2']),
+                ['SINTERCARD', '2', 'set1', 'set2']
+            );
+        });
+
+        it('with limit', () => {
+            assert.deepEqual(
+                transformArguments(['set1', 'set2'], 1),
+                ['SINTERCARD', '2', 'set1', 'set2', 'LIMIT', '1']
+            );
+        });
+    });
+
+    testUtils.testWithClient('client.sInterCard', async client => {
+        assert.deepEqual(
+            await client.sInterCard('key'),
+            0
+        );
+    }, GLOBAL.SERVERS.OPEN);
+});

--- a/packages/client/lib/commands/SINTERCARD.ts
+++ b/packages/client/lib/commands/SINTERCARD.ts
@@ -1,0 +1,21 @@
+import { RedisCommandArgument, RedisCommandArguments } from '.';
+import { pushVerdictArgument } from './generic-transformers';
+
+export const FIRST_KEY_INDEX = 2;
+
+export const IS_READ_ONLY = true;
+
+export function transformArguments(
+    keys: Array<RedisCommandArgument> | RedisCommandArgument,
+    limit?: number
+): RedisCommandArguments {
+    const args = pushVerdictArgument(['SINTERCARD'], keys);
+
+    if (limit) {
+        args.push('LIMIT', limit.toString());
+    }
+
+    return args;
+}
+
+export declare function transformReply(): Number;

--- a/packages/client/lib/commands/SINTERCARD.ts
+++ b/packages/client/lib/commands/SINTERCARD.ts
@@ -18,4 +18,4 @@ export function transformArguments(
     return args;
 }
 
-export declare function transformReply(): Number;
+export declare function transformReply(): number;

--- a/packages/client/lib/commands/ZINTERCARD.spec.ts
+++ b/packages/client/lib/commands/ZINTERCARD.spec.ts
@@ -8,15 +8,15 @@ describe('ZINTERCARD', () => {
     describe('transformArguments', () => {
         it('simple', () => {
             assert.deepEqual(
-                transformArguments(['zset1', 'zset2']),
-                ['ZINTERCARD', '2', 'zset1', 'zset2']
+                transformArguments(['1', '2']),
+                ['ZINTERCARD', '2', '1', '2']
             );
         });
 
         it('with limit', () => {
             assert.deepEqual(
-                transformArguments(['zset1', 'zset2'], 1),
-                ['ZINTERCARD', '2', 'zset1', 'zset2', 'LIMIT', '1']
+                transformArguments(['1', '2'], 1),
+                ['ZINTERCARD', '2', '1', '2', 'LIMIT', '1']
             );
         });
     });

--- a/packages/client/lib/commands/ZINTERCARD.spec.ts
+++ b/packages/client/lib/commands/ZINTERCARD.spec.ts
@@ -1,0 +1,30 @@
+import { strict as assert } from 'assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './ZINTERCARD';
+
+describe('ZINTERCARD', () => {
+    testUtils.isVersionGreaterThanHook([7, 0]);
+
+    describe('transformArguments', () => {
+        it('simple', () => {
+            assert.deepEqual(
+                transformArguments(['zset1', 'zset2']),
+                ['ZINTERCARD', '2', 'zset1', 'zset2']
+            );
+        });
+
+        it('with limit', () => {
+            assert.deepEqual(
+                transformArguments(['zset1', 'zset2'], 1),
+                ['ZINTERCARD', '2', 'zset1', 'zset2', 'LIMIT', '1']
+            );
+        });
+    });
+
+    testUtils.testWithClient('client.zInterCard', async client => {
+        assert.deepEqual(
+            await client.zInterCard('key'),
+            0
+        );
+    }, GLOBAL.SERVERS.OPEN);
+});

--- a/packages/client/lib/commands/ZINTERCARD.ts
+++ b/packages/client/lib/commands/ZINTERCARD.ts
@@ -1,0 +1,21 @@
+import { RedisCommandArgument, RedisCommandArguments } from '.';
+import { pushVerdictArgument } from './generic-transformers';
+
+export const FIRST_KEY_INDEX = 2;
+
+export const IS_READ_ONLY = true;
+
+export function transformArguments(
+    keys: Array<RedisCommandArgument> | RedisCommandArgument,
+    limit?: number
+): RedisCommandArguments {
+    const args = pushVerdictArgument(['ZINTERCARD'], keys);
+
+    if (limit) {
+        args.push('LIMIT', limit.toString());
+    }
+
+    return args;
+}
+
+export declare function transformReply(): Number;

--- a/packages/client/lib/commands/ZINTERCARD.ts
+++ b/packages/client/lib/commands/ZINTERCARD.ts
@@ -18,4 +18,4 @@ export function transformArguments(
     return args;
 }
 
-export declare function transformReply(): Number;
+export declare function transformReply(): number;


### PR DESCRIPTION
### Description

Two new commands:
1. [SINTERCARD](https://redis.io/commands/sintercard)
2. [ZINTERCARD](https://redis.io/commands/zintercard)

Closes #1977, Closes #1971

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
