### PR TITLE
fix #1970 - add support for `RESTORE`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 This folder contains example scripts showing how to use Node Redis in different scenarios.
 
 | File Name                                | Description                                                                                                                                          |
-| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+|------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `blocking-list-pop.js`                   | Block until an element is pushed to a list.                                                                                                          |
 | `bloom-filter.js`                        | Space efficient set membership checks with a [Bloom Filter](https://en.wikipedia.org/wiki/Bloom_filter) using [RedisBloom](https://redisbloom.io).   |
 | `check-connection-status.js`             | Check the client's connection status.                                                                                                                |
@@ -12,6 +12,7 @@ This folder contains example scripts showing how to use Node Redis in different 
 | `connect-to-cluster.js`                  | Connect to a Redis cluster.                                                                                                                          |
 | `count-min-sketch.js`                    | Estimate the frequency of a given event using the [RedisBloom](https://redisbloom.io) Count-Min Sketch.                                              |
 | `cuckoo-filter.js`                       | Space efficient set membership checks with a [Cuckoo Filter](https://en.wikipedia.org/wiki/Cuckoo_filter) using [RedisBloom](https://redisbloom.io). |
+| `dump-and-restore.js`                    | Demonstrates the use of the [`DUMP`](https://redis.io/commands/dump/) and [`RESTORE`](https://redis.io/commands/restore/) commands                   |
 | `get-server-time.js`                     | Get the time from the Redis server.                                                                                                                  |
 | `hyperloglog.js`                         | Showing use of Hyperloglog commands [PFADD, PFCOUNT and PFMERGE](https://redis.io/commands/?group=hyperloglog).                                      |
 | `lua-multi-incr.js`                      | Define a custom lua script that allows you to perform INCRBY on multiple keys.                                                                       |

--- a/examples/dump-and-restore.js
+++ b/examples/dump-and-restore.js
@@ -1,4 +1,4 @@
-// This example demonstrates the use of DUMP and RESTORE functionalities
+// This example demonstrates the use of the DUMP and RESTORE commands
 
 import { commandOptions, createClient } from 'redis';
 
@@ -6,26 +6,17 @@ const client = createClient();
 await client.connect();
 
 // DUMP a specific key into a local variable
-const firstValueDump = await client.dump(
+const dump = await client.dump(
     commandOptions({ returnBuffers: true }),
-    'FirstKey'
+    'source'
 );
 
 // RESTORE into a new key
-await client.restore('newKey', 0, firstValueDump);
+await client.restore('destination', 0, dump);
 
-// DUMP a different key a local variable
-const secondValueDump = await client.dump(
-    commandOptions({ returnBuffers: true }),
-    'FirstKey'
-);
-
-// RESTORE into an existing key
-await client.restore('newKey', 0, secondValueDump, {
+// RESTORE and REPLACE an existing key
+await client.restore('destination', 0, dump, {
     REPLACE: true
 });
-
-// RESTORE into an new key with TTL
-await client.restore('TTLKey', 60000, secondValueDump);
 
 await client.quit();

--- a/examples/dump-and-restore.js
+++ b/examples/dump-and-restore.js
@@ -1,0 +1,31 @@
+// This example demonstrates the use of DUMP and RESTORE functionalities
+
+import { commandOptions, createClient } from 'redis';
+
+const client = createClient();
+await client.connect();
+
+// DUMP a specific key into a local variable
+const firstValueDump = await client.dump(
+    commandOptions({ returnBuffers: true }),
+    'FirstKey'
+);
+
+// RESTORE into a new key
+await client.restore('newKey', 0, firstValueDump);
+
+// DUMP a different key a local variable
+const secondValueDump = await client.dump(
+    commandOptions({ returnBuffers: true }),
+    'FirstKey'
+);
+
+// RESTORE into an existing key
+await client.restore('newKey', 0, secondValueDump, {
+    REPLACE: true
+});
+
+// RESTORE into an new key with TTL
+await client.restore('TTLKey', 60000, secondValueDump);
+
+await client.quit();

--- a/packages/client/lib/cluster/commands.ts
+++ b/packages/client/lib/cluster/commands.ts
@@ -110,6 +110,7 @@ import * as PTTL from '../commands/PTTL';
 import * as PUBLISH from '../commands/PUBLISH';
 import * as RENAME from '../commands/RENAME';
 import * as RENAMENX from '../commands/RENAMENX';
+import * as RESTORE from '../commands/RESTORE';
 import * as RPOP_COUNT from '../commands/RPOP_COUNT';
 import * as RPOP from '../commands/RPOP';
 import * as RPOPLPUSH from '../commands/RPOPLPUSH';
@@ -434,6 +435,8 @@ export default {
     rename: RENAME,
     RENAMENX,
     renameNX: RENAMENX,
+    RESTORE,
+    restore: RESTORE,
     RPOP_COUNT,
     rPopCount: RPOP_COUNT,
     RPOP,

--- a/packages/client/lib/commands/RESTORE.spec.ts
+++ b/packages/client/lib/commands/RESTORE.spec.ts
@@ -1,0 +1,127 @@
+import { strict as assert } from 'assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './RESTORE';
+
+describe('RESTORE', () => {
+    describe('transformArguments', () => {
+        it('parses ttl and value', () => {
+            assert.deepEqual(
+                transformArguments('KeyName', 0, '"\x00\x0bStringValue\n\x00\b\xebpW1H\x0c,"'),
+                ['RESTORE', 'KeyName', '0', '"\x00\x0bStringValue\n\x00\b\xebpW1H\x0c,"']
+            );
+        });
+
+        it('parses REPLACE', () => {
+            assert.deepEqual(
+                transformArguments('KeyName', 0, '"\x00\x0bStringValue\n\x00\b\xebpW1H\x0c,"', {
+                    REPLACE: true
+                }),
+                ['RESTORE', 'KeyName', '0', '"\x00\x0bStringValue\n\x00\b\xebpW1H\x0c,"', 'REPLACE']
+            );
+        });
+
+        it('parses ABSTTL', () => {
+            assert.deepEqual(
+                transformArguments('KeyName', 2693098555000, '"\x00\x0bStringValue\n\x00\b\xebpW1H\x0c,"', {
+                    ABSTTL: true
+                }),
+                ['RESTORE', 'KeyName', '2693098555000', '"\x00\x0bStringValue\n\x00\b\xebpW1H\x0c,"', 'ABSTTL']
+            );
+        });
+
+        it('parses IDLETIME', () => {
+            assert.deepEqual(
+                transformArguments('KeyName', 0, '"\x00\x0bStringValue\n\x00\b\xebpW1H\x0c,"', {
+                    IDLETIME: 5
+                }),
+                ['RESTORE', 'KeyName', '0', '"\x00\x0bStringValue\n\x00\b\xebpW1H\x0c,"', 'IDLETIME', '5']
+            );
+        });
+
+        it('parses FREQ', () => {
+            assert.deepEqual(
+                transformArguments('KeyName', 0, '"\x00\x0bStringValue\n\x00\b\xebpW1H\x0c,"', {
+                    FREQ: 5
+                }),
+                ['RESTORE', 'KeyName', '0', '"\x00\x0bStringValue\n\x00\b\xebpW1H\x0c,"', 'FREQ', '5']
+            );
+        });
+
+        it('parses REPLACE and ABSTTL', () => {
+            assert.deepEqual(
+                transformArguments('KeyName', 2693098555000, '"\x00\x0bStringValue\n\x00\b\xebpW1H\x0c,"', {
+                    REPLACE: true,
+                    ABSTTL: true
+                }),
+                ['RESTORE', 'KeyName', '2693098555000', '"\x00\x0bStringValue\n\x00\b\xebpW1H\x0c,"', 'REPLACE', 'ABSTTL']
+            );
+        });
+
+        it('parses REPLACE and IDLETIME', () => {
+            assert.deepEqual(
+                transformArguments('KeyName', 0, '"\x00\x0bStringValue\n\x00\b\xebpW1H\x0c,"', {
+                    REPLACE: true,
+                    IDLETIME: 5
+                }),
+                ['RESTORE', 'KeyName', '0', '"\x00\x0bStringValue\n\x00\b\xebpW1H\x0c,"', 'REPLACE', 'IDLETIME', '5']
+            );
+        });
+
+        it('parses REPLACE, ABSTTL, IDLETIME and FREQ', () => {
+            assert.deepEqual(
+                transformArguments('KeyName', 2693098555000, '"\x00\x0bStringValue\n\x00\b\xebpW1H\x0c,"', {
+                    REPLACE: true,
+                    ABSTTL: true,
+                    IDLETIME: 5,
+                    FREQ: 50
+                }),
+                ['RESTORE', 'KeyName', '2693098555000', '"\x00\x0bStringValue\n\x00\b\xebpW1H\x0c,"', 'REPLACE', 'ABSTTL', 'IDLETIME', '5', 'FREQ', '50']
+            );
+        });
+    });
+
+    describe('client.restore', () => {
+        testUtils.testWithClient('new key', async client => {
+            await client.set('oldKey', 'oldValue')
+            const dumpValue = await client.dump('oldKey');
+            assert.equal(
+                await client.restore('newKey', 0, dumpValue),
+                'OK'
+            );
+            assert.equal(
+                await client.get('newKey'),
+                'oldValue'
+            )
+        }, GLOBAL.SERVERS.OPEN);
+
+        
+        testUtils.testWithClient('crash on RESTORE for existing key', async client => {
+            await client.set('oldKey', 'oldValue')
+            await client.set('newKey', 'newValue')
+            const dumpValue = await client.dump('oldKey');
+            assert.rejects(
+                client.restore('newKey', 0, dumpValue),
+                {
+                    name: 'ErrorReply',
+                    message: 'BUSYKEY Target key name already exists.'
+                }
+            )
+        }, GLOBAL.SERVERS.OPEN);
+
+        testUtils.testWithClient('replace existing key', async client => {
+            await client.set('oldKey', 'oldValue')
+            await client.set('newKey', 'newValue')
+            const dumpValue = await client.dump('oldKey');
+            assert.equal(
+                await client.restore('newKey', 0, dumpValue, {
+                    REPLACE: true
+                }),
+                'OK'
+            );
+            assert.equal(
+                await client.get('newKey'),
+                'oldValue'
+            )
+        }, GLOBAL.SERVERS.OPEN);
+    })
+});

--- a/packages/client/lib/commands/RESTORE.spec.ts
+++ b/packages/client/lib/commands/RESTORE.spec.ts
@@ -63,7 +63,7 @@ describe('RESTORE', () => {
     testUtils.testWithClient('client.restore', async client => {
         const [, dump] = await Promise.all([
             client.set('source', 'value'),
-            client.dump('source')
+            client.dump(client.commandOptions({ returnBuffers: true }), 'source')
         ]);
 
         assert.equal(

--- a/packages/client/lib/commands/RESTORE.ts
+++ b/packages/client/lib/commands/RESTORE.ts
@@ -1,0 +1,37 @@
+import { RedisCommandArgument, RedisCommandArguments } from '.';
+
+interface RestoreOptions {
+    REPLACE?: true;
+    ABSTTL?: true;
+    IDLETIME?: number;
+    FREQ?: number;
+}
+
+export function transformArguments(
+    key: RedisCommandArgument,
+    ttl: number,
+    serializedValue: RedisCommandArgument,
+    options?: RestoreOptions
+): RedisCommandArguments {
+    const args =  ['RESTORE', key, ttl.toString(), serializedValue];
+
+    if (options?.REPLACE) {
+        args.push('REPLACE');
+    }
+
+    if (options?.ABSTTL) {
+        args.push('ABSTTL');
+    }
+
+    if (options?.IDLETIME) {
+        args.push('IDLETIME', options.IDLETIME.toString());
+    }
+
+    if (options?.FREQ) {
+        args.push('FREQ', options.FREQ.toString());
+    }
+
+    return args;
+}
+
+export declare function transformReply(): 'OK';

--- a/packages/client/lib/commands/RESTORE.ts
+++ b/packages/client/lib/commands/RESTORE.ts
@@ -1,5 +1,7 @@
 import { RedisCommandArgument, RedisCommandArguments } from '.';
 
+export const FIRST_KEY_INDEX = 1;
+
 interface RestoreOptions {
     REPLACE?: true;
     ABSTTL?: true;


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->
Currently, the DUMP command exists in the client, but there is no way to update the server with that dumped values.
The current pull request adds the RESTORE functionality and allows this.
It follows issue #1970 request.

> Describe your pull request here
- A new file that builds the RESTORE command line arguments.
- Update to the general client's commands list.
- A test file for the restore functionality (unit + integration).

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
