### PR TITLE
Remove redundant UNF sub-option in JSON example

### DIFF
--- a/examples/search-json.js
+++ b/examples/search-json.js
@@ -15,7 +15,7 @@ try {
   await client.ft.create('idx:users', {
     '$.name': {
       type: SchemaFieldTypes.TEXT,
-      SORTABLE: 'UNF'
+      SORTABLE: true
     },
     '$.age': {
       type: SchemaFieldTypes.NUMERIC,


### PR DESCRIPTION
UNF option is not required with JSON and makes the  example harder to read and understand.

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
