### PR TITLE
remaining FT.* commands - set FIRST_KEY_INDEX to 1

### DIFF
--- a/packages/search/lib/commands/ALIASADD.ts
+++ b/packages/search/lib/commands/ALIASADD.ts
@@ -1,3 +1,5 @@
+export const FIRST_KEY_INDEX = 2;
+
 export function transformArguments(name: string, index: string): Array<string> {
     return ['FT.ALIASADD', name, index];
 }

--- a/packages/search/lib/commands/ALIASDEL.ts
+++ b/packages/search/lib/commands/ALIASDEL.ts
@@ -1,3 +1,5 @@
+export const FIRST_KEY_INDEX = 2;
+
 export function transformArguments(name: string, index: string): Array<string> {
     return ['FT.ALIASDEL', name, index];
 }

--- a/packages/search/lib/commands/ALIASUPDATE.ts
+++ b/packages/search/lib/commands/ALIASUPDATE.ts
@@ -1,3 +1,5 @@
+export const FIRST_KEY_INDEX = 2;
+
 export function transformArguments(name: string, index: string): Array<string> {
     return ['FT.ALIASUPDATE', name, index];
 }

--- a/packages/search/lib/commands/ALTER.ts
+++ b/packages/search/lib/commands/ALTER.ts
@@ -1,5 +1,7 @@
 import { RediSearchSchema, pushSchema } from '.';
 
