### PR TITLE
Execute empty MULTI

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -518,14 +518,23 @@ describe('Client', () => {
             );
         }, GLOBAL.SERVERS.OPEN);
 
-        testUtils.testWithClient('execAsPipeline', async client => {
-            assert.deepEqual(
-                await client.multi()
-                    .ping()
-                    .exec(true),
-                ['PONG']
-            );
-        }, GLOBAL.SERVERS.OPEN);
+        describe('execAsPipeline', () => {
+            testUtils.testWithClient('exec(true)', async client => {
+                assert.deepEqual(
+                    await client.multi()
+                        .ping()
+                        .exec(true),
+                    ['PONG']
+                );
+            }, GLOBAL.SERVERS.OPEN);
+
+            testUtils.testWithClient('empty execAsPipeline', async client => {
+                assert.deepEqual(
+                    await client.multi().execAsPipeline(),
+                    []
+                );
+            }, GLOBAL.SERVERS.OPEN);
+        });
 
         testUtils.testWithClient('should remember selected db', async client => {
             await client.multi()

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -350,7 +350,7 @@ export default class RedisClient<
             }
         };
 
-        for (const [name, command] of Object.entries(COMMANDS as RedisCommands)) {
+        for (const [ name, command ] of Object.entries(COMMANDS as RedisCommands)) {
             this.#defineLegacyCommand(name, command);
             (this as any)[name.toLowerCase()] ??= (this as any)[name];
         }

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -75,13 +75,13 @@ type WithCommands = {
 
 export type WithModules<M extends RedisModules> = {
     [P in keyof M as ExcludeMappedString<P>]: {
-        [C in keyof M[P]as ExcludeMappedString<C>]: RedisCommandSignature<M[P][C]>;
+        [C in keyof M[P] as ExcludeMappedString<C>]: RedisCommandSignature<M[P][C]>;
     };
 };
 
 export type WithFunctions<F extends RedisFunctions> = {
     [P in keyof F as ExcludeMappedString<P>]: {
-        [FF in keyof F[P]as ExcludeMappedString<FF>]: RedisCommandSignature<F[P][FF]>;
+        [FF in keyof F[P] as ExcludeMappedString<FF>]: RedisCommandSignature<F[P][FF]>;
     };
 };
 

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -732,7 +732,7 @@ export default class RedisClient<
                 this.#addMultiCommands(commands, chainId),
                 this.#queue.addCommand(['EXEC'], { chainId })
             ]) :
-            this.#addMultiCommands(commands, chainId);
+            this.#addMultiCommands(commands);
 
         this.#tick();
 

--- a/packages/client/lib/client/multi-command.ts
+++ b/packages/client/lib/client/multi-command.ts
@@ -15,36 +15,36 @@ type WithCommands<
     F extends RedisFunctions,
     S extends RedisScripts
 > = {
-        [P in keyof typeof COMMANDS]: CommandSignature<(typeof COMMANDS)[P], M, F, S>;
-    };
+    [P in keyof typeof COMMANDS]: CommandSignature<(typeof COMMANDS)[P], M, F, S>;
+};
 
 type WithModules<
     M extends RedisModules,
     F extends RedisFunctions,
     S extends RedisScripts
 > = {
-        [P in keyof M as ExcludeMappedString<P>]: {
-            [C in keyof M[P]as ExcludeMappedString<C>]: CommandSignature<M[P][C], M, F, S>;
-        };
+    [P in keyof M as ExcludeMappedString<P>]: {
+        [C in keyof M[P]as ExcludeMappedString<C>]: CommandSignature<M[P][C], M, F, S>;
     };
+};
 
 type WithFunctions<
     M extends RedisModules,
     F extends RedisFunctions,
     S extends RedisScripts
 > = {
-        [P in keyof F as ExcludeMappedString<P>]: {
-            [FF in keyof F[P]as ExcludeMappedString<FF>]: CommandSignature<F[P][FF], M, F, S>;
-        };
+    [P in keyof F as ExcludeMappedString<P>]: {
+        [FF in keyof F[P]as ExcludeMappedString<FF>]: CommandSignature<F[P][FF], M, F, S>;
     };
+};
 
 type WithScripts<
     M extends RedisModules,
     F extends RedisFunctions,
     S extends RedisScripts
 > = {
-        [P in keyof S as ExcludeMappedString<P>]: CommandSignature<S[P], M, F, S>;
-    };
+    [P in keyof S as ExcludeMappedString<P>]: CommandSignature<S[P], M, F, S>;
+};
 
 export type RedisClientMultiCommandType<
     M extends RedisModules,
@@ -117,7 +117,7 @@ export default class RedisClientMultiCommand {
                 });
         };
 
