### PR TITLE
fixed MIGRATE function when key is array

### DIFF
--- a/packages/client/lib/commands/MIGRATE.spec.ts
+++ b/packages/client/lib/commands/MIGRATE.spec.ts
@@ -13,7 +13,7 @@ describe('MIGRATE', () => {
         it('multiple keys', () => {
             assert.deepEqual(
                 transformArguments('127.0.0.1', 6379, ['1', '2'], 0, 10),
-                ['MIGRATE', '127.0.0.1', '6379', '""', '0', '10', 'KEYS', '1', '2']
+                ['MIGRATE', '127.0.0.1', '6379', '', '0', '10', 'KEYS', '1', '2']
             );
         });
 

--- a/packages/client/lib/commands/MIGRATE.ts
+++ b/packages/client/lib/commands/MIGRATE.ts
@@ -19,7 +19,7 @@ export function transformArguments(
         isKeyArray = Array.isArray(key);
 
     if (isKeyArray) {
-        args.push('""');
+        args.push('');
     } else {
         args.push(key);
     }


### PR DESCRIPTION
### Description

Fix for https://github.com/redis/node-redis/issues/2163

cc: @leibale 

---

### Checklist

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
