### PR TITLE
Fix CLUSTER_NODES ipv6 address parsing

### DIFF
--- a/packages/client/lib/commands/CLUSTER_NODES.spec.ts
+++ b/packages/client/lib/commands/CLUSTER_NODES.spec.ts
@@ -73,6 +73,31 @@ describe('CLUSTER NODES', () => {
             );
         });
 
+        it('should support ipv6 addresses', () => {
+            assert.deepEqual(
+                transformReply(
+                    'id 2a02:6b8:c21:330d:0:1589:ebbe:b1a0:6379@16379 master - 0 0 0 connected 0-549\n'
+                ),
+                [{
+                    id: 'id',
+                    address: '2a02:6b8:c21:330d:0:1589:ebbe:b1a0:6379@16379',
+                    host: '2a02:6b8:c21:330d:0:1589:ebbe:b1a0',
+                    port: 6379,
+                    cport: 16379,
+                    flags: ['master'],
+                    pingSent: 0,
+                    pongRecv: 0,
+                    configEpoch: 0,
+                    linkState: RedisClusterNodeLinkStates.CONNECTED,
+                    slots: [{
+                        from: 0,
+                        to: 549
+                    }],
+                    replicas: []
+                }]
+            );
+        });
+
         it.skip('with importing slots', () => {
             assert.deepEqual(
                 transformReply(

--- a/packages/client/lib/commands/CLUSTER_NODES.ts
+++ b/packages/client/lib/commands/CLUSTER_NODES.ts
@@ -85,7 +85,7 @@ export function transformReply(reply: string): Array<RedisClusterMasterNode> {
 }
 
 function transformNodeAddress(address: string): RedisClusterNodeAddress {
-    const indexOfColon = address.indexOf(':'),
+    const indexOfColon = address.lastIndexOf(':'),
         indexOfAt = address.indexOf('@', indexOfColon),
         host = address.substring(0, indexOfColon);
 


### PR DESCRIPTION
### Description

Hi, I have found a bug with parsing ipv6 addresses from command CLUSTER NODES. This occurs because ipv6 address contains lots `:` symbols (2a02:6b8:c21:330d:0:1589:ebbe:b1a0:6379) so method `indexOf` parse just **first part** of ipv6 address, also afterward it produces **null** in port definition, finally socket can't be created and it **throws an error:**
```
(node:82513) UnhandledPromiseRejectionWarning: RangeError [ERR_SOCKET_BAD_PORT]: Port should be >= 0 and < 65536. Received NaN.
    at new NodeError (internal/errors.js:322:7)
    at validatePort (internal/validators.js:216:11)
    at lookupAndConnect (net.js:1013:5)
    at Socket.connect (net.js:989:5)
    at Object.connect (net.js:201:17)
    at RedisSocket._RedisSocket_createNetSocket (/Users/romanpoleguev/Dev/arcadia/classifieds/realty-frontend/node_modules/@redis/client/dist/lib/client/socket.js:196:21)
    at /Users/romanpoleguev/Dev/arcadia/classifieds/realty-frontend/node_modules/@redis/client/dist/lib/client/socket.js:163:101
    at new Promise (<anonymous>)
    at RedisSocket._RedisSocket_createSocket (/Users/romanpoleguev/Dev/arcadia/classifieds/realty-frontend/node_modules/@redis/client/dist/lib/client/socket.js:160:12)
    at RedisSocket._RedisSocket_connect (/Users/romanpoleguev/Dev/arcadia/classifieds/realty-frontend/node_modules/@redis/client/dist/lib/client/socket.js:134:150)
(Use `node --trace-warnings ...` to show where the warning was created)
(node:82513) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 3)
(node:82513) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

Before fix was made the line `'id 2a02:6b8:c21:330d:0:1589:ebbe:b1a0:6379@16379 master - 0 0 0 connected 0-549'` has beed parsed as

```json
{
  "id": "d1c81675fb0e70923207c250e558afce161dd1a9",
  "address": "2a02:6b8:c21:330d:0:1589:ebbe:b1a0:6379@16379",
  "host": "2a02",
  "port": null,
  "cport": 16379,
  "flags": [
    "master"
  ],
  "pingSent": 0,
  "pongRecv": 0,
  "configEpoch": 69,
  "linkState": "connected"
}
```

Now it works as intended.
Also test was written.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
