### PR TITLE
Fix PubSub isActive with Sharded PubSub

### DIFF
--- a/packages/client/lib/client/pub-sub.ts
+++ b/packages/client/lib/client/pub-sub.ts
@@ -307,7 +307,7 @@ export class PubSub {
         this.#isActive = (
             this.#listeners[PubSubType.CHANNELS].size !== 0 ||
             this.#listeners[PubSubType.PATTERNS].size !== 0 ||
-            this.#listeners[PubSubType.CHANNELS].size !== 0 ||
+            this.#listeners[PubSubType.SHARDED].size !== 0 ||
             this.#subscribing !== 0
         );
     }


### PR DESCRIPTION
Missing PubSubType.SHARDED and duplicate comparison of PubSubType.CHANNELS when comparing listeners size in updateIsActive function

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> When calling the sunsubscribe function, the isActive information is incorrect and the redis client is forcibly disconnected.
In the updateIsActive function, we found that PubSubType.SHARDED was missing where the size of listeners is compared.
The listeners size of PubSubType.CHANNELS is being compared twice.
> We fixed the issue and verified that sunsubscribe is working properly.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Does `npm test` pass with this change (including linting)?
- [X] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
