### PR TITLE
Support new cluster commands

### DIFF
--- a/packages/client/lib/client/commands.ts
+++ b/packages/client/lib/client/commands.ts
@@ -23,8 +23,11 @@ import * as CLIENT_KILL from '../commands/CLIENT_KILL';
 import * as CLIENT_SETNAME from '../commands/CLIENT_SETNAME';
 import * as CLIENT_INFO from '../commands/CLIENT_INFO';
 import * as CLUSTER_ADDSLOTS from '../commands/CLUSTER_ADDSLOTS';
+import * as CLUSTER_ADDSLOTSRANGE from '../commands/CLUSTER_ADDSLOTSRANGE';
+import * as CLUSTER_DELSLOTSRANGE from '../commands/CLUSTER_DELSLOTSRANGE';
 import * as CLUSTER_FLUSHSLOTS from '../commands/CLUSTER_FLUSHSLOTS';
 import * as CLUSTER_INFO from '../commands/CLUSTER_INFO';
+import * as CLUSTER_LINKS from '../commands/CLUSTER_LINKS';
 import * as CLUSTER_NODES from '../commands/CLUSTER_NODES';
 import * as CLUSTER_MEET from '../commands/CLUSTER_MEET';
 import * as CLUSTER_RESET from '../commands/CLUSTER_RESET';
