### PR TITLE
Add zrevrange zrevrangewithscores

### DIFF
--- a/examples/sorted-set.js
+++ b/examples/sorted-set.js
@@ -28,11 +28,6 @@ async function addToSortedSet() {
   for await (const memberWithScore of client.zScanIterator('mysortedset')) {
     console.log(memberWithScore);
   }
-
-  console.log('ZREVRANGE:');
-  console.log(await client.zRevRange('mysortedset', 0, -1, {
-    BY: 'SCORE'
-  }));
   
   await client.quit();
 }

--- a/examples/sorted-set.js
+++ b/examples/sorted-set.js
@@ -28,6 +28,11 @@ async function addToSortedSet() {
   for await (const memberWithScore of client.zScanIterator('mysortedset')) {
     console.log(memberWithScore);
   }
+
+  console.log('ZREVRANGE:');
+  console.log(await client.zRevRange('mysortedset', 0, -1, {
+    BY: 'SCORE'
+  }));
   
   await client.quit();
 }

--- a/packages/client/lib/cluster/commands.ts
+++ b/packages/client/lib/cluster/commands.ts
@@ -189,6 +189,7 @@ import * as ZREM from '../commands/ZREM';
 import * as ZREMRANGEBYLEX from '../commands/ZREMRANGEBYLEX';
 import * as ZREMRANGEBYRANK from '../commands/ZREMRANGEBYRANK';
 import * as ZREMRANGEBYSCORE from '../commands/ZREMRANGEBYSCORE';
+import * as ZREVRANGE from '../commands/ZREVRANGE';
 import * as ZREVRANK from '../commands/ZREVRANK';
 import * as ZSCAN from '../commands/ZSCAN';
 import * as ZSCORE from '../commands/ZSCORE';
