### PR TITLE
Support new muilti pop commands

### DIFF
--- a/packages/client/lib/cluster/commands.ts
+++ b/packages/client/lib/cluster/commands.ts
@@ -6,9 +6,11 @@ import * as BITFIELD from '../commands/BITFIELD';
 import * as BITOP from '../commands/BITOP';
 import * as BITPOS from '../commands/BITPOS';
 import * as BLMOVE from '../commands/BLMOVE';
+import * as BLMPOP from '../commands/BLMPOP';
 import * as BLPOP from '../commands/BLPOP';
 import * as BRPOP from '../commands/BRPOP';
 import * as BRPOPLPUSH from '../commands/BRPOPLPUSH';
+import * as BZMPOP from '../commands/BZMPOP';
 import * as BZPOPMAX from '../commands/BZPOPMAX';
 import * as BZPOPMIN from '../commands/BZPOPMIN';
 import * as COPY from '../commands/COPY';
@@ -58,6 +60,7 @@ import * as LINDEX from '../commands/LINDEX';
 import * as LINSERT from '../commands/LINSERT';
 import * as LLEN from '../commands/LLEN';
 import * as LMOVE from '../commands/LMOVE';
+import * as LMPOP from '../commands/LMPOP';
 import * as LPOP_COUNT from '../commands/LPOP_COUNT';
 import * as LPOP from '../commands/LPOP';
 import * as LPOS_COUNT from '../commands/LPOS_COUNT';
@@ -153,6 +156,7 @@ import * as ZINTER from '../commands/ZINTER';
 import * as ZINTERCARD from '../commands/ZINTERCARD';
 import * as ZINTERSTORE from '../commands/ZINTERSTORE';
 import * as ZLEXCOUNT from '../commands/ZLEXCOUNT';
+import * as ZMPOP from '../commands/ZMPOP';
 import * as ZMSCORE from '../commands/ZMSCORE';
 import * as ZPOPMAX_COUNT from '../commands/ZPOPMAX_COUNT';
 import * as ZPOPMAX from '../commands/ZPOPMAX';
