### PR TITLE
fix cluster extractFirstKey skip commandOptions() passed to args

### DIFF
--- a/packages/client/lib/cluster/index.spec.ts
+++ b/packages/client/lib/cluster/index.spec.ts
@@ -190,7 +190,7 @@ describe('Cluster', () => {
     }, {
         ...GLOBAL.CLUSTERS.OPEN,
         clusterConfiguration: {
-            maxCommandRedirections: 0,
+            maxCommandRedirections: 0
         }
     });
 

--- a/packages/client/lib/cluster/index.spec.ts
+++ b/packages/client/lib/cluster/index.spec.ts
@@ -2,6 +2,7 @@ import { strict as assert } from 'assert';
 import testUtils, { GLOBAL, waitTillBeenCalled } from '../test-utils';
 import RedisCluster from '.';
 import { ClusterSlotStates } from '../commands/CLUSTER_SETSLOT';
+import { commandOptions } from '../command-options';
 import { SQUARE_SCRIPT } from '../client/index.spec';
 import { RootNodesUnavailableError } from '../errors';
 import { spy } from 'sinon';
@@ -177,6 +178,21 @@ describe('Cluster', () => {
     testUtils.testWithCluster('should throw CROSSSLOT error', async cluster => {
         await assert.rejects(cluster.mGet(['a', 'b']));
     }, GLOBAL.CLUSTERS.OPEN);
+
+    testUtils.testWithCluster('should send commands with commandOptions to correct cluster slot (without redirections)', async cluster => {
+        // 'a' and 'b' hash to different cluster slots (see previous unit test)
+        // -> maxCommandRedirections 0: rejects on MOVED/ASK reply
+        await cluster.set(commandOptions({ isolated: true }), 'a', '1'),
+        await cluster.set(commandOptions({ isolated: true }), 'b', '2'),
+
+        assert.equal(await cluster.get('a'), '1');
+        assert.equal(await cluster.get('b'), '2');
+    }, {
+        ...GLOBAL.CLUSTERS.OPEN,
+        clusterConfiguration: {
+            maxCommandRedirections: 0,
+        }
+    });
 
     describe('minimizeConnections', () => {
         testUtils.testWithCluster('false', async cluster => {

--- a/packages/client/lib/cluster/index.ts
+++ b/packages/client/lib/cluster/index.ts
@@ -1,5 +1,6 @@
 import COMMANDS from './commands';
 import { RedisCommand, RedisCommandArgument, RedisCommandArguments, RedisCommandRawReply, RedisCommandReply, RedisFunctions, RedisModules, RedisExtensions, RedisScript, RedisScripts, RedisCommandSignature, RedisFunction } from '../commands';
+import { isCommandOptions } from '../command-options';
 import { ClientCommandOptions, RedisClientOptions, RedisClientType, WithFunctions, WithModules, WithScripts } from '../client';
 import RedisClusterSlots, { NodeAddressMap, ShardNode } from './cluster-slots';
 import { attachExtensions, transformCommandReply, attachCommands, transformCommandArguments } from '../commander';
@@ -74,6 +75,10 @@ export default class RedisCluster<
             return undefined;
         } else if (typeof command.FIRST_KEY_INDEX === 'number') {
             return redisArgs[command.FIRST_KEY_INDEX];
+        }
+
+        if (isCommandOptions(originalArgs[0])) {
+            originalArgs = originalArgs.slice(1);
         }
 
         return command.FIRST_KEY_INDEX(...originalArgs);

--- a/packages/client/lib/cluster/index.ts
+++ b/packages/client/lib/cluster/index.ts
@@ -1,6 +1,5 @@
 import COMMANDS from './commands';
 import { RedisCommand, RedisCommandArgument, RedisCommandArguments, RedisCommandRawReply, RedisCommandReply, RedisFunctions, RedisModules, RedisExtensions, RedisScript, RedisScripts, RedisCommandSignature, RedisFunction } from '../commands';
-import { isCommandOptions } from '../command-options';
 import { ClientCommandOptions, RedisClientOptions, RedisClientType, WithFunctions, WithModules, WithScripts } from '../client';
 import RedisClusterSlots, { NodeAddressMap, ShardNode } from './cluster-slots';
 import { attachExtensions, transformCommandReply, attachCommands, transformCommandArguments } from '../commander';
@@ -75,10 +74,6 @@ export default class RedisCluster<
             return undefined;
         } else if (typeof command.FIRST_KEY_INDEX === 'number') {
             return redisArgs[command.FIRST_KEY_INDEX];
-        }
-
-        if (isCommandOptions(originalArgs[0])) {
-            originalArgs = originalArgs.slice(1);
         }
 
         return command.FIRST_KEY_INDEX(...originalArgs);
@@ -157,11 +152,11 @@ export default class RedisCluster<
         command: C,
         args: Array<unknown>
     ): Promise<RedisCommandReply<C>> {
-        const { args: redisArgs, options } = transformCommandArguments(command, args);
+        const { jsArgs, args: redisArgs, options } = transformCommandArguments(command, args);
         return transformCommandReply(
             command,
             await this.sendCommand(
-                RedisCluster.extractFirstKey(command, args, redisArgs),
+                RedisCluster.extractFirstKey(command, jsArgs, redisArgs),
                 command.IS_READ_ONLY,
                 redisArgs,
                 options

--- a/packages/client/lib/commander.ts
+++ b/packages/client/lib/commander.ts
@@ -108,8 +108,8 @@ export function transformCommandArguments<T = ClientCommandOptions>(
     command: RedisCommand,
     args: Array<unknown>
 ): {
-    jsArgs: RedisCommandArguments;
-    args: Array<unknown>;
+    jsArgs: Array<unknown>;
+    args: RedisCommandArguments;
     options: CommandOptions<T> | undefined;
 } {
     let options;

--- a/packages/client/lib/commander.ts
+++ b/packages/client/lib/commander.ts
@@ -108,6 +108,7 @@ export function transformCommandArguments<T = ClientCommandOptions>(
     command: RedisCommand,
     args: Array<unknown>
 ): {
+    jsArgs: RedisCommandArguments;
     args: RedisCommandArguments;
     options: CommandOptions<T> | undefined;
 } {
@@ -118,6 +119,7 @@ export function transformCommandArguments<T = ClientCommandOptions>(
     }
 
     return {
+        jsArgs: args,
         args: command.transformArguments(...args),
         options
     };

--- a/packages/client/lib/commander.ts
+++ b/packages/client/lib/commander.ts
@@ -109,7 +109,7 @@ export function transformCommandArguments<T = ClientCommandOptions>(
     args: Array<unknown>
 ): {
     jsArgs: RedisCommandArguments;
-    args: RedisCommandArguments;
+    args: Array<unknown>;
     options: CommandOptions<T> | undefined;
 } {
     let options;


### PR DESCRIPTION
### Description

in cluster mode the node/slot is calculated based on `extractFirstKey`. skip `commandOptions` if passed as first argument

f.ex.

```
cluster.xRead(commandOptions({ isolated: true }), [{ key: 'foo', id: '0-0' }], { BLOCK: 1000 });
```



---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
