### PR TITLE
encoder to allow number values

### DIFF
--- a/packages/client/lib/client/RESP2/encoder.ts
+++ b/packages/client/lib/client/RESP2/encoder.ts
@@ -11,6 +11,8 @@ export default function encodeCommand(args: RedisCommandArguments): Array<RedisC
         const arg = args[i];
         if (typeof arg === 'string') {
             strings += '$' + Buffer.byteLength(arg) + CRLF + arg + CRLF;
+        if (typeof arg === 'number') {
+            strings += '$' + Buffer.byteLength(String(arg)) + CRLF + arg + CRLF;
         } else if (arg instanceof Buffer) {
             toWrite.push(
                 strings + '$' + arg.length.toString() + CRLF,


### PR DESCRIPTION
https://github.com/redis/node-redis/issues/1808
https://github.com/redis/node-redis/issues/2019

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Currently xAdd allows for adding to redis streams _only_ string values. In practice often JSONs stringified objects are xadded, but wen they contain number values:
```javascript
{ "key": 1234 } // valid JSON
```
an exception is being thrown:
```
/home/akrsmv/test/node_modules/@redis/client/dist/lib/client/RESP2/encoder.js:17
            throw new TypeError('Invalid argument type');
                  ^

TypeError: Invalid argument type
    at encodeCommand (/home/akrsmv/test/node_modules/@redis/client/dist/lib/client/RESP2/encoder.js:17:19)
    at RedisCommandsQueue.getCommandToSend (/home/akrsmv/test/node_modules/@redis/client/dist/lib/client/commands-queue.js:138:45)
    at Commander._RedisClient_tick (/home/akrsmv/test/node_modules/@redis/client/dist/lib/client/index.js:507:76)
    at Commander._RedisClient_sendCommand (/home/akrsmv/test/node_modules/@redis/client/dist/lib/client/index.js:494:82)
    at Commander.commandsExecutor (/home/akrsmv/test/node_modules/@redis/client/dist/lib/client/index.js:193:154)
    at BaseClass.<computed> [as xAdd] (/home/akrsmv/test/node_modules/@redis/client/dist/lib/commander.js:8:29)
    at /home/akrsmv/test/packages/core/dist/dataStore.js:130:62
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Promise.all (index 4)
    at async loadFromBucketV1 (/home/akrsmv/test/packages/core/dist/dataStore.js:124:9)
```
and one needs to:
```
function replacer(key: string, value: any) {
    if (typeof value === "number") {
        return value.toString();
    }
    return value;
}
xAdd('mystream', '*', JSON.parse(JSON.stringify(JSON.parse(jsonline), replacer)))
```

Which leads to many redundant operations


---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