+export const FIRST_KEY_INDEX = 1;
+
 export function transformArguments(index: string, schema: RediSearchSchema): Array<string> {
     const args = ['FT.ALTER', index, 'SCHEMA', 'ADD'];
     pushSchema(args, schema);

--- a/packages/search/lib/commands/CONFIG_SET.ts
+++ b/packages/search/lib/commands/CONFIG_SET.ts
@@ -1,3 +1,5 @@
+export const FIRST_KEY_INDEX = 1;
+
 export function transformArguments(option: string, value: string): Array<string> {
     return ['FT.CONFIG', 'SET', option, value];
 }

--- a/packages/search/lib/commands/DROPINDEX.ts
+++ b/packages/search/lib/commands/DROPINDEX.ts
@@ -1,3 +1,5 @@
+export const FIRST_KEY_INDEX = 1;
+
 interface DropIndexOptions {
     DD?: true;
 }

--- a/packages/search/lib/commands/EXPLAIN.ts
+++ b/packages/search/lib/commands/EXPLAIN.ts
@@ -1,5 +1,7 @@
 import { Params, pushParamsArgs } from ".";
 
+export const FIRST_KEY_INDEX = 1;
+
 export const IS_READ_ONLY = true;
 
 interface ExplainOptions {

--- a/packages/search/lib/commands/EXPLAINCLI.ts
+++ b/packages/search/lib/commands/EXPLAINCLI.ts
@@ -1,3 +1,5 @@
+export const FIRST_KEY_INDEX = 1;
+
 export const IS_READ_ONLY = true;
 
 export function transformArguments(index: string, query: string): Array<string> {

--- a/packages/search/lib/commands/INFO.ts
+++ b/packages/search/lib/commands/INFO.ts
@@ -1,6 +1,8 @@
 import { RedisCommandArgument } from '@redis/client/dist/lib/commands';
 import { transformTuplesReply } from '@redis/client/dist/lib/commands/generic-transformers';
 
+export const FIRST_KEY_INDEX = 1;
+
 export function transformArguments(index: string): Array<string> {
     return ['FT.INFO', index];
 }

--- a/packages/search/lib/commands/PROFILE_AGGREGATE.ts
+++ b/packages/search/lib/commands/PROFILE_AGGREGATE.ts
@@ -1,6 +1,8 @@
 import { pushAggregatehOptions, AggregateOptions, transformReply as transformAggregateReply, AggregateRawReply } from './AGGREGATE';
 import { ProfileOptions, ProfileRawReply, ProfileReply, transformProfile } from '.';
 
+export const FIRST_KEY_INDEX = 1;
+
 export const IS_READ_ONLY = true;
 
 export function transformArguments(

--- a/packages/search/lib/commands/PROFILE_SEARCH.ts
+++ b/packages/search/lib/commands/PROFILE_SEARCH.ts
@@ -2,6 +2,8 @@ import { SearchOptions, SearchRawReply, transformReply as transformSearchReply }
 import { pushSearchOptions, ProfileOptions, ProfileRawReply, ProfileReply, transformProfile } from '.';
 import { RedisCommandArguments } from '@redis/client/dist/lib/commands';
 
+export const FIRST_KEY_INDEX = 1;
+
 export const IS_READ_ONLY = true;
 
 export function transformArguments(

--- a/packages/search/lib/commands/SPELLCHECK.ts
+++ b/packages/search/lib/commands/SPELLCHECK.ts
@@ -1,3 +1,5 @@
+export const FIRST_KEY_INDEX = 1;
+
 interface SpellCheckTerms {
     mode: 'INCLUDE' | 'EXCLUDE';
     dictionary: string;

--- a/packages/search/lib/commands/SUGADD.ts
+++ b/packages/search/lib/commands/SUGADD.ts
@@ -1,3 +1,5 @@
+export const FIRST_KEY_INDEX = 1;
+
 interface SugAddOptions {
     INCR?: true;
     PAYLOAD?: string;

--- a/packages/search/lib/commands/SUGDEL.ts
+++ b/packages/search/lib/commands/SUGDEL.ts
@@ -1,3 +1,5 @@
+export const FIRST_KEY_INDEX = 1;
+
 export function transformArguments(key: string, string: string): Array<string> {
     return ['FT.SUGDEL', key, string];
 }

--- a/packages/search/lib/commands/SUGGET.ts
+++ b/packages/search/lib/commands/SUGGET.ts
@@ -1,3 +1,5 @@
+export const FIRST_KEY_INDEX = 1;
+
 export const IS_READ_ONLY = true;
 
 export interface SugGetOptions {

--- a/packages/search/lib/commands/SUGGET_WITHPAYLOADS.ts
+++ b/packages/search/lib/commands/SUGGET_WITHPAYLOADS.ts
@@ -1,6 +1,6 @@
 import { SugGetOptions, transformArguments as transformSugGetArguments } from './SUGGET';
 
-export { IS_READ_ONLY } from './SUGGET';
+export { FIRST_KEY_INDEX, IS_READ_ONLY } from './SUGGET';
 
 export function transformArguments(key: string, prefix: string, options?: SugGetOptions): Array<string> {
     return [

--- a/packages/search/lib/commands/SUGGET_WITHSCORES.ts
+++ b/packages/search/lib/commands/SUGGET_WITHSCORES.ts
@@ -1,6 +1,6 @@
 import { SugGetOptions, transformArguments as transformSugGetArguments } from './SUGGET';
 
-export { IS_READ_ONLY } from './SUGGET';
+export { FIRST_KEY_INDEX, IS_READ_ONLY } from './SUGGET';
 
 export function transformArguments(key: string, prefix: string, options?: SugGetOptions): Array<string> {
     return [

--- a/packages/search/lib/commands/SUGGET_WITHSCORES_WITHPAYLOADS.ts
+++ b/packages/search/lib/commands/SUGGET_WITHSCORES_WITHPAYLOADS.ts
@@ -2,7 +2,7 @@ import { SugGetOptions, transformArguments as transformSugGetArguments } from '.
 import { SuggestionWithPayload } from './SUGGET_WITHPAYLOADS';
 import { SuggestionWithScores } from './SUGGET_WITHSCORES';
 
-export { IS_READ_ONLY } from './SUGGET';
+export { FIRST_KEY_INDEX, IS_READ_ONLY } from './SUGGET';
 
 export function transformArguments(key: string, prefix: string, options?: SugGetOptions): Array<string> {
     return [

--- a/packages/search/lib/commands/SUGLEN.ts
+++ b/packages/search/lib/commands/SUGLEN.ts
@@ -1,3 +1,5 @@
+export const FIRST_KEY_INDEX = 1;
+
 export const IS_READ_ONLY = true;
 
 export function transformArguments(key: string): Array<string> {

--- a/packages/search/lib/commands/SYNDUMP.ts
+++ b/packages/search/lib/commands/SYNDUMP.ts
@@ -1,3 +1,5 @@
+export const FIRST_KEY_INDEX = 1;
+
 export function transformArguments(index: string): Array<string> {
     return ['FT.SYNDUMP', index];
 }

--- a/packages/search/lib/commands/SYNUPDATE.ts
+++ b/packages/search/lib/commands/SYNUPDATE.ts
@@ -1,6 +1,8 @@
 import { pushVerdictArguments } from '@redis/client/dist/lib/commands/generic-transformers';
 import { RedisCommandArguments } from '@redis/client/dist/lib/commands';
 
+export const FIRST_KEY_INDEX = 1;
+
 interface SynUpdateOptions {
     SKIPINITIALSCAN?: true;
 }

--- a/packages/search/lib/commands/TAGVALS.ts
+++ b/packages/search/lib/commands/TAGVALS.ts
@@ -1,3 +1,5 @@
+export const FIRST_KEY_INDEX = 1;
+
 export function transformArguments(index: string, fieldName: string): Array<string> {
     return ['FT.TAGVALS', index, fieldName];
 }


### PR DESCRIPTION
### Description

remaining FT.* commands also select the cluster node based on FIRST_KEY_INDEX

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
