### PR TITLE
Reject multi.exec() promise with `ClientClosedError` after client disconnect

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -425,6 +425,19 @@ describe('Client', () => {
             );
         }, GLOBAL.SERVERS.OPEN);
 
+        testUtils.testWithClient('should reject the whole chain upon client disconnect', async client => {
+            await client.disconnect();
+
+            return assert.rejects(
+                client.multi()
+                    .ping()
+                    .set('key', 'value')
+                    .get('key')
+                    .exec(),
+                ClientClosedError
+            );
+        }, GLOBAL.SERVERS.OPEN);
+
         testUtils.testWithClient('with script', async client => {
             assert.deepEqual(
                 await client.multi()

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -611,6 +611,10 @@ export default class RedisClient<
         selectedDB?: number,
         chainId?: symbol
     ): Promise<Array<RedisCommandRawReply>> {
+        if (!this.#socket.isOpen) {
+            return Promise.reject(new ClientClosedError());
+        }
+
         const promise = Promise.all(
             commands.map(({ args }) => {
                 return this.#queue.addCommand(args, { chainId });


### PR DESCRIPTION
### Description

I want all of the Redis commands to inform me properly when the client has been disconnected. Currently, the promise returned by the multi.exec() command is not resolving after which execution hangs.

This pull requests makes sure the promise is rejected with a `ClientClosedError` exactly like `#sendCommand` is currently rejected as well when the client disconnects.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
