### PR TITLE
client/RedisSocket: handle *all* error emits

### DIFF
--- a/packages/client/lib/client/socket.ts
+++ b/packages/client/lib/client/socket.ts
@@ -176,7 +176,7 @@ export default class RedisSocket extends EventEmitter {
                     socket
                         .setTimeout(0)
                         .off('error', reject)
-                        .once('error', (err: Error) => this.#onSocketError(err))
+                        .on('error', (err: Error) => this.#onSocketError(err))
                         .once('close', hadError => {
                             if (!hadError && this.#isOpen && this.#socket === socket) {
                                 this.#onSocketError(new SocketClosedUnexpectedlyError());


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

Attempts to fix https://github.com/redis/node-redis/issues/1993

```
    NodeJS will throw a error event (from EventEmitter) if there's no handler.
    Handle the error at all times to prevent crashing the process.
```

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
