### PR TITLE
Add `count` option to `FT.CURSOR READ`

### DIFF
--- a/packages/search/lib/commands/CURSOR_READ.spec.ts
+++ b/packages/search/lib/commands/CURSOR_READ.spec.ts
@@ -4,7 +4,7 @@ import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments } from './CURSOR_READ';
 
 describe('CURSOR READ', () => {
-    it('transformArguments', () => {
+    describe('transformArguments', () => {
         it('without options', () => {
             assert.deepEqual(
                 transformArguments('index', 0),

--- a/packages/search/lib/commands/CURSOR_READ.spec.ts
+++ b/packages/search/lib/commands/CURSOR_READ.spec.ts
@@ -5,14 +5,23 @@ import { transformArguments } from './CURSOR_READ';
 
 describe('CURSOR READ', () => {
     it('transformArguments', () => {
-        assert.deepEqual(
-            transformArguments('index', 0),
-            ['FT.CURSOR', 'READ', 'index', '0']
-        );
+        it('without options', () => {
+            assert.deepEqual(
+                transformArguments('index', 0),
+                ['FT.CURSOR', 'READ', 'index', '0']
+            );
+        });
+
+        it('with COUNT', () => {
+            assert.deepEqual(
+                transformArguments('index', 0, { COUNT: 1 }),
+                ['FT.CURSOR', 'READ', 'index', '0', 'COUNT', '1']
+            );
+        });
     });
 
     testUtils.testWithClient('client.ft.cursorRead', async client => {
-        const [ ,, { cursor } ] = await Promise.all([
+        const [, , { cursor }] = await Promise.all([
             client.ft.create('idx', {
                 field: {
                     type: SchemaFieldTypes.TEXT

--- a/packages/search/lib/commands/CURSOR_READ.ts
+++ b/packages/search/lib/commands/CURSOR_READ.ts
@@ -4,16 +4,27 @@ export const FIRST_KEY_INDEX = 1;
 
 export const IS_READ_ONLY = true;
 
+interface CursorReadOptions {
+    COUNT?: number;
+}
+
 export function transformArguments(
     index: RedisCommandArgument,
-    cursor: number
+    cursor: number,
+    options?: CursorReadOptions
 ): RedisCommandArguments {
-    return [
+    const args = [
         'FT.CURSOR',
         'READ',
         index,
         cursor.toString()
     ];
+
+    if (options?.COUNT) {
+        args.push('COUNT', options.COUNT.toString());
+    }
+
+    return args;
 }
 
 export { transformReply } from './AGGREGATE_WITHCURSOR';


### PR DESCRIPTION
### Description

The PR provides support for the COUNT argument in FT.CURSOR READ

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
