### PR TITLE
Allow automatic pings to be sent on pubsub channel

### DIFF
--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -361,7 +361,7 @@ export default class RedisClient<
         this.#pingTimer = setTimeout(() => {
             if (!this.#socket.isReady) return;
 
-            (this as unknown as RedisClientType<M, F, S>).ping()
+            this.#sendCommand(['PING'], { ignorePubSubMode: true })
                 .then(reply => this.emit('ping-interval', reply))
                 .catch(err => this.emit('error', err))
                 .finally(() => this.#setPingTimer());


### PR DESCRIPTION

### Description

If you turn on automatic pings (via pingInterval) on a pubsub channel, you get the error: “Cannot send commands in PubSub mode”. PING is one of the legal commands on a pubsub channel, so we override the ping call to set ignorePubSubMode true and allow the ping to be sent on that channel.

<!-- Why does it matter to you? What problem are you trying to solve? -->
We are unable to use the new pingInterval setting on clients being used for pubsub because of an incorrect error that PING is not allowed on pubsub channels.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
