### PR TITLE
Add support for client reply command

### DIFF
--- a/packages/client/lib/client/commands.ts
+++ b/packages/client/lib/client/commands.ts
@@ -24,6 +24,7 @@ import * as CLIENT_KILL from '../commands/CLIENT_KILL';
 import * as CLIENT_LIST from '../commands/CLIENT_LIST';
 import * as CLIENT_NO_EVICT from '../commands/CLIENT_NO-EVICT';
 import * as CLIENT_PAUSE from '../commands/CLIENT_PAUSE';
+import * as CLIENT_REPLY from '../commands/CLIENT_REPLY';
 import * as CLIENT_SETNAME from '../commands/CLIENT_SETNAME';
 import * as CLIENT_TRACKING from '../commands/CLIENT_TRACKING';
 import * as CLIENT_TRACKINGINFO from '../commands/CLIENT_TRACKINGINFO';
@@ -170,6 +171,8 @@ export default {
     clientList: CLIENT_LIST,
     CLIENT_PAUSE,
     clientPause: CLIENT_PAUSE,
+    CLIENT_REPLY,
+    clientReply: CLIENT_REPLY,
     CLIENT_SETNAME,
     clientSetName: CLIENT_SETNAME,
     CLIENT_TRACKING,

--- a/packages/client/lib/commands/CLIENT_REPLY.spec.ts
+++ b/packages/client/lib/commands/CLIENT_REPLY.spec.ts
@@ -1,0 +1,35 @@
+import { strict as assert } from 'assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './CLIENT_REPLY';
+
+describe('CLIENT REPLY', () => {
+    describe('transformArguments', () => {
+        it('on', () => {
+            assert.deepEqual(
+                transformArguments('ON'),
+                ['CLIENT', 'REPLY', 'ON']
+            );
+        });
+
+        it('off', () => {
+            assert.deepEqual(
+                transformArguments('OFF'),
+                ['CLIENT', 'REPLY', 'OFF']
+            );
+        });
+
+        it('skip', () => {
+            assert.deepEqual(
+                transformArguments('SKIP'),
+                ['CLIENT', 'REPLY', 'SKIP']
+            );
+        });
+    });
+
+    testUtils.testWithClient('client.clientReply', async client => {
+        assert.equal(
+            await client.clientReply('ON'),
+            'OK'
+        );
+    }, GLOBAL.SERVERS.OPEN);
+});

--- a/packages/client/lib/commands/CLIENT_REPLY.ts
+++ b/packages/client/lib/commands/CLIENT_REPLY.ts
@@ -1,0 +1,13 @@
+import { RedisCommandArguments } from '.';
+
+export function transformArguments(
+    mode: 'ON' | 'OFF' | 'SKIP'
+): RedisCommandArguments {
+    return [
+        'CLIENT',
+        'REPLY',
+        mode
+    ];
+}
+
+export declare function transformReply(): null | 'OK';


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

Add support for [client reply](https://redis.io/commands/client-reply/) command. Fixes #1913.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Does `npm test` pass with this change (including linting)?
- [X] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
