### PR TITLE
Added `alignTimestamp` in createRule

### DIFF
--- a/packages/time-series/lib/commands/CREATERULE.spec.ts
+++ b/packages/time-series/lib/commands/CREATERULE.spec.ts
@@ -6,8 +6,8 @@ import { transformArguments } from './CREATERULE';
 describe('CREATERULE', () => {
     it('transformArguments', () => {
         assert.deepEqual(
-            transformArguments('source', 'destination', TimeSeriesAggregationType.AVERAGE, 1),
-            ['TS.CREATERULE', 'source', 'destination', 'AGGREGATION', 'avg', '1']
+            transformArguments('source', 'destination', TimeSeriesAggregationType.AVERAGE, 1, 0),
+            ['TS.CREATERULE', 'source', 'destination', 'AGGREGATION', 'avg', '1', '0']
         );
     });
 
@@ -18,7 +18,7 @@ describe('CREATERULE', () => {
         ]);
 
         assert.equal(
-            await client.ts.createRule('source', 'destination', TimeSeriesAggregationType.AVERAGE, 1),
+            await client.ts.createRule('source', 'destination', TimeSeriesAggregationType.AVERAGE, 1, 0),
             'OK'
         );
     }, GLOBAL.SERVERS.OPEN);

--- a/packages/time-series/lib/commands/CREATERULE.ts
+++ b/packages/time-series/lib/commands/CREATERULE.ts
@@ -6,7 +6,8 @@ export function transformArguments(
     sourceKey: string,
     destinationKey: string,
     aggregationType: TimeSeriesAggregationType,
-    timeBucket: number
+    timeBucket: number,
+    alignTimestamp: number
 ): Array<string> {
     return [
         'TS.CREATERULE',
@@ -14,7 +15,8 @@ export function transformArguments(
         destinationKey,
         'AGGREGATION',
         aggregationType,
-        timeBucket.toString()
+        timeBucket.toString(),
+        alignTimestamp.toString()
     ];
 }
 


### PR DESCRIPTION
### Description

`createRule` in redis timeseries package was missing `alignTimestamp` as per the docs. Reference: https://redis.io/commands/ts.createrule/

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
