### PR TITLE
adding support for WITHSCORES for zrange command (updated from 6.2.0)

### DIFF
--- a/packages/client/lib/commands/ZRANGE.ts
+++ b/packages/client/lib/commands/ZRANGE.ts
@@ -12,6 +12,7 @@ interface ZRangeOptions {
         offset: number;
         count: number;
     };
+    WITHSCORES?: false
 }
 
 export function transformArguments(
@@ -43,6 +44,10 @@ export function transformArguments(
 
     if (options?.LIMIT) {
         args.push('LIMIT', options.LIMIT.offset.toString(), options.LIMIT.count.toString());
+    }
+
+    if (options?.WITHSCORES) {
+        args.push('WITHSCORES');
     }
 
     return args;


### PR DESCRIPTION
### Description

Since ZRangeByScore was deprecated from 6.2.0, I've added a small fix for ZRANGE command to allow the WITHSCORES argument
