### PR TITLE
`FT.CREATE` - set `FIRST_KEY_INDEX` to `1`

### DIFF
--- a/packages/search/lib/commands/CREATE.ts
+++ b/packages/search/lib/commands/CREATE.ts
@@ -1,6 +1,8 @@
 import { pushOptionalVerdictArgument } from '@redis/client/dist/lib/commands/generic-transformers';
 import { RedisSearchLanguages, PropertyName, RediSearchSchema, pushSchema } from '.';
 
+export const FIRST_KEY_INDEX = 1;
+
 interface CreateOptions {
     ON?: 'HASH' | 'JSON';
     PREFIX?: string | Array<string>;


### PR DESCRIPTION
### Description

for cluster mode: set FIRST_KEY_INDEX to 1 (index name) for the FT.CREATE command

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
