### PR TITLE
Update sorted set example to show ZRANGE with REV modifier

### DIFF
--- a/examples/sorted-set.js
+++ b/examples/sorted-set.js
@@ -1,5 +1,5 @@
 // Add several values with their scores to a Sorted Set,
-// then retrieve them all using ZSCAN.
+// then retrieve them all using ZSCAN, ZRANGE and ZREVRANGE.
 
 import { createClient } from 'redis';
 
@@ -25,9 +25,30 @@ async function addToSortedSet() {
   // Get all of the values/scores from the sorted set using
   // the scan approach:
   // https://redis.io/commands/zscan
+  console.log('Using ZCSCAN:');
   for await (const memberWithScore of client.zScanIterator('mysortedset')) {
     console.log(memberWithScore);
   }
+
+  // Get all of the values/scores from the sorted set using
+  // ZRANGE with WITHSCORES modifier, plus the REV modifier to
+  // return the largest score first.  The REV modifier was 
+  // introduced in Redis 6.2:
+  // https://redis.io/commands/zrange
+  console.log('');
+  console.log('Using ZRANGE with WITHSCORES and REV options (Redis >=6.2.x)');
+  console.log(
+    await client.zRangeWithScores('mysortedset', 0, -1, {
+      REV: true
+    })
+  );
+
+  // Get all of the values/scores from the sorted set using 
+  // ZREVRANGE, for versions of Redis prior to 6.2 (this is 
+  // considered deprecated from 6.2 onwards)
+  // https://redis.io/commands/zrevrange
+  console.log('');
+  console.log('TODO zRevRange appears to be missing?');
   
   await client.quit();
 }

--- a/examples/sorted-set.js
+++ b/examples/sorted-set.js
@@ -1,5 +1,5 @@
 // Add several values with their scores to a Sorted Set,
-// then retrieve them all using ZSCAN, ZRANGE and ZREVRANGE.
+// then retrieve them all using ZSCAN and ZRANGE.
 
 import { createClient } from 'redis';
 
@@ -7,6 +7,8 @@ async function addToSortedSet() {
   const client = createClient();
   await client.connect();
 
+  // Add to a sorted set, creating it if it doesn't already exist.
+  // https://redis.io/commands/zadd
   await client.zAdd('mysortedset', [
     {
       score: 99,
@@ -42,13 +44,6 @@ async function addToSortedSet() {
       REV: true
     })
   );
-
-  // Get all of the values/scores from the sorted set using 
-  // ZREVRANGE, for versions of Redis prior to 6.2 (this is 
-  // considered deprecated from 6.2 onwards)
-  // https://redis.io/commands/zrevrange
-  console.log('');
-  console.log('TODO zRevRange appears to be missing?');
   
   await client.quit();
 }


### PR DESCRIPTION
Updates the sorted set example to show use of the `REV` modifier to the `ZRANGE` command (Redis >= 6.2).  Closes #2100