### PR TITLE
fix: Fix small typo in Redis Pub/Sub docs

### DIFF
--- a/docs/pub-sub.md
+++ b/docs/pub-sub.md
@@ -8,7 +8,7 @@ Pub/Sub requires a dedicated stand-alone client. You can easily get one by `.dup
 
 ```typescript
 const subscriber = client.duplicate();
-subscribe.on('error', err => console.error(err));
+subscriber.on('error', err => console.error(err));
 await subscriber.connect();
 ```
 


### PR DESCRIPTION
### Description
Fix typo in code block in Redis Pub/Sub docs that misspelt the variable name of the duplicated Redis client.

--- 

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
