### PR TITLE
fixes #2524 delaying graceful exit while pingInterval is set

### DIFF
--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -805,6 +805,7 @@ export default class RedisClient<
     }
 
     async disconnect(): Promise<void> {
+        if (this.#pingTimer) clearTimeout(this.#pingTimer);
         this.#queue.flushAll(new DisconnectsClientError());
         this.#socket.disconnect();
         await this.#destroyIsolationPool();

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -683,6 +683,7 @@ export default class RedisClient<
 
     QUIT(): Promise<string> {
         return this.#socket.quit(async () => {
+            if (this.#pingTimer) clearTimeout(this.#pingTimer);
             const quitPromise = this.#queue.addCommand<string>(['QUIT']);
             this.#tick();
             const [reply] = await Promise.all([


### PR DESCRIPTION
### Description

Fixes #2524 delaying graceful exit while pingInterval is set.

---

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?


