### PR TITLE
fix: loop over arguments instead of spreading

### DIFF
--- a/packages/bloom/lib/commands/bloom/INSERT.ts
+++ b/packages/bloom/lib/commands/bloom/INSERT.ts
@@ -1,4 +1,5 @@
 import { pushVerdictArguments } from '@redis/client/dist/lib/commands/generic-transformers';
+import { RedisCommandArgument, RedisCommandArguments } from '@redis/client/dist/lib/commands';
 
 export const FIRST_KEY_INDEX = 1;
 
@@ -12,9 +13,9 @@ interface InsertOptions {
 
 export function transformArguments(
     key: string,
-    items: string | Array<string>,
+    items: RedisCommandArgument | Array<RedisCommandArguments>,
     options?: InsertOptions
-): Array<string> {
+): RedisCommandArguments {
     const args = ['BF.INSERT', key];
 
     if (options?.CAPACITY) {

--- a/packages/bloom/lib/commands/bloom/INSERT.ts
+++ b/packages/bloom/lib/commands/bloom/INSERT.ts
@@ -13,7 +13,7 @@ interface InsertOptions {
 
 export function transformArguments(
     key: string,
-    items: RedisCommandArgument | Array<RedisCommandArguments>,
+    items: RedisCommandArgument | Array<RedisCommandArgument>,
     options?: InsertOptions
 ): RedisCommandArguments {
     const args = ['BF.INSERT', key];

--- a/packages/bloom/lib/commands/bloom/INSERT.ts
+++ b/packages/bloom/lib/commands/bloom/INSERT.ts
@@ -38,9 +38,7 @@ export function transformArguments(
     }
 
     args.push('ITEMS');
-    pushVerdictArguments(args, items);
-
-    return args;
+    return pushVerdictArguments(args, items);
 }
 
 export { transformBooleanArrayReply as transformReply } from '@redis/client/dist/lib/commands/generic-transformers';

--- a/packages/client/lib/commands/PUBSUB_NUMSUB.ts
+++ b/packages/client/lib/commands/PUBSUB_NUMSUB.ts
@@ -5,9 +5,7 @@ export const IS_READ_ONLY = true;
 export function transformArguments(channels?: Array<string> | string): Array<string> {
     const args = ['PUBSUB', 'NUMSUB'];
 
-    if (channels) {
-        pushVerdictArguments(args, channels);
-    }
+    if (channels) return pushVerdictArguments(args, channels);
 
     return args;
 }

--- a/packages/client/lib/commands/PUBSUB_NUMSUB.ts
+++ b/packages/client/lib/commands/PUBSUB_NUMSUB.ts
@@ -1,8 +1,11 @@
 import { pushVerdictArguments } from './generic-transformers';
+import { RedisCommandArgument, RedisCommandArguments } from '.';
 
 export const IS_READ_ONLY = true;
 
-export function transformArguments(channels?: Array<string> | string): Array<string> {
+export function transformArguments(
+    channels?: Array<RedisCommandArgument> | RedisCommandArgument
+): RedisCommandArguments {
     const args = ['PUBSUB', 'NUMSUB'];
 
     if (channels) return pushVerdictArguments(args, channels);

--- a/packages/client/lib/commands/XCLAIM.ts
+++ b/packages/client/lib/commands/XCLAIM.ts
@@ -18,9 +18,10 @@ export function transformArguments(
     id: RedisCommandArgument | Array<RedisCommandArgument>,
     options?: XClaimOptions
 ): RedisCommandArguments {
-    const args = ['XCLAIM', key, group, consumer, minIdleTime.toString()];
-
-    pushVerdictArguments(args, id);
+    const args =  pushVerdictArguments(
+        ['XCLAIM', key, group, consumer, minIdleTime.toString()],
+        id
+    );
 
     if (options?.IDLE) {
         args.push('IDLE', options.IDLE.toString());

--- a/packages/client/lib/commands/generic-transformers.spec.ts
+++ b/packages/client/lib/commands/generic-transformers.spec.ts
@@ -578,19 +578,6 @@ describe('Generic Transformers', () => {
                 ['1', '2']
             );
         });
-
-        it('handles large arrays', () => {
-            const arr: string[] = [];
-            for(let i = 0; i < 200_000; i++) {
-                arr.push(i.toString());
-            }
-            assert.deepEqual(
-                pushVerdictArguments([], arr),
-                arr
-            );
-        });
-
-
     });
 
     describe('pushVerdictNumberArguments', () => {

--- a/packages/client/lib/commands/generic-transformers.spec.ts
+++ b/packages/client/lib/commands/generic-transformers.spec.ts
@@ -578,6 +578,19 @@ describe('Generic Transformers', () => {
                 ['1', '2']
             );
         });
+
+        it('handles large arrays', () => {
+            const arr: string[] = [];
+            for(let i = 0; i < 200_000; i++) {
+                arr.push(i.toString());
+            }
+            assert.deepEqual(
+                pushVerdictArguments([], arr),
+                arr
+            );
+        });
+
+
     });
 
     describe('pushVerdictNumberArguments', () => {

--- a/packages/client/lib/commands/generic-transformers.ts
+++ b/packages/client/lib/commands/generic-transformers.ts
@@ -428,9 +428,7 @@ export function pushEvalArguments(args: Array<string>, options?: EvalOptions): A
 
 export function pushVerdictArguments(args: RedisCommandArguments, value: RedisCommandArgument | Array<RedisCommandArgument>): RedisCommandArguments  {
     if (Array.isArray(value)) {
-        for(const item of value) {
-            args.push(item);
-        }
+       args = args.concat(value);
     } else {
         args.push(value);
     }

--- a/packages/client/lib/commands/generic-transformers.ts
+++ b/packages/client/lib/commands/generic-transformers.ts
@@ -428,7 +428,8 @@ export function pushEvalArguments(args: Array<string>, options?: EvalOptions): A
 
 export function pushVerdictArguments(args: RedisCommandArguments, value: RedisCommandArgument | Array<RedisCommandArgument>): RedisCommandArguments  {
     if (Array.isArray(value)) {
-       args = args.concat(value);
+        // https://github.com/redis/node-redis/pull/2160
+        args = args.concat(value);
     } else {
         args.push(value);
     }

--- a/packages/client/lib/commands/generic-transformers.ts
+++ b/packages/client/lib/commands/generic-transformers.ts
@@ -428,7 +428,9 @@ export function pushEvalArguments(args: Array<string>, options?: EvalOptions): A
 
 export function pushVerdictArguments(args: RedisCommandArguments, value: RedisCommandArgument | Array<RedisCommandArgument>): RedisCommandArguments  {
     if (Array.isArray(value)) {
-        args.push(...value);
+        for(const item of value) {
+            args.push(item);
+        }
     } else {
         args.push(value);
     }

--- a/packages/json/lib/commands/GET.ts
+++ b/packages/json/lib/commands/GET.ts
@@ -14,7 +14,7 @@ interface GetOptions {
 }
 
 export function transformArguments(key: string, options?: GetOptions): RedisCommandArguments {
-    let args = ['JSON.GET', key];
+    let args: RedisCommandArguments = ['JSON.GET', key];
 
     if (options?.path) {
         args = pushVerdictArguments(args, options.path);

--- a/packages/json/lib/commands/GET.ts
+++ b/packages/json/lib/commands/GET.ts
@@ -1,4 +1,5 @@
 import { pushVerdictArguments } from '@redis/client/dist/lib/commands/generic-transformers';
+import { RedisCommandArguments } from '@redis/client/dist/lib/commands';
 
 export const FIRST_KEY_INDEX = 1;
 
@@ -12,7 +13,7 @@ interface GetOptions {
     NOESCAPE?: true;
 }
 
-export function transformArguments(key: string, options?: GetOptions): Array<string> {
+export function transformArguments(key: string, options?: GetOptions): RedisCommandArguments {
     let args = ['JSON.GET', key];
 
     if (options?.path) {

--- a/packages/json/lib/commands/GET.ts
+++ b/packages/json/lib/commands/GET.ts
@@ -13,10 +13,10 @@ interface GetOptions {
 }
 
 export function transformArguments(key: string, options?: GetOptions): Array<string> {
-    const args = ['JSON.GET', key];
+    let args = ['JSON.GET', key];
 
     if (options?.path) {
-        pushVerdictArguments(args, options.path);
+        args = pushVerdictArguments(args, options.path);
     }
 
     if (options?.INDENT) {

--- a/packages/time-series/lib/commands/MGET_WITHLABELS.ts
+++ b/packages/time-series/lib/commands/MGET_WITHLABELS.ts
@@ -19,13 +19,8 @@ export function transformArguments(
     filter: Filter,
     options?: MGetWithLabelsOptions
 ): Array<string> {
-    const args = ['TS.MGET'];
-
-    pushWithLabelsArgument(args, options?.SELECTED_LABELS);
-
-    pushFilterArgument(args, filter);
-
-    return args;
+    const args = pushWithLabelsArgument(['TS.MGET'], options?.SELECTED_LABELS);
+    return pushFilterArgument(args, filter);
 }
 
 export interface MGetWithLabelsReply extends MGetReply {

--- a/packages/time-series/lib/commands/MGET_WITHLABELS.ts
+++ b/packages/time-series/lib/commands/MGET_WITHLABELS.ts
@@ -8,6 +8,7 @@ import {
     pushFilterArgument
 } from '.';
 import { MGetRawReply, MGetReply } from './MGET';
+import { RedisCommandArguments } from '@redis/client/dist/lib/commands';
 
 export const IS_READ_ONLY = true;
 
@@ -18,7 +19,7 @@ interface MGetWithLabelsOptions {
 export function transformArguments(
     filter: Filter,
     options?: MGetWithLabelsOptions
-): Array<string> {
+): RedisCommandArguments {
     const args = pushWithLabelsArgument(['TS.MGET'], options?.SELECTED_LABELS);
     return pushFilterArgument(args, filter);
 }

--- a/packages/time-series/lib/commands/index.ts
+++ b/packages/time-series/lib/commands/index.ts
@@ -313,8 +313,7 @@ export type Filter = string | Array<string>;
 
 export function pushFilterArgument(args: RedisCommandArguments, filter: string | Array<string>): RedisCommandArguments {
     args.push('FILTER');
-    pushVerdictArguments(args, filter);
-    return args;
+    return pushVerdictArguments(args, filter);
 }
 
 export interface MRangeOptions extends RangeOptions {
@@ -328,10 +327,9 @@ export function pushMRangeArguments(
     filter: Filter,
     options?: MRangeOptions
 ): RedisCommandArguments {
-    pushRangeArguments(args, fromTimestamp, toTimestamp, options);
-    pushFilterArgument(args, filter);
-    pushMRangeGroupByArguments(args, options?.GROUPBY);
-    return args;
+    args = pushRangeArguments(args, fromTimestamp, toTimestamp, options);
+    args = pushFilterArgument(args, filter);
+    return pushMRangeGroupByArguments(args, options?.GROUPBY);
 }
 
 export type SelectedLabels = string | Array<string>;
@@ -341,7 +339,7 @@ export function pushWithLabelsArgument(args: RedisCommandArguments, selectedLabe
         args.push('WITHLABELS');
     } else {
         args.push('SELECTED_LABELS');
-        pushVerdictArguments(args, selectedLabels);
+        args = pushVerdictArguments(args, selectedLabels);
     }
 
     return args;
@@ -358,11 +356,10 @@ export function pushMRangeWithLabelsArguments(
     filter: Filter,
     options?: MRangeWithLabelsOptions
 ): RedisCommandArguments {
-    pushRangeArguments(args, fromTimestamp, toTimestamp, options);
-    pushWithLabelsArgument(args, options?.SELECTED_LABELS);
-    pushFilterArgument(args, filter);
-    pushMRangeGroupByArguments(args, options?.GROUPBY);
-    return args;
+    args = pushRangeArguments(args, fromTimestamp, toTimestamp, options);
+    args = pushWithLabelsArgument(args, options?.SELECTED_LABELS);
+    args = pushFilterArgument(args, filter);
+    return pushMRangeGroupByArguments(args, options?.GROUPBY);
 }
 
 export function transformRangeReply(reply: Array<SampleRawReply>): Array<SampleReply> {


### PR DESCRIPTION

### Description
Pushing a large number of arguments (100ks) to a command causes a `RangeError: Maximum call stack size exceeded`. 

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

This is caused by using the spread operator since javascript can't hold all the values in memory. This updates to loop over the passed in array and add the values in a loop instead of using spread. 


```
/app/node_modules/@node-redis/client/dist/lib/commands/generic-transformers.js:198
        args.push(...value);
             ^
RangeError: Maximum call stack size exceeded
   at pushVerdictArguments (/app/node_modules/@node-redis/client/dist/lib/commands/generic-transformers.js:198:14)
   at Object.transformArguments (/app/node_modules/@node-redis/client/dist/lib/commands/SREM.js:7:60)
   at transformCommandArguments (/app/node_modules/@node-redis/client/dist/lib/commander.js:62:23)
   at Commander.commandsExecutor (/app/node_modules/@node-redis/client/dist/lib/client/index.js:165:88)
   at Commander.BaseClass.<computed> [as sRem] (/app/node_modules/@node-redis/client/dist/lib/commander.js:8:29)
   at RedisService.removeKeysFromSetByPattern (/app/src/common/services/redis/redis.service.ts:232:23)
   at processTicksAndRejections (node:internal/process/task_queues:96:5)
```
---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
