### PR TITLE
fix #1956 - add support for `LATENCY HISTORY`

### DIFF
--- a/packages/client/lib/client/commands.ts
+++ b/packages/client/lib/client/commands.ts
@@ -84,6 +84,7 @@ import * as KEYS from '../commands/KEYS';
 import * as LASTSAVE from '../commands/LASTSAVE';
 import * as LATENCY_DOCTOR from '../commands/LATENCY_DOCTOR';
 import * as LATENCY_GRAPH from '../commands/LATENCY_GRAPH';
+import * as LATENCY_HISTORY from '../commands/LATENCY_HISTORY';
 import * as LATENCY_LATEST from '../commands/LATENCY_LATEST';
 import * as LOLWUT from '../commands/LOLWUT';
 import * as MEMORY_DOCTOR from '../commands/MEMORY_DOCTOR';
@@ -291,6 +292,8 @@ export default {
     latencyDoctor: LATENCY_DOCTOR,
     LATENCY_GRAPH,
     latencyGraph: LATENCY_GRAPH,
+    LATENCY_HISTORY,
+    latencyHistory: LATENCY_HISTORY,
     LATENCY_LATEST,
     latencyLatest: LATENCY_LATEST,
     LOLWUT,

--- a/packages/client/lib/commands/LATENCY_HISTORY.spec.ts
+++ b/packages/client/lib/commands/LATENCY_HISTORY.spec.ts
@@ -1,0 +1,26 @@
+import {strict as assert} from 'assert';
+import testUtils, {GLOBAL} from '../test-utils';
+import { transformArguments } from './LATENCY_HISTORY';
+
+describe('LATENCY HISTORY', () => {
+    it('transformArguments', () => {
+        assert.deepEqual(
+            transformArguments('command'),
+            ['LATENCY', 'HISTORY', 'command']
+        );
+    });
+
+    testUtils.testWithClient('client.latencyHistory', async client => {
+        await Promise.all([
+            client.configSet('latency-monitor-threshold', '100'),
+            client.sendCommand(['DEBUG', 'SLEEP', '1'])
+        ]);
+        
+        const latencyHisRes = await client.latencyHistory('command');
+        assert.ok(Array.isArray(latencyHisRes));
+        for (const [timestamp, latency] of latencyHisRes) {
+            assert.equal(typeof timestamp, 'number');
+            assert.equal(typeof latency, 'number');
+        }
+    }, GLOBAL.SERVERS.OPEN);
+});

--- a/packages/client/lib/commands/LATENCY_HISTORY.ts
+++ b/packages/client/lib/commands/LATENCY_HISTORY.ts
@@ -1,25 +1,23 @@
-import { RedisCommandArguments } from ".";
+export type EventType = (
+    'active-defrag-cycle' |
+    'aof-fsync-always' |
+    'aof-stat' |
+    'aof-rewrite-diff-write' |
+    'aof-rename' |
+    'aof-write' |
+    'aof-write-active-child' |
+    'aof-write-alone' |
+    'aof-write-pending-fsync' |
+    'command' |
+    'expire-cycle' |
+    'eviction-cycle' |
+    'eviction-del' |
+    'fast-command' |
+    'fork' |
+    'rdb-unlink-temp-file'
+);
 
-export type EventType =
-    'active-defrag-cycle'
-    | 'aof-fsync-always'
-    | 'aof-stat'
-    | 'aof-rewrite-diff-write'
-    | 'aof-rename'
-    | 'aof-write'
-    | 'aof-write-active-child'
-    | 'aof-write-alone'
-    | 'aof-write-pending-fsync'
-    | 'command'
-    | 'expire-cycle'
-    | 'eviction-cycle'
-    | 'eviction-del'
-    | 'fast-command'
-    | 'fork'
-    | 'rdb-unlink-temp-file';
-
-
-export function transformArguments (event: EventType): RedisCommandArguments {
+export function transformArguments (event: EventType) {
     return ['LATENCY', 'HISTORY', event];
 }
 

--- a/packages/client/lib/commands/LATENCY_HISTORY.ts
+++ b/packages/client/lib/commands/LATENCY_HISTORY.ts
@@ -17,7 +17,7 @@ export type EventType = (
     'rdb-unlink-temp-file'
 );
 
-export function transformArguments (event: EventType) {
+export function transformArguments(event: EventType) {
     return ['LATENCY', 'HISTORY', event];
 }
 

--- a/packages/client/lib/commands/LATENCY_HISTORY.ts
+++ b/packages/client/lib/commands/LATENCY_HISTORY.ts
@@ -1,0 +1,29 @@
+import { RedisCommandArguments } from ".";
+
+export type EventType =
+    'active-defrag-cycle'
+    | 'aof-fsync-always'
+    | 'aof-stat'
+    | 'aof-rewrite-diff-write'
+    | 'aof-rename'
+    | 'aof-write'
+    | 'aof-write-active-child'
+    | 'aof-write-alone'
+    | 'aof-write-pending-fsync'
+    | 'command'
+    | 'expire-cycle'
+    | 'eviction-cycle'
+    | 'eviction-del'
+    | 'fast-command'
+    | 'fork'
+    | 'rdb-unlink-temp-file';
+
+
+export function transformArguments (event: EventType): RedisCommandArguments {
+    return ['LATENCY', 'HISTORY', event];
+}
+
+export declare function transformReply(): Array<[
+    timestamp: number,
+    latency: number,
+]>;


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

Its regarding issue https://github.com/redis/node-redis/issues/1956 request.
> Describe your pull request here

-  A new file that builds the LATENCY HISTORY command line arguments.
- Update to the general client's commands list.
- A test file for the latency history command

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
