### PR TITLE
Fix legacyMode/pingInterval issue

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -341,6 +341,19 @@ describe('Client', () => {
                 legacyMode: true
             }
         });
+
+        testUtils.testWithClient('pingInterval', async client => {
+            assert.deepEqual(
+                await once(client, 'ping-interval'),
+                ['PONG']
+            );
+        }, {
+            ...GLOBAL.SERVERS.OPEN,
+            clientOptions: {
+                legacyMode: true,
+                pingInterval: 1
+            }
+        });
     });
 
     describe('events', () => {

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -362,8 +362,8 @@ export default class RedisClient<
         this.#pingTimer = setTimeout(() => {
             if (!this.#socket.isReady) return;
 
-            const v4Client = (this.#options?.legacyMode ? this.v4 : this);
-            (v4Client as unknown as RedisClientType<M, F, S>).ping()
+            // using #sendCommand to support legacy mode
+            this.#sendCommand(['PING'])
                 .then(reply => this.emit('ping-interval', reply))
                 .catch(err => this.emit('error', err))
                 .finally(() => this.#setPingTimer());

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -362,7 +362,8 @@ export default class RedisClient<
         this.#pingTimer = setTimeout(() => {
             if (!this.#socket.isReady) return;
 
-            (this as unknown as RedisClientType<M, F, S>).ping()
+            const v4Client = (this.#options?.legacyMode ? this.v4 : this);
+            (v4Client as unknown as RedisClientType<M, F, S>).ping()
                 .then(reply => this.emit('ping-interval', reply))
                 .catch(err => this.emit('error', err))
                 .finally(() => this.#setPingTimer());


### PR DESCRIPTION
### Description

Fixes #2383 - when `pingInterval` is used with a client in `legacyMode` an error was thrown (see #2383) - this PR aims to resolve the issue.

---

### Checklist

- [ ] Does `npm test` pass with this change (including linting)?

I do not have Docker installed under WSL, so am unable to run your test suite. I was hoping CI might take care of this. You don't seem to have a `npm run format` or similar command to apply autofixes to the formatting and I cannot run the test suite without Docker, so cannot confirm if linting passes.

- [x] Is the new or changed code fully tested?
- [x] ~~Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?~~
