### PR TITLE
docs: added info on how to use flushAll with createCluster

### DIFF
--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -113,6 +113,23 @@ Commands such as `GET`, `SET`, etc. are routed by the first key, for instance `M
 
 Admin commands such as `MEMORY STATS`, `FLUSHALL`, etc. are not attached to the cluster, and must be executed on a specific node via `.getSlotMaster()`.
 
+Here is an example of how to FLUSHALL until [#2431](https://github.com/redis/node-redis/issues/2431) will be implemented:
+```javascript
+await Promise.all(
+  cluster.masters.map(async master => {
+    await (await cluster.nodeClient(master)).flushAll();
+  });
+);
+```
+
+```javascript
+cluster.slots - to get the client of a specific slot
+cluster.shards - to work on a "per shard" (master + it's replicas) basis.
+cluster.masters - just the masters
+cluster.replicas - just the replicas
+```
+
+
 ### "Forwarded Commands"
 
 Certain commands (e.g. `PUBLISH`) are forwarded to other cluster nodes by the Redis server. This client sends these commands to a random node in order to spread the load across the cluster.


### PR DESCRIPTION
I'm working with redis clusters and was trying to implement my own abstraction layer on top of node-redis. 
In that layer I needed a `deleteAllKeys` function, which is based on the `flushAll` method that doesn't exist on `RedisClusterType`.

There were no related docs or mentions on how to work around it, thought it should be added to the docs: https://github.com/redis/node-redis/issues/2446#issuecomment-1475252348