### PR TITLE
Add a note about multiple Pub/Sub channel listeners

### DIFF
--- a/docs/pub-sub.md
+++ b/docs/pub-sub.md
@@ -31,8 +31,6 @@ The event listener signature is as follows:
 
 ## Subscribing
 
-The code below subscribes a new listener to a channel. Subscribing to the same channel more than once will create multiple listeners which will each be called when a message is recieved.
-
 ```javascript
 const listener = (message, channel) => console.log(message, channel);
 await client.subscribe('channel', listener);
@@ -40,6 +38,8 @@ await client.pSubscribe('channe*', listener);
 // Use sSubscribe for sharded Pub/Sub:
 await client.sSubscribe('channel', listener);
 ```
+
+> ⚠️ Subscribing to the same channel more than once will create multiple listeners which will each be called when a message is recieved.
 
 ## Publishing
 

--- a/docs/pub-sub.md
+++ b/docs/pub-sub.md
@@ -31,6 +31,8 @@ The event listener signature is as follows:
 
 ## Subscribing
 
+The code below subscribes a new listener to a channel. Subscribing to the same channel more than once will create multiple listeners which will each be called when a message is recieved.
+
 ```javascript
 const listener = (message, channel) => console.log(message, channel);
 await client.subscribe('channel', listener);


### PR DESCRIPTION
Clarify that multiple subscriptions create multiple listeners.

### Description

This change informs the developer that multiple subscriptions will create multiple listeners. This is important because redis-cli SUBSCRIBE commands do not behave this way, so it may be counter-intuitive.
I personally spent some time debugging my code and my misunderstanding of this was the root cause.

> Describe your pull request here
This changes the pub/sub docs to clarify that multiple subscriptions create multiple listeners.
---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Does `npm test` pass with this change (including linting)?
- [X] Is the new or changed code fully tested?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
