### PR TITLE
Read vector example

### DIFF
--- a/examples/search-knn.js
+++ b/examples/search-knn.js
@@ -88,4 +88,22 @@ console.log(JSON.stringify(results, null, 2));
 //     }
 //   ]
 // }
+
+// The inverse of tobytes, for parsing results out of hget.
+const frombytes = (buffer) => {
+  const array = new Float32Array(buffer.length / 4);
+  for (let i = 0; i < array.length; i++) {
+    array[i] = buffer.readFloatLE(i * 4);
+  }
+  return array;
+};
+
+// An example of how to get a particular vector back out of Redis.
+const vector = await client.hGet(
+  commandOptions({ returnBuffers: true }),
+  'noderedis:knn:a',
+  'v'
+);
+console.log(frombytes(vector));
+
 await client.quit();


### PR DESCRIPTION
### Description

This adds a snippet to `examples/search-knn.js` that clarifies how one would read a vector back out of Redis after having stored it.

I had to do this myself in my app logic, after having gotten the vector similarity search basically working, as a means of checking whether a given vector had already been computed.

Closes #2566 

### Checklist

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?