### PR TITLE
Add support for `TIMEOUT` in `FT.AGGREGATE` and `FT.SEARCH`

### DIFF
--- a/packages/search/lib/commands/AGGREGATE.spec.ts
+++ b/packages/search/lib/commands/AGGREGATE.spec.ts
@@ -454,6 +454,13 @@ describe('AGGREGATE', () => {
                 ['FT.AGGREGATE', 'index', '*', 'DIALECT', '1']
             );
         });
+
+        it('with TIMEOUT', () => {
+            assert.deepEqual(
+                transformArguments('index', '*', { TIMEOUT: 10 }),
+                ['FT.AGGREGATE', 'index', '*', '10']
+            );
+        });
     });
 
     testUtils.testWithClient('client.ft.aggregate', async client => {

--- a/packages/search/lib/commands/AGGREGATE.spec.ts
+++ b/packages/search/lib/commands/AGGREGATE.spec.ts
@@ -458,7 +458,7 @@ describe('AGGREGATE', () => {
         it('with TIMEOUT', () => {
             assert.deepEqual(
                 transformArguments('index', '*', { TIMEOUT: 10 }),
-                ['FT.AGGREGATE', 'index', '*', '10']
+                ['FT.AGGREGATE', 'index', '*', 'TIMEOUT', '10']
             );
         });
     });

--- a/packages/search/lib/commands/AGGREGATE.ts
+++ b/packages/search/lib/commands/AGGREGATE.ts
@@ -214,7 +214,7 @@ export function pushAggregatehOptions(
         args.push('DIALECT', options.DIALECT.toString());
     }
 
-    if (options?.TIMEOUT) {
+    if (options?.TIMEOUT !== undefined) {
         args.push('TIMEOUT', options.TIMEOUT.toString());
     }
 

--- a/packages/search/lib/commands/AGGREGATE.ts
+++ b/packages/search/lib/commands/AGGREGATE.ts
@@ -124,6 +124,7 @@ export interface AggregateOptions {
     STEPS?: Array<GroupByStep | SortStep | ApplyStep | LimitStep | FilterStep>;
     PARAMS?: Params;
     DIALECT?: number;
+    TIMEOUT?: number;
 }
 
 export const FIRST_KEY_INDEX = 1;

--- a/packages/search/lib/commands/AGGREGATE.ts
+++ b/packages/search/lib/commands/AGGREGATE.ts
@@ -214,6 +214,10 @@ export function pushAggregatehOptions(
         args.push('DIALECT', options.DIALECT.toString());
     }
 
+    if (options?.TIMEOUT) {
+        args.push('TIMEOUT', options.TIMEOUT.toString());
+    }
+
     return args;
 }
 

--- a/packages/search/lib/commands/SEARCH.spec.ts
+++ b/packages/search/lib/commands/SEARCH.spec.ts
@@ -233,6 +233,15 @@ describe('SEARCH', () => {
                 ['FT.SEARCH', 'index', 'query', 'DIALECT', '1']
             );
         });
+
+        it('with TIMEOUT', () => {
+            assert.deepEqual(
+                transformArguments('index', 'query', {
+                    TIMEOUT: 5
+                }),
+                ['FT.SEARCH', 'index', 'query', 'TIMEOUT', '5']
+            );
+        });
     });
 
     describe('client.ft.search', () => {

--- a/packages/search/lib/commands/SEARCH.ts
+++ b/packages/search/lib/commands/SEARCH.ts
@@ -55,6 +55,7 @@ export interface SearchOptions {
     };
     PARAMS?: Params;
     DIALECT?: number;
+    TIMEOUT?: number;
 }
 
 export function transformArguments(

--- a/packages/search/lib/commands/index.ts
+++ b/packages/search/lib/commands/index.ts
@@ -510,7 +510,7 @@ export function pushSearchOptions(
         args.preserve = true;
     }
 
-    if (options?.TIMEOUT) {
+    if (options?.TIMEOUT !== undefined) {
         args.push('TIMEOUT', options.TIMEOUT.toString());
     }
 

--- a/packages/search/lib/commands/index.ts
+++ b/packages/search/lib/commands/index.ts
@@ -510,6 +510,10 @@ export function pushSearchOptions(
         args.preserve = true;
     }
 
+    if (options?.TIMEOUT) {
+        args.push('TIMEOUT', options.TIMEOUT.toString());
+    }
+
     return args;
 }
 


### PR DESCRIPTION
fix #2486 - add support for `TIMEOUT` in `FT.AGGREGATE` and `FT.SEARCH`