@@ -577,6 +578,8 @@ export default {
     zRemRangeByRank: ZREMRANGEBYRANK,
     ZREMRANGEBYSCORE,
     zRemRangeByScore: ZREMRANGEBYSCORE,
+    ZREVRANGE,
+    zRevRange: ZREVRANGE,
     ZREVRANK,
     zRevRank: ZREVRANK,
     ZSCAN,

--- a/packages/client/lib/cluster/commands.ts
+++ b/packages/client/lib/cluster/commands.ts
@@ -190,6 +190,7 @@ import * as ZREMRANGEBYLEX from '../commands/ZREMRANGEBYLEX';
 import * as ZREMRANGEBYRANK from '../commands/ZREMRANGEBYRANK';
 import * as ZREMRANGEBYSCORE from '../commands/ZREMRANGEBYSCORE';
 import * as ZREVRANGE from '../commands/ZREVRANGE';
+import * as ZREVRANGEWITHSCORES from '../commands/ZREVRANGE_WITHSCORES';
 import * as ZREVRANK from '../commands/ZREVRANK';
 import * as ZSCAN from '../commands/ZSCAN';
 import * as ZSCORE from '../commands/ZSCORE';
@@ -580,6 +581,8 @@ export default {
     zRemRangeByScore: ZREMRANGEBYSCORE,
     ZREVRANGE,
     zRevRange: ZREVRANGE,
+    ZREVRANGEWITHSCORES,
+    zRevRangeWithScores: ZREVRANGEWITHSCORES,
     ZREVRANK,
     zRevRank: ZREVRANK,
     ZSCAN,

--- a/packages/client/lib/commands/ZREVRANGE.spec.ts
+++ b/packages/client/lib/commands/ZREVRANGE.spec.ts
@@ -1,0 +1,21 @@
+import { strict as assert } from 'assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './ZREVRANGE';
+
+describe('ZREVRANGE', () => {
+    describe('transformArguments', () => {
+        it('simple', () => {
+            assert.deepEqual(
+                transformArguments('src', 0, 1),
+                ['ZREVRANGE', 'src', '0', '1']
+            );
+        });
+    });
+
+    testUtils.testWithClient('client.zRevRange', async client => {
+        assert.deepEqual(
+            await client.zRevRange('src', 0, 1),
+            []
+        );
+    }, GLOBAL.SERVERS.OPEN);
+});

--- a/packages/client/lib/commands/ZREVRANGE.ts
+++ b/packages/client/lib/commands/ZREVRANGE.ts
@@ -1,0 +1,23 @@
+import { RedisCommandArgument, RedisCommandArguments } from '.';
+import { transformStringNumberInfinityArgument } from './generic-transformers';
+
+export const FIRST_KEY_INDEX = 1;
+
+export const IS_READ_ONLY = true;
+
+export function transformArguments(
+    key: RedisCommandArgument,
+    min: RedisCommandArgument | number,
+    max: RedisCommandArgument | number
+): RedisCommandArguments {
+    const args = [
+        'ZREVRANGE',
+        key,
+        transformStringNumberInfinityArgument(min),
+        transformStringNumberInfinityArgument(max)
+    ];
+
+    return args;
+}
+
+export declare function transformReply(): Array<RedisCommandArgument>;

--- a/packages/client/lib/commands/ZREVRANGE_WITHSCORES.spec.ts
+++ b/packages/client/lib/commands/ZREVRANGE_WITHSCORES.spec.ts
@@ -1,0 +1,21 @@
+import { strict as assert } from 'assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './ZREVRANGE_WITHSCORES';
+
+describe('ZREVRANGE WITHSCORES', () => {
+    describe('transformArguments', () => {
+        it('simple', () => {
+            assert.deepEqual(
+                transformArguments('src', 0, 1),
+                ['ZREVRANGE', 'src', '0', '1', 'WITHSCORES']
+            );
+        });
+    });
+
+    testUtils.testWithClient('client.zRevRangeWithScores', async client => {
+        assert.deepEqual(
+            await client.zRevRangeWithScores('src', 0, 1),
+            []
+        );
+    }, GLOBAL.SERVERS.OPEN);
+});

--- a/packages/client/lib/commands/ZREVRANGE_WITHSCORES.ts
+++ b/packages/client/lib/commands/ZREVRANGE_WITHSCORES.ts
@@ -1,0 +1,24 @@
+import { RedisCommandArgument, RedisCommandArguments } from '.';
+import { transformStringNumberInfinityArgument } from './generic-transformers';
+
+export const FIRST_KEY_INDEX = 1;
+
+export const IS_READ_ONLY = true;
+
+export function transformArguments(
+    key: RedisCommandArgument,
+    min: RedisCommandArgument | number,
+    max: RedisCommandArgument | number
+): RedisCommandArguments {
+    const args = [
+        'ZREVRANGE',
+        key,
+        transformStringNumberInfinityArgument(min),
+        transformStringNumberInfinityArgument(max),
+        'WITHSCORES'
+    ];
+
+    return args;
+}
+
+export { transformSortedSetWithScoresReply as transformReply } from './generic-transformers';


### PR DESCRIPTION
Adds `ZREVRANGE` and `ZREVRANGEWITHSCORES` commands:

```javascript
const client = createClient();
await client.connect();

await client.zAdd('mysortedset', [
  {
    score: 99,
    value: 'Ninety Nine'
  },
  {
    score: 100,
    value: 'One Hundred'
  },
  {
    score: 101,
    value: 'One Hundred and One'
  }
]);

console.log('ZREVRANGE:');
console.log(await client.zRevRange('mysortedset', 0, -1));
  
console.log('ZREVRANGE WITHSCORES:');
console.log(await client.zRevRangeWithScores('mysortedset', 0, -1));
  
await client.quit();
```

output:

```
ZREVRANGE:
[ 'One Hundred and One', 'One Hundred', 'Ninety Nine' ]
ZREVRANGE WITHSCORES:
[
  { value: 'One Hundred and One', score: 101 },
  { value: 'One Hundred', score: 100 },
  { value: 'Ninety Nine', score: 99 }
]
```

Closes #2107 Closes #2173