-        for (const [name, command] of Object.entries(COMMANDS as RedisCommands)) {
+        for (const [ name, command ] of Object.entries(COMMANDS as RedisCommands)) {
             this.#defineLegacyCommand(name, command);
             (this as any)[name.toLowerCase()] ??= (this as any)[name];
         }

--- a/packages/client/lib/client/multi-command.ts
+++ b/packages/client/lib/client/multi-command.ts
@@ -24,7 +24,7 @@ type WithModules<
     S extends RedisScripts
 > = {
     [P in keyof M as ExcludeMappedString<P>]: {
-        [C in keyof M[P]as ExcludeMappedString<C>]: CommandSignature<M[P][C], M, F, S>;
+        [C in keyof M[P] as ExcludeMappedString<C>]: CommandSignature<M[P][C], M, F, S>;
     };
 };
 
@@ -34,7 +34,7 @@ type WithFunctions<
     S extends RedisScripts
 > = {
     [P in keyof F as ExcludeMappedString<P>]: {
-        [FF in keyof F[P]as ExcludeMappedString<FF>]: CommandSignature<F[P][FF], M, F, S>;
+        [FF in keyof F[P] as ExcludeMappedString<FF>]: CommandSignature<F[P][FF], M, F, S>;
     };
 };
 

--- a/packages/client/lib/client/multi-command.ts
+++ b/packages/client/lib/client/multi-command.ts
@@ -182,6 +182,8 @@ export default class RedisClientMultiCommand {
     EXEC = this.exec;
 
     async execAsPipeline(): Promise<Array<RedisCommandRawReply>> {
+        if (this.#multi.queue.length === 0) return [];
+        
         return this.#multi.transformReplies(
             await this.#executor(
                 this.#multi.queue,

--- a/packages/client/lib/client/multi-command.ts
+++ b/packages/client/lib/client/multi-command.ts
@@ -15,36 +15,36 @@ type WithCommands<
     F extends RedisFunctions,
     S extends RedisScripts
 > = {
-    [P in keyof typeof COMMANDS]: CommandSignature<(typeof COMMANDS)[P], M, F, S>;
-};
+        [P in keyof typeof COMMANDS]: CommandSignature<(typeof COMMANDS)[P], M, F, S>;
+    };
 
 type WithModules<
     M extends RedisModules,
     F extends RedisFunctions,
     S extends RedisScripts
 > = {
-    [P in keyof M as ExcludeMappedString<P>]: {
-        [C in keyof M[P] as ExcludeMappedString<C>]: CommandSignature<M[P][C], M, F, S>;
+        [P in keyof M as ExcludeMappedString<P>]: {
+            [C in keyof M[P]as ExcludeMappedString<C>]: CommandSignature<M[P][C], M, F, S>;
+        };
     };
-};
 
 type WithFunctions<
     M extends RedisModules,
     F extends RedisFunctions,
     S extends RedisScripts
 > = {
-    [P in keyof F as ExcludeMappedString<P>]: {
-        [FF in keyof F[P] as ExcludeMappedString<FF>]: CommandSignature<F[P][FF], M, F, S>;
+        [P in keyof F as ExcludeMappedString<P>]: {
+            [FF in keyof F[P]as ExcludeMappedString<FF>]: CommandSignature<F[P][FF], M, F, S>;
+        };
     };
-};
 
 type WithScripts<
     M extends RedisModules,
     F extends RedisFunctions,
     S extends RedisScripts
 > = {
-    [P in keyof S as ExcludeMappedString<P>]: CommandSignature<S[P], M, F, S>;
-};
+        [P in keyof S as ExcludeMappedString<P>]: CommandSignature<S[P], M, F, S>;
+    };
 
 export type RedisClientMultiCommandType<
     M extends RedisModules,
@@ -117,7 +117,7 @@ export default class RedisClientMultiCommand {
                 });
         };
 
-        for (const [ name, command ] of Object.entries(COMMANDS as RedisCommands)) {
+        for (const [name, command] of Object.entries(COMMANDS as RedisCommands)) {
             this.#defineLegacyCommand(name, command);
             (this as any)[name.toLowerCase()] ??= (this as any)[name];
         }
@@ -170,11 +170,9 @@ export default class RedisClientMultiCommand {
             return this.execAsPipeline();
         }
 
-        const commands = this.#multi.exec();
-
         return this.#multi.handleExecReplies(
             await this.#executor(
-                commands,
+                this.#multi.queue,
                 this.#selectedDB,
                 RedisMultiCommand.generateChainId()
             )

--- a/packages/client/lib/client/multi-command.ts
+++ b/packages/client/lib/client/multi-command.ts
@@ -171,7 +171,6 @@ export default class RedisClientMultiCommand {
         }
 
         const commands = this.#multi.exec();
-        if (!commands) return [];
 
         return this.#multi.handleExecReplies(
             await this.#executor(

