### PR TITLE
Handle early server errors (issue #2417)

### DIFF
--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -248,7 +248,8 @@ export default class RedisClient<
     #initiateQueue(): RedisCommandsQueue {
         return new RedisCommandsQueue(
             this.#options?.commandsQueueMaxLength,
-            (channel, listeners) => this.emit('sharded-channel-moved', channel, listeners)
+            (channel, listeners) => this.emit('sharded-channel-moved', channel, listeners),
+            (err: Error) => this.emit('error', err)
         );
     }
 


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

This fixes a bug where the library does not handle early server errors such as `-DENIED` or `-ERR max number of clients reached`.

There may be a better way to do this, this is just a first stab that seems to work.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
