### PR TITLE
fix: zero ttl is ignored

### DIFF
--- a/packages/client/lib/commands/SET.spec.ts
+++ b/packages/client/lib/commands/SET.spec.ts
@@ -13,8 +13,8 @@ describe('SET', () => {
 
         it('number', () => {
             assert.deepEqual(
-                transformArguments('key', 1),
-                ['SET', 'key', '1']
+                transformArguments('key', 0),
+                ['SET', 'key', '0']
             );
         });
 
@@ -22,36 +22,36 @@ describe('SET', () => {
             it('with EX', () => {
                 assert.deepEqual(
                     transformArguments('key', 'value', {
-                        EX: 1
+                        EX: 0
                     }),
-                    ['SET', 'key', 'value', 'EX', '1']
+                    ['SET', 'key', 'value', 'EX', '0']
                 );
             });
 
             it('with PX', () => {
                 assert.deepEqual(
                     transformArguments('key', 'value', {
-                        PX: 1
+                        PX: 0
                     }),
-                    ['SET', 'key', 'value', 'PX', '1']
+                    ['SET', 'key', 'value', 'PX', '0']
                 );
             });
 
             it('with EXAT', () => {
                 assert.deepEqual(
                     transformArguments('key', 'value', {
-                        EXAT: 1
+                        EXAT: 0
                     }),
-                    ['SET', 'key', 'value', 'EXAT', '1']
+                    ['SET', 'key', 'value', 'EXAT', '0']
                 );
             });
 
             it('with PXAT', () => {
                 assert.deepEqual(
                     transformArguments('key', 'value', {
-                        PXAT: 1
+                        PXAT: 0
                     }),
-                    ['SET', 'key', 'value', 'PXAT', '1']
+                    ['SET', 'key', 'value', 'PXAT', '0']
                 );
             });
 

--- a/packages/client/lib/commands/SET.ts
+++ b/packages/client/lib/commands/SET.ts
@@ -36,13 +36,13 @@ export function transformArguments(
     ];
 
     if (options?.EX !== undefined) {
-        args.push('EX', EX.toString());
+        args.push('EX', options.EX.toString());
     } else if (options?.PX !== undefined) {
-        args.push('PX', PX.toString());
+        args.push('PX', options.PX.toString());
     } else if (options?.EXAT !== undefined) {
-        args.push('EXAT', EXAT.toString());
+        args.push('EXAT', options.EXAT.toString());
     } else if (options?.PXAT !== undefined) {
-        args.push('PXAT', PXAT.toString());
+        args.push('PXAT', options.PXAT.toString());
     } else if (options?.KEEPTTL) {
         args.push('KEEPTTL');
     }

--- a/packages/client/lib/commands/SET.ts
+++ b/packages/client/lib/commands/SET.ts
@@ -35,27 +35,25 @@ export function transformArguments(
         typeof value === 'number' ? value.toString() : value
     ];
 
-	const { EX, PX, EXAT, PXAT, KEEPTTL, NX, XX, GET } = options || {};
-
-    if (EX !== undefined) {
+    if (options?.EX !== undefined) {
         args.push('EX', EX.toString());
-    } else if (PX !== undefined) {
+    } else if (options?.PX !== undefined) {
         args.push('PX', PX.toString());
-    } else if (EXAT !== undefined) {
+    } else if (options?.EXAT !== undefined) {
         args.push('EXAT', EXAT.toString());
-    } else if (PXAT !== undefined) {
+    } else if (options?.PXAT !== undefined) {
         args.push('PXAT', PXAT.toString());
-    } else if (KEEPTTL) {
+    } else if (options?.KEEPTTL) {
         args.push('KEEPTTL');
     }
 
-    if (NX) {
+    if (options?.NX) {
         args.push('NX');
-    } else if (XX) {
+    } else if (options?.XX) {
         args.push('XX');
     }
 
-    if (GET) {
+    if (options?.GET) {
         args.push('GET');
     }
 

--- a/packages/client/lib/commands/SET.ts
+++ b/packages/client/lib/commands/SET.ts
@@ -35,25 +35,27 @@ export function transformArguments(
         typeof value === 'number' ? value.toString() : value
     ];
 
-    if (options?.EX) {
-        args.push('EX', options.EX.toString());
-    } else if (options?.PX) {
-        args.push('PX', options.PX.toString());
-    } else if (options?.EXAT) {
-        args.push('EXAT', options.EXAT.toString());
-    } else if (options?.PXAT) {
-        args.push('PXAT', options.PXAT.toString());
-    } else if (options?.KEEPTTL) {
+	const { EX, PX, EXAT, PXAT, KEEPTTL, NX, XX, GET } = options || {};
+
+    if (EX !== undefined) {
+        args.push('EX', EX.toString());
+    } else if (PX !== undefined) {
+        args.push('PX', PX.toString());
+    } else if (EXAT !== undefined) {
+        args.push('EXAT', EXAT.toString());
+    } else if (PXAT !== undefined) {
+        args.push('PXAT', PXAT.toString());
+    } else if (KEEPTTL) {
         args.push('KEEPTTL');
     }
 
-    if (options?.NX) {
+    if (NX) {
         args.push('NX');
-    } else if (options?.XX) {
+    } else if (XX) {
         args.push('XX');
     }
 
-    if (options?.GET) {
+    if (GET) {
         args.push('GET');
     }
 


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->


This fixes an issue when a `0` ttl is provided. 0 ttl should mean that the item effectively won't be stored because it's so short-lived. However, the current code fails to pass the 0 ttl to redis, meaning the value is stored forever.

This fixes it. I changed the value in some tests from 1 to 0, as it prevents this bug from reappearing, and I believe the number 0 covers the code just as well as number 1.

---

btw. it would be nice to have prettier / editorconfig or something like that in place, my ide reformatted the code in a bad way on my first attempt to make changes 

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