--- a/packages/client/lib/cluster/multi-command.ts
+++ b/packages/client/lib/cluster/multi-command.ts
@@ -16,36 +16,36 @@ type WithCommands<
     F extends RedisFunctions,
     S extends RedisScripts
 > = {
-    [P in keyof typeof COMMANDS]: RedisClusterMultiCommandSignature<(typeof COMMANDS)[P], M, F, S>;
-};
+        [P in keyof typeof COMMANDS]: RedisClusterMultiCommandSignature<(typeof COMMANDS)[P], M, F, S>;
+    };
 
 type WithModules<
     M extends RedisModules,
     F extends RedisFunctions,
     S extends RedisScripts
 > = {
-    [P in keyof M as ExcludeMappedString<P>]: {
-        [C in keyof M[P] as ExcludeMappedString<C>]: RedisClusterMultiCommandSignature<M[P][C], M, F, S>;
+        [P in keyof M as ExcludeMappedString<P>]: {
+            [C in keyof M[P]as ExcludeMappedString<C>]: RedisClusterMultiCommandSignature<M[P][C], M, F, S>;
+        };
     };
-};
 
 type WithFunctions<
     M extends RedisModules,
     F extends RedisFunctions,
     S extends RedisScripts
 > = {
-    [P in keyof F as ExcludeMappedString<P>]: {
-        [FF in keyof F[P] as ExcludeMappedString<FF>]: RedisClusterMultiCommandSignature<F[P][FF], M, F, S>;
+        [P in keyof F as ExcludeMappedString<P>]: {
+            [FF in keyof F[P]as ExcludeMappedString<FF>]: RedisClusterMultiCommandSignature<F[P][FF], M, F, S>;
+        };
     };
-};
 
 type WithScripts<
     M extends RedisModules,
     F extends RedisFunctions,
     S extends RedisScripts
 > = {
-    [P in keyof S as ExcludeMappedString<P>]: RedisClusterMultiCommandSignature<S[P], M, F, S>;
-};
+        [P in keyof S as ExcludeMappedString<P>]: RedisClusterMultiCommandSignature<S[P], M, F, S>;
+    };
 
 export type RedisClusterMultiCommandType<
     M extends RedisModules,
@@ -120,10 +120,8 @@ export default class RedisClusterMultiCommand {
             return this.execAsPipeline();
         }
 
-        const commands = this.#multi.exec();
-
         return this.#multi.handleExecReplies(
-            await this.#executor(commands, this.#firstKey, RedisMultiCommand.generateChainId())
+            await this.#executor(this.#multi.queue, this.#firstKey, RedisMultiCommand.generateChainId())
         );
     }
 

--- a/packages/client/lib/cluster/multi-command.ts
+++ b/packages/client/lib/cluster/multi-command.ts
@@ -25,7 +25,7 @@ type WithModules<
     S extends RedisScripts
 > = {
     [P in keyof M as ExcludeMappedString<P>]: {
-        [C in keyof M[P]as ExcludeMappedString<C>]: RedisClusterMultiCommandSignature<M[P][C], M, F, S>;
+        [C in keyof M[P] as ExcludeMappedString<C>]: RedisClusterMultiCommandSignature<M[P][C], M, F, S>;
     };
 };
 
@@ -35,7 +35,7 @@ type WithFunctions<
     S extends RedisScripts
 > = {
     [P in keyof F as ExcludeMappedString<P>]: {
-        [FF in keyof F[P]as ExcludeMappedString<FF>]: RedisClusterMultiCommandSignature<F[P][FF], M, F, S>;
+        [FF in keyof F[P] as ExcludeMappedString<FF>]: RedisClusterMultiCommandSignature<F[P][FF], M, F, S>;
     };
 };
 

--- a/packages/client/lib/cluster/multi-command.ts
+++ b/packages/client/lib/cluster/multi-command.ts
@@ -121,7 +121,6 @@ export default class RedisClusterMultiCommand {
         }
 
         const commands = this.#multi.exec();
-        if (!commands) return [];
 
         return this.#multi.handleExecReplies(
             await this.#executor(commands, this.#firstKey, RedisMultiCommand.generateChainId())

