### PR TITLE
fix(client): Avoids infinite promise-chaining when socket's creation fails

### DIFF
--- a/packages/client/lib/client/socket.spec.ts
+++ b/packages/client/lib/client/socket.spec.ts
@@ -19,7 +19,7 @@ describe('Socket', () => {
 
     describe('reconnectStrategy', () => {
         it('custom strategy', async () => {
-            const numberOfRetries = 10
+            const numberOfRetries = 10;
 
             const reconnectStrategy = spy((retries: number) => {
                 assert.equal(retries + 1, reconnectStrategy.callCount);

--- a/packages/client/lib/client/socket.spec.ts
+++ b/packages/client/lib/client/socket.spec.ts
@@ -9,9 +9,8 @@ describe('Socket', () => {
             options
         );
 
-        socket.on('error', (err) => {
+        socket.on('error', () => {
             // ignore errors
-            console.log(err);
         });
 
         return socket;
@@ -32,8 +31,8 @@ describe('Socket', () => {
 
             const socket = createSocket({
                 host: 'error',
-                reconnectStrategy,
-                connectTimeout:100,
+                connectTimeout: 1,
+                reconnectStrategy
             });
 
             await assert.rejects(socket.connect(), {
@@ -46,7 +45,7 @@ describe('Socket', () => {
         it('should handle errors', async () => {
             const socket = createSocket({
                 host: 'error',
-                connectTimeout:100,
+                connectTimeout: 1,
                 reconnectStrategy(retries: number) {
                     if (retries === 1) return new Error('done');
                     throw new Error();

--- a/packages/client/lib/client/socket.ts
+++ b/packages/client/lib/client/socket.ts
@@ -109,7 +109,7 @@ export default class RedisSocket extends EventEmitter {
     }
 
     async #connect(hadError?: boolean): Promise<void> {
-        let retries = 0
+        let retries = 0;
         do {
             if (retries > 0 || hadError) {
                 this.emit('reconnecting');
@@ -141,8 +141,8 @@ export default class RedisSocket extends EventEmitter {
                 this.emit('error', err);
                 await promiseTimeout(retryIn);
             }
-            retries++
-        } while (!this.#isReady)
+            retries++;
+        } while (!this.#isReady);
     }
 
     #createSocket(): Promise<net.Socket | tls.TLSSocket> {

--- a/packages/client/lib/client/socket.ts
+++ b/packages/client/lib/client/socket.ts
@@ -105,46 +105,49 @@ export default class RedisSocket extends EventEmitter {
             throw new Error('Socket already opened');
         }
 
-        return this.#connect(0);
+        return this.#connect();
     }
 
-    async #connect(retries: number, hadError?: boolean): Promise<void> {
-        if (retries > 0 || hadError) {
-            this.emit('reconnecting');
-        }
-
-        try {
-            this.#isOpen = true;
-            this.#socket = await this.#createSocket();
-            this.#writableNeedDrain = false;
-            this.emit('connect');
+    async #connect(hadError?: boolean): Promise<void> {
+        let retries = 0
+        do {
+            if (retries > 0 || hadError) {
+                this.emit('reconnecting');
+            }
 
             try {
-                await this.#initiator();
-            } catch (err) {
-                this.#socket.destroy();
-                this.#socket = undefined;
-                throw err;
-            }
-            this.#isReady = true;
-            this.emit('ready');
-        } catch (err) {
-            const retryIn = this.reconnectStrategy(retries);
-            if (retryIn instanceof Error) {
-                this.#isOpen = false;
-                this.emit('error', err);
-                throw new ReconnectStrategyError(retryIn, err);
-            }
+                this.#isOpen = true;
+                this.#socket = await this.#createSocket();
+                this.#writableNeedDrain = false;
+                this.emit('connect');
 
-            this.emit('error', err);
-            await promiseTimeout(retryIn);
-            return this.#connect(retries + 1);
-        }
+                try {
+                    await this.#initiator();
+                } catch (err) {
+                    this.#socket.destroy();
+                    this.#socket = undefined;
+                    throw err;
+                }
+                this.#isReady = true;
+                this.emit('ready');
+            } catch (err) {
+                const retryIn = this.reconnectStrategy(retries);
+                if (retryIn instanceof Error) {
+                    this.#isOpen = false;
+                    this.emit('error', err);
+                    throw new ReconnectStrategyError(retryIn, err);
+                }
+
+                this.emit('error', err);
+                await promiseTimeout(retryIn);
+            }
+            retries++
+        } while (!this.#isReady)
     }
 
     #createSocket(): Promise<net.Socket | tls.TLSSocket> {
         return new Promise((resolve, reject) => {
-            const {connectEvent, socket} = RedisSocket.#isTlsSocket(this.#options) ?
+            const { connectEvent, socket } = RedisSocket.#isTlsSocket(this.#options) ?
                 this.#createTlsSocket() :
                 this.#createNetSocket();
 
@@ -200,7 +203,7 @@ export default class RedisSocket extends EventEmitter {
         this.#isReady = false;
         this.emit('error', err);
 
-        this.#connect(0, true).catch(() => {
+        this.#connect(true).catch(() => {
             // the error was already emitted, silently ignore it
         });
     }


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
This change prevents a memory leak when a Redis client tries to connect to an unavailable host. This is achieve by switching from a recursive to an iterative approach.

<!-- Why does it matter to you? What problem are you trying to solve? -->
When a Redis instance fails, our clients slowly build up memory until they get killed. 

<!-- Tag in any linked issues. -->
https://github.com/redis/node-redis/issues/2134

First, I had to slightly change the tests' implementation to work around timeout issues when running the tests, ie : specifying a timeout using the _connectTimeout_ argument & giving up mocking time by specifying a very small retry delay. This commit should preferably be reverted if someone who manages to run tests locally can validate my implementation with the previous implementation for those tests :shrug: 

Second, I swapped the recursive call to `connect` for a do{}while loop and leverage the `#this.isReady` property as the exit condition. 

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
