### PR TITLE
exported GeoReplyWith

### DIFF
--- a/packages/client/index.ts
+++ b/packages/client/index.ts
@@ -15,4 +15,6 @@ export const createCluster = RedisCluster.create;
 
 export { defineScript } from './lib/lua-script';
 
+export { GeoReplyWith } from './lib/commands/generic-transformers';
+
 export * from './lib/errors';


### PR DESCRIPTION
### Description

Added GeoReplyWith to exports so that JavaScript folks don't have to hard-code strings and TypeScript folks don't have to hardcode string *and* use any.