--- a/packages/client/lib/cluster/multi-command.ts
+++ b/packages/client/lib/cluster/multi-command.ts
@@ -16,36 +16,36 @@ type WithCommands<
     F extends RedisFunctions,
     S extends RedisScripts
 > = {
-        [P in keyof typeof COMMANDS]: RedisClusterMultiCommandSignature<(typeof COMMANDS)[P], M, F, S>;
-    };
+    [P in keyof typeof COMMANDS]: RedisClusterMultiCommandSignature<(typeof COMMANDS)[P], M, F, S>;
+};
 
 type WithModules<
     M extends RedisModules,
     F extends RedisFunctions,
     S extends RedisScripts
 > = {
-        [P in keyof M as ExcludeMappedString<P>]: {
-            [C in keyof M[P]as ExcludeMappedString<C>]: RedisClusterMultiCommandSignature<M[P][C], M, F, S>;
-        };
+    [P in keyof M as ExcludeMappedString<P>]: {
+        [C in keyof M[P]as ExcludeMappedString<C>]: RedisClusterMultiCommandSignature<M[P][C], M, F, S>;
     };
+};
 
 type WithFunctions<
     M extends RedisModules,
     F extends RedisFunctions,
     S extends RedisScripts
 > = {
-        [P in keyof F as ExcludeMappedString<P>]: {
-            [FF in keyof F[P]as ExcludeMappedString<FF>]: RedisClusterMultiCommandSignature<F[P][FF], M, F, S>;
-        };
+    [P in keyof F as ExcludeMappedString<P>]: {
+        [FF in keyof F[P]as ExcludeMappedString<FF>]: RedisClusterMultiCommandSignature<F[P][FF], M, F, S>;
     };
+};
 
 type WithScripts<
     M extends RedisModules,
     F extends RedisFunctions,
     S extends RedisScripts
 > = {
-        [P in keyof S as ExcludeMappedString<P>]: RedisClusterMultiCommandSignature<S[P], M, F, S>;
-    };
+    [P in keyof S as ExcludeMappedString<P>]: RedisClusterMultiCommandSignature<S[P], M, F, S>;
+};
 
 export type RedisClusterMultiCommandType<
     M extends RedisModules,

--- a/packages/client/lib/multi-command.spec.ts
+++ b/packages/client/lib/multi-command.spec.ts
@@ -46,14 +46,16 @@ describe('Multi Command', () => {
     });
 
     describe('exec', () => {
-        it('undefined', () => {
+        it('without commands', () => {
             assert.equal(
                 new RedisMultiCommand().exec(),
-                undefined
+                [
+                  { args: ['UNWATCH'] }
+                ]
             );
         });
 
-        it('Array', () => {
+        it('with commands', () => {
             const multi = new RedisMultiCommand();
             multi.addCommand(['PING']);
 

--- a/packages/client/lib/multi-command.spec.ts
+++ b/packages/client/lib/multi-command.spec.ts
@@ -47,11 +47,9 @@ describe('Multi Command', () => {
 
     describe('exec', () => {
         it('without commands', () => {
-            assert.equal(
-                new RedisMultiCommand().exec(),
-                [
-                  { args: ['UNWATCH'] }
-                ]
+            assert.deepEqual(
+                new RedisMultiCommand().queue,
+                []
             );
         });
 
@@ -60,12 +58,11 @@ describe('Multi Command', () => {
             multi.addCommand(['PING']);
 
             assert.deepEqual(
-                multi.exec(),
-                [
-                    { args: ['MULTI'] },
-                    { args: ['PING'], transformReply: undefined },
-                    { args: ['EXEC'] }
-                ]
+                multi.queue,
+                [{
+                    args: ['PING'],
+                    transformReply: undefined
+                }]
             );
         });
     });

--- a/packages/client/lib/multi-command.ts
+++ b/packages/client/lib/multi-command.ts
@@ -69,18 +69,6 @@ export default class RedisMultiCommand {
         return transformedArguments;
     }
 
-    exec(): Array<RedisMultiQueuedCommand> {
-        if (!this.queue.length) {
-            return [{ args: ['UNWATCH'] }];
-        }
-
-        return [
-            { args: ['MULTI'] },
-            ...this.queue,
-            { args: ['EXEC'] }
-        ];
-    }
-
     handleExecReplies(rawReplies: Array<RedisCommandRawReply>): Array<RedisCommandRawReply> {
         const execReply = rawReplies[rawReplies.length - 1] as (null | Array<RedisCommandRawReply>);
         if (execReply === null) {

--- a/packages/client/lib/multi-command.ts
+++ b/packages/client/lib/multi-command.ts
@@ -69,9 +69,9 @@ export default class RedisMultiCommand {
         return transformedArguments;
     }
 
-    exec(): undefined | Array<RedisMultiQueuedCommand> {
+    exec(): Array<RedisMultiQueuedCommand> {
         if (!this.queue.length) {
-            return;
+            return [{ args: ['UNWATCH'] }];
         }
 
         return [


### PR DESCRIPTION
### Description

Currently, calling `.exec()` on an "empty" multi command (without calling any other command on it), is not executing `MULTI EXEC` on the server.
This can cause problems when using `WATCH`, because no `MULTI EXEC` means the key is still watched.

### Fix
Execute `MULTI EXEC` even if the multi is empty.