@@ -132,10 +135,16 @@ export default {
     clientInfo: CLIENT_INFO,
     CLUSTER_ADDSLOTS,
     clusterAddSlots: CLUSTER_ADDSLOTS,
+    CLUSTER_ADDSLOTSRANGE,
+    clusterAddSlotsRange: CLUSTER_ADDSLOTSRANGE,
+    CLUSTER_DELSLOTSRANGE,
+    clusterDelSlotsRange: CLUSTER_DELSLOTSRANGE,
     CLUSTER_FLUSHSLOTS,
     clusterFlushSlots: CLUSTER_FLUSHSLOTS,
     CLUSTER_INFO,
     clusterInfo: CLUSTER_INFO,
+    CLUSTER_LINKS,
+    clusterLinks: CLUSTER_LINKS,
     CLUSTER_NODES,
     clusterNodes: CLUSTER_NODES,
     CLUSTER_MEET,

--- a/packages/client/lib/commands/CLUSTER_ADDSLOTSRANGE.spec.ts
+++ b/packages/client/lib/commands/CLUSTER_ADDSLOTSRANGE.spec.ts
@@ -5,14 +5,23 @@ describe('CLUSTER ADDSLOTSRANGE', () => {
     describe('transformArguments', () => {
         it('single', () => {
             assert.deepEqual(
-                transformArguments([0, 1]),
+                transformArguments({
+                    start: 0,
+                    end: 1
+                }),
                 ['CLUSTER', 'ADDSLOTSRANGE', '0', '1']
             );
         });
 
         it('multiple', () => {
             assert.deepEqual(
-                transformArguments([0, 1], [2, 3]),
+                transformArguments([{
+                    start: 0,
+                    end: 1
+                }, {
+                    start: 2,
+                    end: 3
+                }]),
                 ['CLUSTER', 'ADDSLOTSRANGE', '0', '1', '2', '3']
             );
         });

--- a/packages/client/lib/commands/CLUSTER_ADDSLOTSRANGE.spec.ts
+++ b/packages/client/lib/commands/CLUSTER_ADDSLOTSRANGE.spec.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from 'assert';
+import { transformArguments } from './CLUSTER_ADDSLOTSRANGE';
+
+describe('CLUSTER ADDSLOTSRANGE', () => {
+    describe('transformArguments', () => {
+        it('single', () => {
+            assert.deepEqual(
+                transformArguments([0, 1]),
+                ['CLUSTER', 'ADDSLOTSRANGE', '0', '1']
+            );
+        });
+
+        it('multiple', () => {
+            assert.deepEqual(
+                transformArguments([0, 1], [2, 3]),
+                ['CLUSTER', 'ADDSLOTSRANGE', '0', '1', '2', '3']
+            );
+        });
+    });
+});

--- a/packages/client/lib/commands/CLUSTER_ADDSLOTSRANGE.ts
+++ b/packages/client/lib/commands/CLUSTER_ADDSLOTSRANGE.ts
@@ -1,0 +1,11 @@
+export function transformArguments(...slots: Array<[startSlot: number, endSlot: number]>): Array<string> {
+    const args =  ['CLUSTER', 'DELSLOTSRANGE'];
+
+    for(const [start, end] of slots) {
+        args.push(start.toString(), end.toString());
+    }
+
+    return args;
+}
+
+export declare function transformReply(): 'OK';

--- a/packages/client/lib/commands/CLUSTER_ADDSLOTSRANGE.ts
+++ b/packages/client/lib/commands/CLUSTER_ADDSLOTSRANGE.ts
@@ -1,11 +1,13 @@
-export function transformArguments(...slots: Array<[startSlot: number, endSlot: number]>): Array<string> {
-    const args =  ['CLUSTER', 'DELSLOTSRANGE'];
+import { RedisCommandArguments } from '.';
+import { pushSlotRangesArguments, SlotRange } from './generic-transformers';
 
-    for(const [start, end] of slots) {
-        args.push(start.toString(), end.toString());
-    }
-
-    return args;
+export function transformArguments(
+    ranges: SlotRange | Array<SlotRange>
+): RedisCommandArguments {
+    return pushSlotRangesArguments(
+        ['CLUSTER', 'ADDSLOTSRANGE'],
+        ranges
+    );
 }
 
 export declare function transformReply(): 'OK';

--- a/packages/client/lib/commands/CLUSTER_DELSLOTSRANGE.spec.ts
+++ b/packages/client/lib/commands/CLUSTER_DELSLOTSRANGE.spec.ts
@@ -5,14 +5,23 @@ describe('CLUSTER DELSLOTSRANGE', () => {
     describe('transformArguments', () => {
         it('single', () => {
             assert.deepEqual(
-                transformArguments([0, 1]),
+                transformArguments({
+                    start: 0,
+                    end: 1
+                }),
                 ['CLUSTER', 'DELSLOTSRANGE', '0', '1']
             );
         });
 
         it('multiple', () => {
             assert.deepEqual(
-                transformArguments([0, 1], [2, 3]),
+                transformArguments([{
+                    start: 0,
+                    end: 1
+                }, {
+                    start: 2,
+                    end: 3
+                }]),
                 ['CLUSTER', 'DELSLOTSRANGE', '0', '1', '2', '3']
             );
         });

--- a/packages/client/lib/commands/CLUSTER_DELSLOTSRANGE.spec.ts
+++ b/packages/client/lib/commands/CLUSTER_DELSLOTSRANGE.spec.ts
@@ -1,0 +1,20 @@
+import { strict as assert } from 'assert';
+import { transformArguments } from './CLUSTER_DELSLOTSRANGE';
+
+describe('CLUSTER DELSLOTSRANGE', () => {
+    describe('transformArguments', () => {
+        it('single', () => {
+            assert.deepEqual(
+                transformArguments([0, 1]),
+                ['CLUSTER', 'DELSLOTSRANGE', '0', '1']
+            );
+        });
+
+        it('multiple', () => {
+            assert.deepEqual(
+                transformArguments([0, 1], [2, 3]),
+                ['CLUSTER', 'DELSLOTSRANGE', '0', '1', '2', '3']
+            );
+        });
+    });
+});

--- a/packages/client/lib/commands/CLUSTER_DELSLOTSRANGE.ts
+++ b/packages/client/lib/commands/CLUSTER_DELSLOTSRANGE.ts
@@ -1,0 +1,11 @@
+export function transformArguments(...slots: Array<[startSlot: number, endSlot: number]>): Array<string> {
+    const args =  ['CLUSTER', 'ADDSLOTSRANGE'];
+
+    for(const [start, end] of slots) {
+        args.push(start.toString(), end.toString());
+    }
+
+    return args;
+}
+
+export declare function transformReply(): 'OK';

--- a/packages/client/lib/commands/CLUSTER_DELSLOTSRANGE.ts
+++ b/packages/client/lib/commands/CLUSTER_DELSLOTSRANGE.ts
@@ -1,11 +1,13 @@
-export function transformArguments(...slots: Array<[startSlot: number, endSlot: number]>): Array<string> {
-    const args =  ['CLUSTER', 'ADDSLOTSRANGE'];
+import { RedisCommandArguments } from '.';
+import { pushSlotRangesArguments, SlotRange } from './generic-transformers';
 
-    for(const [start, end] of slots) {
-        args.push(start.toString(), end.toString());
-    }
-
-    return args;
+export function transformArguments(
+    ranges: SlotRange | Array<SlotRange>
+): RedisCommandArguments {
+    return pushSlotRangesArguments(
+        ['CLUSTER', 'DELSLOTSRANGE'],
+        ranges
+    );
 }
 
 export declare function transformReply(): 'OK';

--- a/packages/client/lib/commands/CLUSTER_LINKS.spec.ts
+++ b/packages/client/lib/commands/CLUSTER_LINKS.spec.ts
@@ -1,0 +1,22 @@
+import { strict as assert } from 'assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './CLUSTER_LINKS';
+
+describe('CLUSTER LINKS', () => {
+    it('transformArguments', () => {
+        assert.deepEqual(
+            transformArguments(),
+            ['CLUSTER', 'LINKS']
+        );
+    });
+
+    testUtils.isVersionGreaterThanHook([7, 0]);
+    
+    testUtils.testWithCluster('clusterNode.clusterSaveConfig', async cluster => {
+        const links = await cluster.getSlotMaster(0).client.clusterLinks();
+
+        assert.notEqual(links, null);
+        assert.equal(typeof links[0].node, 'string');
+
+    }, GLOBAL.CLUSTERS.OPEN);
+});

--- a/packages/client/lib/commands/CLUSTER_LINKS.spec.ts
+++ b/packages/client/lib/commands/CLUSTER_LINKS.spec.ts
@@ -3,6 +3,8 @@ import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './CLUSTER_LINKS';
 
 describe('CLUSTER LINKS', () => {
+    testUtils.isVersionGreaterThanHook([7, 0]);
+
     it('transformArguments', () => {
         assert.deepEqual(
             transformArguments(),
@@ -10,13 +12,16 @@ describe('CLUSTER LINKS', () => {
         );
     });
 
-    testUtils.isVersionGreaterThanHook([7, 0]);
-    
-    testUtils.testWithCluster('clusterNode.clusterSaveConfig', async cluster => {
+    testUtils.testWithCluster('clusterNode.clusterLinks', async cluster => {
         const links = await cluster.getSlotMaster(0).client.clusterLinks();
-
-        assert.notEqual(links, null);
-        assert.equal(typeof links[0].node, 'string');
-
+        assert.ok(Array.isArray(links));
+        for (const link of links) {
+            assert.equal(typeof link.direction, 'string');
+            assert.equal(typeof link.node, 'string');
+            assert.equal(typeof link.createTime, 'number');
+            assert.equal(typeof link.events, 'string');
+            assert.equal(typeof link.sendBufferAllocated, 'number');
+            assert.equal(typeof link.sendBufferUsed, 'number');
+        }
     }, GLOBAL.CLUSTERS.OPEN);
 });

--- a/packages/client/lib/commands/CLUSTER_LINKS.ts
+++ b/packages/client/lib/commands/CLUSTER_LINKS.ts
@@ -1,0 +1,25 @@
+export function transformArguments(): Array<string> {
+    return ['CLUSTER', 'LINKS'];
+}
+
+type ClusterLinksReply = Array<{
+    direction: string;
+    node: string;
+    createTime: number;
+    events: string;
+    sendBufferAllocated: number;
+    sendBufferUsed: number;
+}>;
+
+export function transformReply(reply: Array<Array<string>>): ClusterLinksReply {
+    return reply.map(peerLink => {
+        return {
+            direction: peerLink[1],
+            node: peerLink[3],
+            createTime: Number(peerLink[5]),
+            events: peerLink[7],
+            sendBufferAllocated: Number(peerLink[9]),
+            sendBufferUsed: Number(peerLink[11])
+        }
+    });
+}

--- a/packages/client/lib/commands/CLUSTER_LINKS.ts
+++ b/packages/client/lib/commands/CLUSTER_LINKS.ts
@@ -2,6 +2,21 @@ export function transformArguments(): Array<string> {
     return ['CLUSTER', 'LINKS'];
 }
 
+type ClusterLinksRawReply = Array<[
+    'direction',
+    string,
+    'node',
+    string,
+    'createTime',
+    number,
+    'events',
+    string,
+    'send-buffer-allocated',
+    number,
+    'send-buffer-used',
+    number
+]>;
+
 type ClusterLinksReply = Array<{
     direction: string;
     node: string;
@@ -11,15 +26,13 @@ type ClusterLinksReply = Array<{
     sendBufferUsed: number;
 }>;
 
-export function transformReply(reply: Array<Array<string>>): ClusterLinksReply {
-    return reply.map(peerLink => {
-        return {
-            direction: peerLink[1],
-            node: peerLink[3],
-            createTime: Number(peerLink[5]),
-            events: peerLink[7],
-            sendBufferAllocated: Number(peerLink[9]),
-            sendBufferUsed: Number(peerLink[11])
-        }
-    });
+export function transformReply(reply: ClusterLinksRawReply): ClusterLinksReply {
+    return reply.map(peerLink => ({
+        direction: peerLink[1],
+        node: peerLink[3],
+        createTime: Number(peerLink[5]),
+        events: peerLink[7],
+        sendBufferAllocated: Number(peerLink[9]),
+        sendBufferUsed: Number(peerLink[11])
+    }));
 }

--- a/packages/client/lib/commands/generic-transformers.spec.ts
+++ b/packages/client/lib/commands/generic-transformers.spec.ts
@@ -23,7 +23,8 @@ import {
     pushOptionalVerdictArgument,
     transformCommandReply,
     CommandFlags,
-    CommandCategories
+    CommandCategories,
+    pushSlotRangesArguments
 } from './generic-transformers';
 
 describe('Generic Transformers', () => {
@@ -638,5 +639,30 @@ describe('Generic Transformers', () => {
                 categories: new Set([CommandCategories.FAST, CommandCategories.CONNECTION])
             }
         );
+    });
+
+    describe('pushSlotRangesArguments', () => {
+        it('single range', () => {
+            assert.deepEqual(
+                pushSlotRangesArguments([], {
+                    start: 0,
+                    end: 1
+                }),
+                ['0', '1']
+            );
+        });
+
+        it('multiple ranges', () => {
+            assert.deepEqual(
+                pushSlotRangesArguments([], [{
+                    start: 0,
+                    end: 1
+                }, {
+                    start: 2,
+                    end: 3
+                }]),
+                ['0', '1', '2', '3']
+            );
+        });
     });
 });

--- a/packages/client/lib/commands/generic-transformers.ts
+++ b/packages/client/lib/commands/generic-transformers.ts
@@ -422,3 +422,33 @@ export function transformCommandReply(
         categories: new Set(categories)
     };
 }
+
+export interface SlotRange {
+    start: number;
+    end: number;
+}
+
+function pushSlotRangeArguments(
+    args: RedisCommandArguments,
+    range: SlotRange
+): void {
+    args.push(
+        range.start.toString(),
+        range.end.toString()
+    );
+}
+
+export function pushSlotRangesArguments(
+    args: RedisCommandArguments,
+    ranges: SlotRange | Array<SlotRange>
+): RedisCommandArguments {
+    if (Array.isArray(ranges)) {
+        for (const range of ranges) {
+            pushSlotRangeArguments(args, range);
+        }
+    } else {
+        pushSlotRangeArguments(args, ranges);
+    }
+
+    return args;
+}


### PR DESCRIPTION
### Description

Support new CLUSTER [...] commands:
1. [CLUSTER ADDSLOTSRANGE](https://redis.io/commands/cluster-addslotsrange)
2. [CLUSTER DELSLOTSRANGE](https://redis.io/commands/cluster-delslotsrange)
3. [CLUSTER LINKS](https://redis.io/commands/cluster-links)

closes #1927, closes #1923, closes #1918 

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
