### PR TITLE
set scanIterator starting cursor from options

### DIFF
--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -621,7 +621,7 @@ export default class RedisClient<
     }
 
     async* scanIterator(options?: ScanCommandOptions): AsyncIterable<string> {
-        let cursor = 0;
+        let cursor = (options && options.CURSOR) || 0;
         do {
             const reply = await (this as any).scan(cursor, options);
             cursor = reply.cursor;
@@ -632,7 +632,7 @@ export default class RedisClient<
     }
 
     async* hScanIterator(key: string, options?: ScanOptions): AsyncIterable<ConvertArgumentType<HScanTuple, string>> {
-        let cursor = 0;
+        let cursor = (options && options.CURSOR) || 0;
         do {
             const reply = await (this as any).hScan(key, cursor, options);
             cursor = reply.cursor;
@@ -643,7 +643,7 @@ export default class RedisClient<
     }
 
     async* sScanIterator(key: string, options?: ScanOptions): AsyncIterable<string> {
-        let cursor = 0;
+        let cursor = (options && options.CURSOR) || 0;
         do {
             const reply = await (this as any).sScan(key, cursor, options);
             cursor = reply.cursor;
@@ -654,7 +654,7 @@ export default class RedisClient<
     }
 
     async* zScanIterator(key: string, options?: ScanOptions): AsyncIterable<ConvertArgumentType<ZMember, string>> {
-        let cursor = 0;
+        let cursor = (options && options.CURSOR) || 0;
         do {
             const reply = await (this as any).zScan(key, cursor, options);
             cursor = reply.cursor;


### PR DESCRIPTION
Before this commit, the cursor was always 0. So we need to always iterate from the 0 cursor on all keys!

before:
`let cursor = 0;`
now:
`let cursor = (options && options.CURSOR) || 0;`