@@ -194,12 +198,16 @@ export default {
     bitPos: BITPOS,
     BLMOVE,
     blMove: BLMOVE,
+    BLMPOP,
+    blmPop: BLMPOP,
     BLPOP,
     blPop: BLPOP,
     BRPOP,
     brPop: BRPOP,
     BRPOPLPUSH,
     brPopLPush: BRPOPLPUSH,
+    BZMPOP,
+    bzmPop: BZMPOP,
     BZPOPMAX,
     bzPopMax: BZPOPMAX,
     BZPOPMIN,
@@ -298,6 +306,8 @@ export default {
     lLen: LLEN,
     LMOVE,
     lMove: LMOVE,
+    LMPOP,
+    lmPop: LMPOP,
     LPOP_COUNT,
     lPopCount: LPOP_COUNT,
     LPOP,
@@ -488,6 +498,8 @@ export default {
     zInterStore: ZINTERSTORE,
     ZLEXCOUNT,
     zLexCount: ZLEXCOUNT,
+    ZMPOP,
+    zmPop: ZMPOP,
     ZMSCORE,
     zmScore: ZMSCORE,
     ZPOPMAX_COUNT,

--- a/packages/client/lib/commands/BLMOVE.ts
+++ b/packages/client/lib/commands/BLMOVE.ts
@@ -1,13 +1,13 @@
 import { RedisCommandArgument, RedisCommandArguments } from '.';
-import { LMoveSide } from './LMOVE';
+import { ListSide } from './generic-transformers';
 
 export const FIRST_KEY_INDEX = 1;
 
 export function transformArguments(
     source: RedisCommandArgument,
     destination: RedisCommandArgument,
-    sourceDirection: LMoveSide,
-    destinationDirection: LMoveSide,
+    sourceDirection: ListSide,
+    destinationDirection: ListSide,
     timeout: number
 ): RedisCommandArguments {
     return [

--- a/packages/client/lib/commands/BLMPOP.spec.ts
+++ b/packages/client/lib/commands/BLMPOP.spec.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './BLMPOP';
 
-describe.only('BLMPOP', () => {
+describe('BLMPOP', () => {
     testUtils.isVersionGreaterThanHook([7, 0]);
 
     describe('transformArguments', () => {

--- a/packages/client/lib/commands/BLMPOP.spec.ts
+++ b/packages/client/lib/commands/BLMPOP.spec.ts
@@ -23,9 +23,9 @@ describe('BLMPOP', () => {
         });
     });
 
-    testUtils.testWithClient('client.zmScore', async client => {
+    testUtils.testWithClient('client.blmPop', async client => {
         assert.deepEqual(
-            await client.blmPop(0, 'key', 'RIGHT'),
+            await client.blmPop(1, 'key', 'RIGHT'),
             null
         );
     }, GLOBAL.SERVERS.OPEN);

--- a/packages/client/lib/commands/BLMPOP.spec.ts
+++ b/packages/client/lib/commands/BLMPOP.spec.ts
@@ -8,17 +8,14 @@ describe('BLMPOP', () => {
     describe('transformArguments', () => {
         it('simple', () => {
             assert.deepEqual(
-                transformArguments(0, 'key', {
-                    SIDE: 'LEFT'
-                }),
+                transformArguments(0, 'key', 'LEFT'),
                 ['BLMPOP', '0', '1', 'key', 'LEFT']
             );
         });
 
-        it('with score and count', () => {
+        it('with COUNT', () => {
             assert.deepEqual(
-                transformArguments(0, 'key', {
-                    SIDE: 'LEFT',
+                transformArguments(0, 'key', 'LEFT', {
                     COUNT: 2
                 }),
                 ['BLMPOP', '0', '1', 'key', 'LEFT', 'COUNT', '2']
@@ -28,9 +25,7 @@ describe('BLMPOP', () => {
 
     testUtils.testWithClient('client.zmScore', async client => {
         assert.deepEqual(
-            await client.blmPop(0, 'key', {
-                SIDE: 'LEFT'
-            }),
+            await client.blmPop(0, 'key', 'RIGHT'),
             null
         );
     }, GLOBAL.SERVERS.OPEN);

--- a/packages/client/lib/commands/BLMPOP.spec.ts
+++ b/packages/client/lib/commands/BLMPOP.spec.ts
@@ -1,0 +1,37 @@
+import { strict as assert } from 'assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './BLMPOP';
+
+describe.only('BLMPOP', () => {
+    testUtils.isVersionGreaterThanHook([7, 0]);
+
+    describe('transformArguments', () => {
+        it('simple', () => {
+            assert.deepEqual(
+                transformArguments(0, 'key', {
+                    SIDE: 'LEFT'
+                }),
+                ['BLMPOP', '0', '1', 'key', 'LEFT']
+            );
+        });
+
+        it('with score and count', () => {
+            assert.deepEqual(
+                transformArguments(0, 'key', {
+                    SIDE: 'LEFT',
+                    COUNT: 2
+                }),
+                ['BLMPOP', '0', '1', 'key', 'LEFT', 'COUNT', '2']
+            );
+        });
+    });
+
+    testUtils.testWithClient('client.zmScore', async client => {
+        assert.deepEqual(
+            await client.blmPop(0, 'key', {
+                SIDE: 'LEFT'
+            }),
+            null
+        );
+    }, GLOBAL.SERVERS.OPEN);
+});

--- a/packages/client/lib/commands/BLMPOP.ts
+++ b/packages/client/lib/commands/BLMPOP.ts
@@ -1,0 +1,14 @@
+import { RedisCommandArguments } from '.';
+import { transformLMPopArguments, LMPopOptions } from './generic-transformers';
+
+export const FIRST_KEY_INDEX = 3;
+
+export function transformArguments(
+    timeout: number,
+    keys: string | Array<string>,
+    options: LMPopOptions
+): RedisCommandArguments {
+    return transformLMPopArguments(['BLMPOP', timeout.toString()], keys, options);
+}
+
+export { transformReply } from './LMPOP';

--- a/packages/client/lib/commands/BLMPOP.ts
+++ b/packages/client/lib/commands/BLMPOP.ts
@@ -1,14 +1,20 @@
-import { RedisCommandArguments } from '.';
-import { transformLMPopArguments, LMPopOptions } from './generic-transformers';
+import { RedisCommandArgument, RedisCommandArguments } from '.';
+import { transformLMPopArguments, LMPopOptions, ListSide } from './generic-transformers';
 
 export const FIRST_KEY_INDEX = 3;
 
 export function transformArguments(
     timeout: number,
-    keys: string | Array<string>,
-    options: LMPopOptions
+    keys: RedisCommandArgument | Array<RedisCommandArgument>,
+    side: ListSide,
+    options?: LMPopOptions
 ): RedisCommandArguments {
-    return transformLMPopArguments(['BLMPOP', timeout.toString()], keys, options);
+    return transformLMPopArguments(
+        ['BLMPOP', timeout.toString()],
+        keys,
+        side,
+        options
+    );
 }
 
 export { transformReply } from './LMPOP';

--- a/packages/client/lib/commands/BLPOP.spec.ts
+++ b/packages/client/lib/commands/BLPOP.spec.ts
@@ -65,7 +65,7 @@ describe('BLPOP', () => {
                 'key',
                 1
             ),
-            cluster.lPush('key', 'element'),
+            cluster.lPush('key', 'element')
         ]);
 
         assert.deepEqual(

--- a/packages/client/lib/commands/BZMPOP.spec.ts
+++ b/packages/client/lib/commands/BZMPOP.spec.ts
@@ -25,7 +25,7 @@ describe('BZMPOP', () => {
 
     testUtils.testWithClient('client.bzmPop', async client => {
         assert.deepEqual(
-            await client.bzmPop(0, 'key', 'MAX'),
+            await client.bzmPop(1, 'key', 'MAX'),
             null
         );
     }, GLOBAL.SERVERS.OPEN);

--- a/packages/client/lib/commands/BZMPOP.spec.ts
+++ b/packages/client/lib/commands/BZMPOP.spec.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './BZMPOP';
 
-describe.only('BZMPOP', () => {
+describe('BZMPOP', () => {
     testUtils.isVersionGreaterThanHook([7, 0]);
 
     describe('transformArguments', () => {

--- a/packages/client/lib/commands/BZMPOP.spec.ts
+++ b/packages/client/lib/commands/BZMPOP.spec.ts
@@ -8,17 +8,14 @@ describe('BZMPOP', () => {
     describe('transformArguments', () => {
         it('simple', () => {
             assert.deepEqual(
-                transformArguments(0, 'key', {
-                    SCORE: 'MIN'
-                }),
+                transformArguments(0, 'key', 'MIN'),
                 ['BZMPOP', '0', '1', 'key', 'MIN']
             );
         });
 
-        it('with score and count', () => {
+        it('with COUNT', () => {
             assert.deepEqual(
-                transformArguments(0, 'key', {
-                    SCORE: 'MIN',
+                transformArguments(0, 'key', 'MIN', {
                     COUNT: 2
                 }),
                 ['BZMPOP', '0', '1', 'key', 'MIN', 'COUNT', '2']
@@ -26,11 +23,9 @@ describe('BZMPOP', () => {
         });
     });
 
-    testUtils.testWithClient('client.zmScore', async client => {
+    testUtils.testWithClient('client.bzmPop', async client => {
         assert.deepEqual(
-            await client.bzmPop(0, 'key', {
-                SCORE: 'MAX'
-            }),
+            await client.bzmPop(0, 'key', 'MAX'),
             null
         );
     }, GLOBAL.SERVERS.OPEN);

--- a/packages/client/lib/commands/BZMPOP.spec.ts
+++ b/packages/client/lib/commands/BZMPOP.spec.ts
@@ -1,0 +1,37 @@
+import { strict as assert } from 'assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './BZMPOP';
+
+describe.only('BZMPOP', () => {
+    testUtils.isVersionGreaterThanHook([7, 0]);
+
+    describe('transformArguments', () => {
+        it('simple', () => {
+            assert.deepEqual(
+                transformArguments(0, 'key', {
+                    SCORE: 'MIN'
+                }),
+                ['BZMPOP', '0', '1', 'key', 'MIN']
+            );
+        });
+
+        it('with score and count', () => {
+            assert.deepEqual(
+                transformArguments(0, 'key', {
+                    SCORE: 'MIN',
+                    COUNT: 2
+                }),
+                ['BZMPOP', '0', '1', 'key', 'MIN', 'COUNT', '2']
+            );
+        });
+    });
+
+    testUtils.testWithClient('client.zmScore', async client => {
+        assert.deepEqual(
+            await client.bzmPop(0, 'key', {
+                SCORE: 'MAX'
+            }),
+            null
+        );
+    }, GLOBAL.SERVERS.OPEN);
+});

--- a/packages/client/lib/commands/BZMPOP.ts
+++ b/packages/client/lib/commands/BZMPOP.ts
@@ -1,0 +1,14 @@
+import { RedisCommandArguments } from '.';
+import { transformZMPopArguments, ZMPopOptions } from './generic-transformers';
+
+export const FIRST_KEY_INDEX = 3;
+
+export function transformArguments(
+    timeout: number,
+    keys: string | Array<string>,
+    options: ZMPopOptions
+): RedisCommandArguments {
+    return transformZMPopArguments(['BZMPOP', timeout.toString()], keys, options);
+}
+
+export { transformReply } from './ZMPOP';

--- a/packages/client/lib/commands/BZMPOP.ts
+++ b/packages/client/lib/commands/BZMPOP.ts
@@ -1,14 +1,20 @@
-import { RedisCommandArguments } from '.';
-import { transformZMPopArguments, ZMPopOptions } from './generic-transformers';
+import { RedisCommandArgument, RedisCommandArguments } from '.';
+import { SortedSetSide, transformZMPopArguments, ZMPopOptions } from './generic-transformers';
 
 export const FIRST_KEY_INDEX = 3;
 
 export function transformArguments(
     timeout: number,
-    keys: string | Array<string>,
-    options: ZMPopOptions
+    keys: RedisCommandArgument | Array<RedisCommandArgument>,
+    side: SortedSetSide,
+    options?: ZMPopOptions
 ): RedisCommandArguments {
-    return transformZMPopArguments(['BZMPOP', timeout.toString()], keys, options);
+    return transformZMPopArguments(
+        ['BZMPOP', timeout.toString()],
+        keys,
+        side,
+        options
+    );
 }
 
 export { transformReply } from './ZMPOP';

--- a/packages/client/lib/commands/BZPOPMAX.spec.ts
+++ b/packages/client/lib/commands/BZPOPMAX.spec.ts
@@ -45,7 +45,7 @@ describe('BZPOPMAX', () => {
             client.bzPopMax(
                 commandOptions({ isolated: true }),
                 'key',
-                0
+                1
             ),
             client.zAdd('key', [{
                 value: '1',

--- a/packages/client/lib/commands/BZPOPMIN.spec.ts
+++ b/packages/client/lib/commands/BZPOPMIN.spec.ts
@@ -45,7 +45,7 @@ describe('BZPOPMIN', () => {
             client.bzPopMin(
                 commandOptions({ isolated: true }),
                 'key',
-                0
+                1
             ),
             client.zAdd('key', [{
                 value: '1',

--- a/packages/client/lib/commands/LMOVE.ts
+++ b/packages/client/lib/commands/LMOVE.ts
@@ -1,14 +1,13 @@
 import { RedisCommandArgument, RedisCommandArguments } from '.';
+import { ListSide } from './generic-transformers';
 
 export const FIRST_KEY_INDEX = 1;
-
-export type LMoveSide = 'LEFT' | 'RIGHT';
 
 export function transformArguments(
     source: RedisCommandArgument,
     destination: RedisCommandArgument,
-    sourceSide: LMoveSide,
-    destinationSide: LMoveSide
+    sourceSide: ListSide,
+    destinationSide: ListSide
 ): RedisCommandArguments {
     return [
         'LMOVE',

--- a/packages/client/lib/commands/LMPOP.spec.ts
+++ b/packages/client/lib/commands/LMPOP.spec.ts
@@ -1,0 +1,37 @@
+import { strict as assert } from 'assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './LMPOP';
+
+describe.only('LMPOP', () => {
+    testUtils.isVersionGreaterThanHook([7, 0]);
+
+    describe('transformArguments', () => {
+        it('simple', () => {
+            assert.deepEqual(
+                transformArguments('key', {
+                    SIDE: 'LEFT'
+                }),
+                ['LMPOP', '1', 'key', 'LEFT']
+            );
+        });
+
+        it('with score and count', () => {
+            assert.deepEqual(
+                transformArguments('key', {
+                    SIDE: 'LEFT',
+                    COUNT: 2
+                }),
+                ['LMPOP', '1', 'key', 'LEFT', 'COUNT', '2']
+            );
+        });
+    });
+
+    testUtils.testWithClient('client.zmScore', async client => {
+        assert.deepEqual(
+            await client.lmPop('key', {
+                SIDE: 'RIGHT'
+            }),
+            null
+        );
+    }, GLOBAL.SERVERS.OPEN);
+});

--- a/packages/client/lib/commands/LMPOP.spec.ts
+++ b/packages/client/lib/commands/LMPOP.spec.ts
@@ -8,17 +8,14 @@ describe('LMPOP', () => {
     describe('transformArguments', () => {
         it('simple', () => {
             assert.deepEqual(
-                transformArguments('key', {
-                    SIDE: 'LEFT'
-                }),
+                transformArguments('key', 'LEFT'),
                 ['LMPOP', '1', 'key', 'LEFT']
             );
         });
 
-        it('with score and count', () => {
+        it('with COUNT', () => {
             assert.deepEqual(
-                transformArguments('key', {
-                    SIDE: 'LEFT',
+                transformArguments('key', 'LEFT', {
                     COUNT: 2
                 }),
                 ['LMPOP', '1', 'key', 'LEFT', 'COUNT', '2']
@@ -26,11 +23,9 @@ describe('LMPOP', () => {
         });
     });
 
-    testUtils.testWithClient('client.zmScore', async client => {
+    testUtils.testWithClient('client.lmPop', async client => {
         assert.deepEqual(
-            await client.lmPop('key', {
-                SIDE: 'RIGHT'
-            }),
+            await client.lmPop('key', 'RIGHT'),
             null
         );
     }, GLOBAL.SERVERS.OPEN);

--- a/packages/client/lib/commands/LMPOP.spec.ts
+++ b/packages/client/lib/commands/LMPOP.spec.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './LMPOP';
 
-describe.only('LMPOP', () => {
+describe('LMPOP', () => {
     testUtils.isVersionGreaterThanHook([7, 0]);
 
     describe('transformArguments', () => {

--- a/packages/client/lib/commands/LMPOP.ts
+++ b/packages/client/lib/commands/LMPOP.ts
@@ -1,20 +1,22 @@
-import { RedisCommandArguments } from '.';
-import { transformLMPopArguments, LMPopOptions } from './generic-transformers';
+import { RedisCommandArgument, RedisCommandArguments } from '.';
+import { transformLMPopArguments, LMPopOptions, ListSide } from './generic-transformers';
 
 export const FIRST_KEY_INDEX = 2;
 
-export const IS_READ_ONLY = true;
-
 export function transformArguments(
-    keys: string | Array<string>,
-    options: LMPopOptions
+    keys: RedisCommandArgument | Array<RedisCommandArgument>,
+    side: ListSide,
+    options?: LMPopOptions
 ): RedisCommandArguments {
-    return transformLMPopArguments(['LMPOP'], keys, options);
+    return transformLMPopArguments(
+        ['LMPOP'],
+        keys,
+        side,
+        options
+    );
 }
 
-type LMPopReply = null | [
-    key: string, 
-    elements: Array<String>
+export declare function transformReply(): null | [
+    key: string,
+    elements: Array<string>
 ];
-
-export declare function transformReply(): LMPopReply;

--- a/packages/client/lib/commands/LMPOP.ts
+++ b/packages/client/lib/commands/LMPOP.ts
@@ -1,0 +1,20 @@
+import { RedisCommandArguments } from '.';
+import { transformLMPopArguments, LMPopOptions } from './generic-transformers';
+
+export const FIRST_KEY_INDEX = 2;
+
+export const IS_READ_ONLY = true;
+
+export function transformArguments(
+    keys: string | Array<string>,
+    options: LMPopOptions
+): RedisCommandArguments {
+    return transformLMPopArguments(['LMPOP'], keys, options);
+}
+
+type LMPopReply = null | [
+    key: string, 
+    elements: Array<String>
+];
+
+export declare function transformReply(): LMPopReply;

--- a/packages/client/lib/commands/ZMPOP.spec.ts
+++ b/packages/client/lib/commands/ZMPOP.spec.ts
@@ -8,17 +8,14 @@ describe('ZMPOP', () => {
     describe('transformArguments', () => {
         it('simple', () => {
             assert.deepEqual(
-                transformArguments('key', {
-                    SCORE: 'MIN'
-                }),
+                transformArguments('key', 'MIN'),
                 ['ZMPOP', '1', 'key', 'MIN']
             );
         });
 
         it('with score and count', () => {
             assert.deepEqual(
-                transformArguments('key', {
-                    SCORE: 'MIN',
+                transformArguments('key', 'MIN', {
                     COUNT: 2
                 }),
                 ['ZMPOP', '1', 'key', 'MIN', 'COUNT', '2']
@@ -28,9 +25,7 @@ describe('ZMPOP', () => {
 
     testUtils.testWithClient('client.zmScore', async client => {
         assert.deepEqual(
-            await client.zmPop('key', {
-                SCORE: 'MAX'
-            }),
+            await client.zmPop('key', 'MIN'),
             null
         );
     }, GLOBAL.SERVERS.OPEN);

--- a/packages/client/lib/commands/ZMPOP.spec.ts
+++ b/packages/client/lib/commands/ZMPOP.spec.ts
@@ -23,7 +23,7 @@ describe('ZMPOP', () => {
         });
     });
 
-    testUtils.testWithClient('client.zmScore', async client => {
+    testUtils.testWithClient('client.zmPop', async client => {
         assert.deepEqual(
             await client.zmPop('key', 'MIN'),
             null

--- a/packages/client/lib/commands/ZMPOP.spec.ts
+++ b/packages/client/lib/commands/ZMPOP.spec.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './ZMPOP';
 
-describe.only('ZMPOP', () => {
+describe('ZMPOP', () => {
     testUtils.isVersionGreaterThanHook([7, 0]);
 
     describe('transformArguments', () => {

--- a/packages/client/lib/commands/ZMPOP.spec.ts
+++ b/packages/client/lib/commands/ZMPOP.spec.ts
@@ -1,0 +1,37 @@
+import { strict as assert } from 'assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './ZMPOP';
+
+describe.only('ZMPOP', () => {
+    testUtils.isVersionGreaterThanHook([7, 0]);
+
+    describe('transformArguments', () => {
+        it('simple', () => {
+            assert.deepEqual(
+                transformArguments('key', {
+                    SCORE: 'MIN'
+                }),
+                ['ZMPOP', '1', 'key', 'MIN']
+            );
+        });
+
+        it('with score and count', () => {
+            assert.deepEqual(
+                transformArguments('key', {
+                    SCORE: 'MIN',
+                    COUNT: 2
+                }),
+                ['ZMPOP', '1', 'key', 'MIN', 'COUNT', '2']
+            );
+        });
+    });
+
+    testUtils.testWithClient('client.zmScore', async client => {
+        assert.deepEqual(
+            await client.zmPop('key', {
+                SCORE: 'MAX'
+            }),
+            null
+        );
+    }, GLOBAL.SERVERS.OPEN);
+});

--- a/packages/client/lib/commands/ZMPOP.ts
+++ b/packages/client/lib/commands/ZMPOP.ts
@@ -1,26 +1,34 @@
 import { RedisCommandArgument, RedisCommandArguments } from '.';
-import { transformSortedSetMemberReply, transformZMPopArguments, ZMember, ZMPopOptions } from './generic-transformers';
+import { SortedSetSide, transformSortedSetMemberReply, transformZMPopArguments, ZMember, ZMPopOptions } from './generic-transformers';
 
 export const FIRST_KEY_INDEX = 2;
 
-export const IS_READ_ONLY = true;
-
 export function transformArguments(
-    keys: string | Array<string>,
-    options: ZMPopOptions
+    keys: RedisCommandArgument | Array<RedisCommandArgument>,
+    side: SortedSetSide,
+    options?: ZMPopOptions
 ): RedisCommandArguments {
-    return transformZMPopArguments(['ZMPOP'], keys, options);
+    return transformZMPopArguments(
+        ['ZMPOP'],
+        keys,
+        side,
+        options
+    );
 }
 
-type ZMPopRawReply = null | [string, Array<[RedisCommandArgument, RedisCommandArgument]>];
-
-type ZMPopReply = null | [
-    key: string, 
-    elements: Array<ZMember>
+type ZMPopRawReply = null | [
+    key: string,
+    elements: Array<[RedisCommandArgument, RedisCommandArgument]>
 ];
 
-export function transformReply(reply: ZMPopRawReply): ZMPopReply {
-    if (reply == null) return null;
+type ZMPopReply = null | {
+    key: string,
+    elements: Array<ZMember>
+};
 
-    return [reply[0], reply[1].map(transformSortedSetMemberReply)];
+export function transformReply(reply: ZMPopRawReply): ZMPopReply {
+    return reply === null ? null : {
+        key: reply[0],
+        elements: reply[1].map(transformSortedSetMemberReply)
+    };
 }

--- a/packages/client/lib/commands/ZMPOP.ts
+++ b/packages/client/lib/commands/ZMPOP.ts
@@ -1,0 +1,26 @@
+import { RedisCommandArgument, RedisCommandArguments } from '.';
+import { transformSortedSetMemberReply, transformZMPopArguments, ZMember, ZMPopOptions } from './generic-transformers';
+
+export const FIRST_KEY_INDEX = 2;
+
+export const IS_READ_ONLY = true;
+
+export function transformArguments(
+    keys: string | Array<string>,
+    options: ZMPopOptions
+): RedisCommandArguments {
+    return transformZMPopArguments(['ZMPOP'], keys, options);
+}
+
+type ZMPopRawReply = null | [string, Array<[RedisCommandArgument, RedisCommandArgument]>];
+
+type ZMPopReply = null | [
+    key: string, 
+    elements: Array<ZMember>
+];
+
+export function transformReply(reply: ZMPopRawReply): ZMPopReply {
+    if (reply == null) return null;
+
+    return [reply[0], reply[1].map(transformSortedSetMemberReply)];
+}

--- a/packages/client/lib/commands/generic-transformers.ts
+++ b/packages/client/lib/commands/generic-transformers.ts
@@ -131,6 +131,13 @@ export function transformSortedSetMemberNullReply(
 ): ZMember | null {
     if (!reply.length) return null;
 
+    return transformSortedSetMemberReply(reply);
+}
+
+export function transformSortedSetMemberReply(
+    reply: [RedisCommandArgument, RedisCommandArgument]
+): ZMember {
+
     return {
         value: reply[0],
         score: transformNumberInfinityReply(reply[1])
@@ -148,6 +155,49 @@ export function transformSortedSetWithScoresReply(reply: Array<RedisCommandArgum
     }
 
     return members;
+}
+
+
+export interface ZMPopOptions {
+    SCORE: 'MIN' | 'MAX';
+    COUNT?: number;
+}
+
+export function transformZMPopArguments(
+    args: RedisCommandArguments,
+    keys: string | Array<string>,
+    options: ZMPopOptions
+): RedisCommandArguments {
+    pushVerdictArgument(args, keys);
+
+    args.push(options.SCORE);
+
+    if (options?.COUNT) {
+        args.push('COUNT', options.COUNT.toString());
+    }
+
+    return args;
+}
+
+export interface LMPopOptions {
+    SIDE: 'LEFT' | 'RIGHT';
+    COUNT?: number;
+}
+
+export function transformLMPopArguments(
+    args: RedisCommandArguments,
+    keys: string | Array<string>,
+    options: LMPopOptions
+): RedisCommandArguments {
+    pushVerdictArgument(args, keys);
+
+    args.push(options.SIDE);
+
+    if (options?.COUNT) {
+        args.push('COUNT', options.COUNT.toString());
+    }
+
+    return args;
 }
 
 type GeoCountArgument = number | {

--- a/packages/client/lib/commands/generic-transformers.ts
+++ b/packages/client/lib/commands/generic-transformers.ts
@@ -157,20 +157,21 @@ export function transformSortedSetWithScoresReply(reply: Array<RedisCommandArgum
     return members;
 }
 
+export type SortedSetSide = 'MIN' | 'MAX';
 
 export interface ZMPopOptions {
-    SCORE: 'MIN' | 'MAX';
     COUNT?: number;
 }
 
 export function transformZMPopArguments(
     args: RedisCommandArguments,
-    keys: string | Array<string>,
-    options: ZMPopOptions
+    keys: RedisCommandArgument | Array<RedisCommandArgument>,
+    side: SortedSetSide,
+    options?: ZMPopOptions
 ): RedisCommandArguments {
     pushVerdictArgument(args, keys);
 
-    args.push(options.SCORE);
+    args.push(side);
 
     if (options?.COUNT) {
         args.push('COUNT', options.COUNT.toString());
@@ -179,19 +180,21 @@ export function transformZMPopArguments(
     return args;
 }
 
+export type ListSide = 'LEFT' | 'RIGHT';
+
 export interface LMPopOptions {
-    SIDE: 'LEFT' | 'RIGHT';
     COUNT?: number;
 }
 
 export function transformLMPopArguments(
     args: RedisCommandArguments,
-    keys: string | Array<string>,
-    options: LMPopOptions
+    keys: RedisCommandArgument | Array<RedisCommandArgument>,
+    side: ListSide,
+    options?: LMPopOptions
 ): RedisCommandArguments {
     pushVerdictArgument(args, keys);
 
-    args.push(options.SIDE);
+    args.push(side);
 
     if (options?.COUNT) {
         args.push('COUNT', options.COUNT.toString());


### PR DESCRIPTION
### Description

List of new commands:
1. [BLMPOP](https://redis.io/commands/blmpop)
2. [LMPOP](https://redis.io/commands/lmpop)
3. [BZMPOP](https://redis.io/commands/bzmpop)
4. [ZMPOP](https://redis.io/commands/zmpop)

closes #1909, closes #1908, closes #1960 , closes #1978 

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
