### PR TITLE
Fix issue with buffers in objects using hSet

### DIFF
--- a/packages/client/lib/commands/HSET.spec.ts
+++ b/packages/client/lib/commands/HSET.spec.ts
@@ -41,11 +41,20 @@ describe('HSET', () => {
             );
         });
 
-        it('Object', () => {
-            assert.deepEqual(
-                transformArguments('key', { field: 'value' }),
-                ['HSET', 'key', 'field', 'value']
-            );
+        describe('Object', () => {
+            it('string', () => {
+                assert.deepEqual(
+                    transformArguments('key', { field: 'value' }),
+                    ['HSET', 'key', 'field', 'value']
+                );
+            });
+            
+            it('Buffer', () => {
+                assert.deepEqual(
+                    transformArguments('key', { field: Buffer.from('value') }),
+                    ['HSET', 'key', 'field', Buffer.from('value')]
+                );
+            });
         });
     });
 

--- a/packages/client/lib/commands/HSET.ts
+++ b/packages/client/lib/commands/HSET.ts
@@ -53,7 +53,13 @@ function pushTuples(args: RedisCommandArguments, tuples: HSETTuples): void {
 
 function pushObject(args: RedisCommandArguments, object: HSETObject): void {
     for (const key of Object.keys(object)) {
-        args.push(key.toString(), object[key].toString());
+        const value = object[key];
+        args.push(
+            key.toString(),
+            Buffer.isBuffer(value) ?
+                value :
+                value.toString()
+        );
     }
 }
 

--- a/packages/client/lib/commands/HSET.ts
+++ b/packages/client/lib/commands/HSET.ts
@@ -20,8 +20,10 @@ export function transformArguments(...[ key, value, fieldValue ]: SingleFieldArg
     const args: RedisCommandArguments = ['HSET', key];
 
     if (typeof value === 'string' || typeof value === 'number' || Buffer.isBuffer(value)) {
-        pushValue(args, value);
-        pushValue(args, fieldValue!);
+        args.push(
+            convertValue(value),
+            convertValue(fieldValue!)
+        );
     } else if (value instanceof Map) {
         pushMap(args, value);
     } else if (Array.isArray(value)) {
@@ -35,8 +37,10 @@ export function transformArguments(...[ key, value, fieldValue ]: SingleFieldArg
 
 function pushMap(args: RedisCommandArguments, map: HSETMap): void {
     for (const [key, value] of map.entries()) {
-        pushValue(args, key);
-        pushValue(args, value);
+        args.push(
+            convertValue(key),
+            convertValue(value)
+        );
     }
 }
 
@@ -47,28 +51,23 @@ function pushTuples(args: RedisCommandArguments, tuples: HSETTuples): void {
             continue;
         }
 
-        pushValue(args, tuple);
+        args.push(convertValue(tuple));
     }
 }
 
 function pushObject(args: RedisCommandArguments, object: HSETObject): void {
     for (const key of Object.keys(object)) {
-        const value = object[key];
         args.push(
-            key.toString(),
-            Buffer.isBuffer(value) ?
-                value :
-                value.toString()
+            convertValue(key),
+            convertValue(object[key])
         );
     }
 }
 
-function pushValue(args: RedisCommandArguments, value: Types): void {
-    args.push(
-        typeof value === 'number' ?
-            value.toString() :
-            value
-    );
+function convertValue(value: Types): RedisCommandArgument {
+    return typeof value === 'number' ?
+        value.toString() :
+        value;
 }
 
 export declare function transformReply(): number;


### PR DESCRIPTION

### Description

When using hSet with an object, any buffer values inside the object are converted to strings instead of left as buffers.

This fix specifically handles the special case of buffers, whilst casting everything else strings (to continue "gracefully" handling the case where the value not a valid type).

This is technically a breaking change, but it's unlikely that anyone is relying on the existing broken behaviour - which is that buffers come back out (using hGetAll) mangled. Eg:

```
> b
<Buffer 01 02 81 82 f1>
> r.hSet('temp', {b})
> r.hGetAll(redis.commandOptions({returnBuffers: true}), 'temp').then(console.log)
> [Object: null prototype] {
  b: <Buffer 01 02 ef bf bd ef bf bd ef bf bd>
}
```

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
