### PR TITLE
Add WITHSCORES option to ZRANGE command

### DIFF
--- a/packages/client/lib/commands/ZRANGE.spec.ts
+++ b/packages/client/lib/commands/ZRANGE.spec.ts
@@ -63,6 +63,30 @@ describe('ZRANGE', () => {
                 ['ZRANGE', 'src', '0', '1', 'BYSCORE', 'REV', 'LIMIT', '0', '1']
             );
         });
+
+        it('with WITHSCORES', () => {
+            assert.deepEqual(
+                transformArguments('src', 0, 1, {
+                    WITHSCORES: true
+                }),
+                ['ZRANGE', 'src', '0', '1', 'WITHSCORES']
+            );
+        });
+
+        it('with BY & REV & LIMIT & WITHSCORES', () => {
+            assert.deepEqual(
+                transformArguments('src', 0, 1, {
+                    BY: 'SCORE',
+                    REV: true,
+                    LIMIT: {
+                        offset: 0,
+                        count: 1
+                    },
+                    WITHSCORES: true
+                }),
+                ['ZRANGE', 'src', '0', '1', 'BYSCORE', 'REV', 'LIMIT', '0', '1', 'WITHSCORES']
+            );
+        });
     });
 
     testUtils.testWithClient('client.zRange', async client => {

--- a/packages/client/lib/commands/ZRANGE.ts
+++ b/packages/client/lib/commands/ZRANGE.ts
@@ -12,6 +12,7 @@ interface ZRangeOptions {
         offset: number;
         count: number;
     };
+    WITHSCORES?: true;
 }
 
 export function transformArguments(
@@ -43,6 +44,10 @@ export function transformArguments(
 
     if (options?.LIMIT) {
         args.push('LIMIT', options.LIMIT.offset.toString(), options.LIMIT.count.toString());
+    }
+
+    if (options?.WITHSCORES) {
+        args.push('WITHSCORES');
     }
 
     return args;


### PR DESCRIPTION
### Description

<img width="641" alt="Screen Shot 2022-09-07 at 13 56 04" src="https://user-images.githubusercontent.com/16532326/188791931-25c0978f-fa2d-4b17-a8e2-9083ce6fcefd.png">

> The `ZRANGE` command has `WITHSCORES` option. 
> 
> But, current node-redis package doesn't support `WITHSCORES` option
>
> So, i added.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
