### PR TITLE
#2038 Resolve legacy mode hGetAll returning in the wrong format compared to v3 results

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -8,6 +8,7 @@ import { defineScript } from '../lua-script';
 import { spy } from 'sinon';
 import { once } from 'events';
 import { ClientKillFilters } from '../commands/CLIENT_KILL';
+import { promisify } from 'util';
 
 export const SQUARE_SCRIPT = defineScript({
     SCRIPT: 'return ARGV[1] * ARGV[1];',
@@ -142,26 +143,9 @@ describe('Client', () => {
     });
 
     describe('legacyMode', () => {
-        function sendCommandAsync<
-            M extends RedisModules,
-            F extends RedisFunctions,
-            S extends RedisScripts
-        >(
-            client: RedisClientType<M, F, S>,
-            args: RedisCommandArguments
-        ): Promise<RedisCommandRawReply> {
-            return new Promise((resolve, reject) => {
-                (client as any).sendCommand(args, (err: Error | undefined, reply: RedisCommandRawReply) => {
-                    if (err) return reject(err);
-
-                    resolve(reply);
-                });
-            });
-        }
-
         testUtils.testWithClient('client.sendCommand should call the callback', async client => {
             assert.equal(
-                await sendCommandAsync(client, ['PING']),
+                await promisify(client.sendCommand).call(client, 'PING'),
                 'PONG'
             );
         }, {
@@ -193,26 +177,9 @@ describe('Client', () => {
             }
         });
 
-        function setAsync<
-            M extends RedisModules,
-            F extends RedisFunctions,
-            S extends RedisScripts
-        >(
-            client: RedisClientType<M, F, S>,
-            ...args: Array<any>
-        ): Promise<RedisCommandRawReply> {
-            return new Promise((resolve, reject) => {
-                (client as any).set(...args, (err: Error | undefined, reply: RedisCommandRawReply) => {
-                    if (err) return reject(err);
-
-                    resolve(reply);
-                });
-            });
-        }
-
         testUtils.testWithClient('client.{command} should accept vardict arguments', async client => {
             assert.equal(
-                await setAsync(client, 'a', 'b'),
+                await promisify(client.set).call(client, 'a', 'b'),
                 'OK'
             );
         }, {
@@ -224,7 +191,7 @@ describe('Client', () => {
 
         testUtils.testWithClient('client.{command} should accept arguments array', async client => {
             assert.equal(
-                await setAsync(client, ['a', 'b']),
+                await promisify(client.set).call(client, ['a', 'b']),
                 'OK'
             );
         }, {
@@ -236,8 +203,28 @@ describe('Client', () => {
 
         testUtils.testWithClient('client.{command} should accept mix of arrays and arguments', async client => {
             assert.equal(
-                await setAsync(client, ['a'], 'b', ['EX', 1]),
+                await promisify(client.set).call(client, ['a'], 'b', ['EX', 1]),
                 'OK'
+            );
+        }, {
+            ...GLOBAL.SERVERS.OPEN,
+            clientOptions: {
+                legacyMode: true
+            }
+        });
+
+        testUtils.testWithClient('client.hGetAll should return object', async client => {
+            await client.v4.hSet('key', 'field', 'value');
+            
+            assert.deepEqual(
+                await promisify(client.hGetAll).call(client, 'key'),
+                Object.create(null, {
+                    field: {
+                        value: 'value',
+                        configurable: true,
+                        enumerable: true
+                    }
+                })
             );
         }, {
             ...GLOBAL.SERVERS.OPEN,
@@ -330,6 +317,30 @@ describe('Client', () => {
             }
         });
 
+        testUtils.testWithClient('client.multi.hGetAll should return object', async client => { 
+            assert.deepEqual(
+                await multiExecAsync(
+                    client.multi()
+                        .hSet('key', 'field', 'value')
+                        .hGetAll('key')
+                ),
+                [
+                    1,
+                    Object.create(null, {
+                        field: {
+                            value: 'value',
+                            configurable: true,
+                            enumerable: true
+                        }
+                    })
+                ]
+            );
+        }, {
+            ...GLOBAL.SERVERS.OPEN,
+            clientOptions: {
+                legacyMode: true
+            }
+        });
     });
 
     describe('events', () => {

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -1,5 +1,5 @@
 import COMMANDS from './commands';
-import { RedisCommand, RedisCommandArguments, RedisCommandRawReply, RedisCommandReply, RedisFunctions, RedisModules, RedisExtensions, RedisScript, RedisScripts, RedisCommandSignature, ConvertArgumentType, RedisFunction, ExcludeMappedString } from '../commands';
+import { RedisCommand, RedisCommandArguments, RedisCommandRawReply, RedisCommandReply, RedisFunctions, RedisModules, RedisExtensions, RedisScript, RedisScripts, RedisCommandSignature, ConvertArgumentType, RedisFunction, ExcludeMappedString, RedisCommands } from '../commands';
 import RedisSocket, { RedisSocketOptions, RedisTlsSocketOptions } from './socket';
 import RedisCommandsQueue, { PubSubListener, PubSubSubscribeCommands, PubSubUnsubscribeCommands, QueueCommandOptions } from './commands-queue';
 import RedisClientMultiCommand, { RedisClientMultiCommandType } from './multi-command';
@@ -300,36 +300,14 @@ export default class RedisClient<
 
         (this as any).#v4.sendCommand = this.#sendCommand.bind(this);
         (this as any).sendCommand = (...args: Array<any>): void => {
-            const [name]: Array<string> = args;
-            let callback: ClientLegacyCallback;
-            if (typeof args[args.length - 1] === 'function') {
-                callback = args.pop() as ClientLegacyCallback;
+            const result = this.#legacySendCommand(...args);
+            if (result) {
+                result.promise.then(reply => result.callback(null, reply));
             }
-
-            this.#sendCommand(transformLegacyCommandArguments(args))
-                .then((reply: RedisCommandRawReply) => {
-                    if (!callback) {
-                        return;
-                    } else if ((COMMANDS as any)[name].TRANSFORM_LEGACY_REPLY) {
-                        reply = (COMMANDS as any)[name].transformReply(reply);
-                    }
-                    callback(null, reply);
-                })
-                .catch((err: Error) => {
-                    if (!callback) {
-                        this.emit('error', err);
-                        return;
-                    }
-
-                    callback(err);
-                });
         };
 
-        for (const name of Object.keys(COMMANDS)) {
-            this.#defineLegacyCommand(name);
-        }
-
-        for (const name of Object.keys(COMMANDS)) {
+        for (const [ name, command ] of Object.entries(COMMANDS as RedisCommands)) {
+            this.#defineLegacyCommand(name, command);
             (this as any)[name.toLowerCase()] = (this as any)[name];
         }
 
@@ -348,10 +326,31 @@ export default class RedisClient<
         this.#defineLegacyCommand('quit');
     }
 
-    #defineLegacyCommand(name: string): void {
-        this.#v4[name] = (this as any)[name].bind(this);
-        (this as any)[name] =
-            (...args: Array<unknown>): void => (this as any).sendCommand(name, ...args);
+    #legacySendCommand(...args: Array<any>) {
+        const callback = typeof args[args.length - 1] === 'function' ?
+            args.pop() as ClientLegacyCallback :
+            undefined;
+
+        const promise = this.#sendCommand(transformLegacyCommandArguments(args));
+        if (callback) return {
+            promise,
+            callback
+        };
+        promise.catch(err => this.emit('error', err));
+    }
+
+    #defineLegacyCommand(this: any, name: string, command?: RedisCommand): void {
+        this.#v4[name] = this[name].bind(this);
+        this[name] = command && command.TRANSFORM_LEGACY_REPLY && command.transformReply ?
+            (...args: Array<unknown>) => {
+                const result = this.#legacySendCommand(name, ...args);
+                if (result) {
+                    result.promise.then((reply: any) => {
+                        result.callback(null, command.transformReply!(reply));
+                    });
+                }
+            } :
+            (...args: Array<unknown>) => this.sendCommand(name, ...args);
     }
 
     #pingTimer?: NodeJS.Timer;

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -310,7 +310,7 @@ export default class RedisClient<
                 .then((reply: RedisCommandRawReply) => {
                     if (!callback) {
                         return;
-                    } else if (name === 'hGetAll') {
+                    } else if ((COMMANDS as any)[name].TRANSFORM_LEGACY_REPLY) {
                         reply = (COMMANDS as any)[name].transformReply(reply);
                     }
                     callback(null, reply);

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -310,11 +310,8 @@ export default class RedisClient<
                 .then((reply: RedisCommandRawReply) => {
                     if (!callback) {
                         return;
-                    } else {
-                        const transformReply = (COMMANDS as any)[name]?.transformReply
-                        if (transformReply) {
-                            reply = transformReply(reply);
-                        }
+                    } else if (name === 'hGetAll') {
+                        reply = (COMMANDS as any)[name].transformReply(reply);
                     }
                     callback(null, reply);
                 })

--- a/packages/client/lib/client/multi-command.ts
+++ b/packages/client/lib/client/multi-command.ts
@@ -96,7 +96,8 @@ export default class RedisClientMultiCommand {
     #legacyMode(): void {
         this.v4.addCommand = this.addCommand.bind(this);
         (this as any).addCommand = (...args: Array<any>): this => {
-            this.#multi.addCommand(transformLegacyCommandArguments(args));
+            const [name]: Array<string> = args
+            this.#multi.addCommand(transformLegacyCommandArguments(args), (COMMANDS as any)[name]?.transformReply);
             return this;
         };
         this.v4.exec = this.exec.bind(this);

--- a/packages/client/lib/client/multi-command.ts
+++ b/packages/client/lib/client/multi-command.ts
@@ -96,7 +96,7 @@ export default class RedisClientMultiCommand {
     #legacyMode(): void {
         this.v4.addCommand = this.addCommand.bind(this);
         (this as any).addCommand = (...args: Array<any>): this => {
-            const [name]: Array<string> = args
+            const [name]: Array<string> = args;
             this.#multi.addCommand(transformLegacyCommandArguments(args), (COMMANDS as any)[name]?.transformReply);
             return this;
         };

--- a/packages/client/lib/client/multi-command.ts
+++ b/packages/client/lib/client/multi-command.ts
@@ -97,7 +97,7 @@ export default class RedisClientMultiCommand {
         this.v4.addCommand = this.addCommand.bind(this);
         (this as any).addCommand = (...args: Array<any>): this => {
             const [name]: Array<string> = args;            
-            if (name === 'hGetAll') {
+            if ((COMMANDS as any)[name].TRANSFORM_LEGACY_REPLY) {
                 this.#multi.addCommand(transformLegacyCommandArguments(args), (COMMANDS as any)[name].transformReply);
             } else {
                 this.#multi.addCommand(transformLegacyCommandArguments(args));

--- a/packages/client/lib/client/multi-command.ts
+++ b/packages/client/lib/client/multi-command.ts
@@ -96,8 +96,12 @@ export default class RedisClientMultiCommand {
     #legacyMode(): void {
         this.v4.addCommand = this.addCommand.bind(this);
         (this as any).addCommand = (...args: Array<any>): this => {
-            const [name]: Array<string> = args;
-            this.#multi.addCommand(transformLegacyCommandArguments(args), (COMMANDS as any)[name]?.transformReply);
+            const [name]: Array<string> = args;            
+            if (name === 'hGetAll') {
+                this.#multi.addCommand(transformLegacyCommandArguments(args), (COMMANDS as any)[name].transformReply);
+            } else {
+                this.#multi.addCommand(transformLegacyCommandArguments(args));
+            }
             return this;
         };
         this.v4.exec = this.exec.bind(this);

--- a/packages/client/lib/commands/HGETALL.ts
+++ b/packages/client/lib/commands/HGETALL.ts
@@ -4,6 +4,8 @@ export const FIRST_KEY_INDEX = 1;
 
 export const IS_READ_ONLY = true;
 
+export const TRANSFORM_LEGACY_REPLY = true;
+
 export function transformArguments(key: RedisCommandArgument): RedisCommandArguments {
     return ['HGETALL', key];
 }

--- a/packages/client/lib/commands/index.ts
+++ b/packages/client/lib/commands/index.ts
@@ -11,6 +11,7 @@ export type RedisCommandArguments = Array<RedisCommandArgument> & { preserve?: u
 export interface RedisCommand {
     FIRST_KEY_INDEX?: number | ((...args: Array<any>) => RedisCommandArgument | undefined);
     IS_READ_ONLY?: boolean;
+    TRANSFORM_LEGACY_REPLY?: boolean;
     transformArguments(this: void, ...args: Array<any>): RedisCommandArguments;
     transformReply?(this: void, reply: any, preserved?: any): any;
 }


### PR DESCRIPTION
### Description

Resolves Issue #2038

Noteworthy:

- In V3 empty replies came back as `null` where in V4 empty replies are delivered as an empty object ({}) or array([])
- I did not fix empty reply behavior pertaining to `legacyMode`, perhaps it warrants more investigation but is outside the scope of 2038

Left Side V4 vs Right Side V3

<img width="430" alt="Screenshot 2023-01-05 at 11 50 02 AM" src="https://user-images.githubusercontent.com/29527680/210857807-c6948b97-7a32-4e52-82f3-1854b4445559.png">

---

During a migration to version 4 our team encountered an issue regarding legacy mode return formatting.

`multi.hGetAll` was returning as a tuple instead of an object. _**Prior**_ to upgrading and enabling `legacyMode` it was returning the value as an object, and the v4 version also returns the reply as an object. Thanks to our joi data validation we were able to catch the mismatch and investigate.

I believe this is because the `legacyMode` `addCommand` for non-v4 currently calls
`this.#multi.addCommand(transformLegacyCommandArguments(args));` and omits the `transformReply` which is exported by the various commands and seemingly needed for `hGetAll` to match the v3 formatting.

I've added an optional boolean to `RedisCommands` needing this transform (`hGetAll` for now). As COMMANDS is lacking typing I cast it as any to avoid errors when accessing the object using the command name string.

With this fix in place the legacy mode `multi.hGetAll` is now returning an object as expected.

### Additional Work

#2038 points out that this issue may also spread to the `sendCommand` method which takes a very similar approach to legacy splitting as the `addCommand` method did.

I've also applied the transform in this case, which formats the reply as an object instead of a tuple, mimicking v3 behavior.

<img width="512" alt="Screenshot 2023-01-05 at 11 39 59 AM" src="https://user-images.githubusercontent.com/29527680/210855859-c26ef153-0349-4fa4-a292-39a3c1c77e6e.png">

### Important:

By applying `transformReply` to _**everything**_ (as a test case) I've noticed odd behavior. `hGetAll` with `transformReply` applied matches the old v3 behavior. Something like `client.scan` returned a tuple originally but a `transformReply` causes it to incorrectly return as an object.

Since `hGetAll` is the only one known to have an issue I've limited the scope to the `hGetAll / HGETALL` command. I believe applying the transform to everything is dangerous, as it appears this reply type mismatch either only happens to `hGetAll` or a small subset of commands that have yet to be discovered.

### Testing Issues

I was able to run this through my own project test suite and the issue appears to be resolved. 

I've partially figured out how to run the official test suite locally but still having some trouble with some Cluster tests... perhaps I'm not setting it up correctly.

`npm run test -w ./packages/client -- --redis-version 7.0`

**Local Test Run (exact same results as master test run):**
1119 passing
2 pending
9 failing

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
