### PR TITLE
Support multiple parametrs on CONFIG SET

### DIFF
--- a/packages/client/lib/commands/CONFIG_SET.spec.ts
+++ b/packages/client/lib/commands/CONFIG_SET.spec.ts
@@ -12,8 +12,12 @@ describe('CONFIG SET', () => {
 
         it('set muiltiple parameters', () => {
             assert.deepEqual(
-                transformArguments('parameter', 'value', [['parameter2', 'value2'], ['parameter3', 'value3']]),
-                ['CONFIG', 'SET', 'parameter', 'value', 'parameter2', 'value2', 'parameter3', 'value3']
+                transformArguments({
+                    1: 'a',
+                    2: 'b',
+                    3: 'c'
+                }),
+                ['CONFIG', 'SET', '1', 'a', '2', 'b', '3', 'c']
             );
         });
     });

--- a/packages/client/lib/commands/CONFIG_SET.spec.ts
+++ b/packages/client/lib/commands/CONFIG_SET.spec.ts
@@ -2,10 +2,19 @@ import { strict as assert } from 'assert';
 import { transformArguments } from './CONFIG_SET';
 
 describe('CONFIG SET', () => {
-    it('transformArguments', () => {
-        assert.deepEqual(
-            transformArguments('parameter', 'value'),
-            ['CONFIG', 'SET', 'parameter', 'value']
-        );
+    describe('transformArguments', () => {
+        it('set one parameter (old version)', () => {
+            assert.deepEqual(
+                transformArguments('parameter', 'value'),
+                ['CONFIG', 'SET', 'parameter', 'value']
+            );
+        });
+
+        it('set muiltiple parameters', () => {
+            assert.deepEqual(
+                transformArguments('parameter', 'value', [['parameter2', 'value2'], ['parameter3', 'value3']]),
+                ['CONFIG', 'SET', 'parameter', 'value', 'parameter2', 'value2', 'parameter3', 'value3']
+            );
+        });
     });
 });

--- a/packages/client/lib/commands/CONFIG_SET.ts
+++ b/packages/client/lib/commands/CONFIG_SET.ts
@@ -1,12 +1,20 @@
-export function transformArguments(
-    parameter: string,
-    value: string,
-    mulitipleParams?: Array<[parameter: string, value: string]>
-): Array<string> {
-    const args = ['CONFIG', 'SET', parameter, value];
+import { RedisCommandArgument, RedisCommandArguments } from '.';
 
-    if (mulitipleParams) {
-        mulitipleParams.forEach(pair => args.push(pair[0], pair[1]));
+type SingleParameter = [parameter: RedisCommandArgument, value: RedisCommandArgument];
+
+type MultipleParameters = [config: Record<string, RedisCommandArgument>];
+
+export function transformArguments(
+    ...[parameterOrConfig, value]: SingleParameter | MultipleParameters
+): RedisCommandArguments {
+    const args: RedisCommandArguments = ['CONFIG', 'SET'];
+
+    if (typeof parameterOrConfig === 'string') {
+        args.push(parameterOrConfig, value!);
+    } else {
+        for (const [key, value] of Object.entries(parameterOrConfig)) {
+            args.push(key, value);
+        }
     }
 
     return args;

--- a/packages/client/lib/commands/CONFIG_SET.ts
+++ b/packages/client/lib/commands/CONFIG_SET.ts
@@ -1,5 +1,15 @@
-export function transformArguments(parameter: string, value: string): Array<string> {
-    return ['CONFIG', 'SET', parameter, value];
+export function transformArguments(
+    parameter: string,
+    value: string,
+    mulitipleParams?: Array<[parameter: string, value: string]>
+): Array<string> {
+    const args = ['CONFIG', 'SET', parameter, value];
+
+    if (mulitipleParams) {
+        mulitipleParams.forEach(pair => args.push(pair[0], pair[1]));
+    }
+
+    return args;
 }
 
 export declare function transformReply(): string;


### PR DESCRIPTION
### Description

[CONFIG SET](https://redis.io/commands/config-set)
Closes #1936 

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
