### PR TITLE
 Have client.connect() return a Promise<RedisClient>

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,11 +51,9 @@ Looking for a high-level library to handle object mapping? See [redis-om-node](h
 ```typescript
 import { createClient } from 'redis';
 
-const client = createClient();
-
-client.on('error', err => console.log('Redis Client Error', err));
-
-await client.connect();
+const client = await createClient()
+  .on('error', err => console.log('Redis Client Error', err))
+  .connect();
 
 await client.set('key', 'value');
 const value = await client.get('key');
@@ -68,13 +66,6 @@ The above code connects to localhost on port 6379. To connect to a different hos
 createClient({
   url: 'redis://alice:foobared@awesome.redis.server:6380'
 });
-```
-
-You can create the client and connect it in a single line, but if you do so and it throws an error it will halt the whole Node process:
-
-```typescript
-// In this example an error connecting will throw
-const client = await createClient().connect();
 ```
 
 You can also use discrete parameters, UNIX sockets, and even TLS to connect. Details can be found in the [client configuration guide](./docs/client-configuration.md).

--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ createClient({
 });
 ```
 
+You can create the client and connect it in a single line, but if you do so and it throws an error it will halt the whole Node process:
+
+```typescript
+// In this example an error connecting will throw
+const client = await createClient().connect();
+```
+
 You can also use discrete parameters, UNIX sockets, and even TLS to connect. Details can be found in the [client configuration guide](./docs/client-configuration.md).
 
 To check if the the client is connected and ready to send commands, use `client.isReady` which returns a boolean. `client.isOpen` is also available.  This returns `true` when the client's underlying socket is open, and `false` when it isn't (for example when the client is still connecting or reconnecting after a network error).

--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -108,10 +108,12 @@ describe('Client', () => {
     });
 
     describe('connect', () => {
-        testUtils.testWithClient('connect returns an instance', async (client) => {
-            const client2 = await client.connect();
-            assert.equal(client, client2);
-            await client.disconnect();
+        testUtils.testWithClient('connect should return the clietn instance', async client => {
+            try {
+                assert.equal(await client.connect(), client);
+            } finally {
+                if (client.isOpen) await client.disconnect();
+            }
         }, {
             ...GLOBAL.SERVERS.PASSWORD,
             disableClientSetup: true

--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -112,7 +112,10 @@ describe('Client', () => {
             const client2 = await client.connect();
             assert.equal(client, client2);
             await client.disconnect();
-        }, GLOBAL.SERVERS.PASSWORD);
+        }, {
+            ...GLOBAL.SERVERS.PASSWORD,
+            disableClientSetup: true
+        });
     });
 
     describe('authentication', () => {

--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -107,6 +107,14 @@ describe('Client', () => {
         });
     });
 
+    describe('connect', () => {
+        testUtils.testWithClient('connect returns an instance', async (client) => {
+            const client2 = await client.connect();
+            assert.equal(client, client2);
+            await client.disconnect();
+        }, GLOBAL.SERVERS.PASSWORD);
+    });
+
     describe('authentication', () => {
         testUtils.testWithClient('Client should be authenticated', async client => {
             assert.equal(

--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -108,7 +108,7 @@ describe('Client', () => {
     });
 
     describe('connect', () => {
-        testUtils.testWithClient('connect should return the clietn instance', async client => {
+        testUtils.testWithClient('connect should return the client instance', async client => {
             try {
                 assert.equal(await client.connect(), client);
             } finally {

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -426,10 +426,11 @@ export default class RedisClient<
         });
     }
 
-    connect(): Promise<void> {
+    async connect(): Promise<RedisClient<M, F, S>> {
         // see comment in constructor
         this.#isolationPool ??= this.#initiateIsolationPool();
-        return this.#socket.connect();
+        await this.#socket.connect();
+        return this;
     }
 
     async commandsExecutor<C extends RedisCommand>(

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -426,11 +426,11 @@ export default class RedisClient<
         });
     }
 
-    async connect(): Promise<RedisClientType<M, F, S>> {
+    async connect() {
         // see comment in constructor
         this.#isolationPool ??= this.#initiateIsolationPool();
         await this.#socket.connect();
-        return this;
+        return this as unknown as RedisClientType<M, F, S>;
     }
 
     async commandsExecutor<C extends RedisCommand>(

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -426,7 +426,7 @@ export default class RedisClient<
         });
     }
 
-    async connect(): Promise<RedisClient<M, F, S>> {
+    async connect(): Promise<RedisClientType<M, F, S>> {
         // see comment in constructor
         this.#isolationPool ??= this.#initiateIsolationPool();
         await this.#socket.connect();


### PR DESCRIPTION
### Description

Make the `.connect()` method to return a promise with an instance of itself, so we can do:

```js
const client = await createClient().connect();
```

Issue: [ Have client.connect() return a `Promise<client>` instead of `Promise<void>`](https://github.com/redis/node-redis/issues/2601)

As explained above, added a case that simplifies the creation of the client for those who want to initialize AND connect at the same time, while retaining the ability to do so separately as before otherwise.

Added a test to make sure the return of `connet()` is the same client instance. I noticed there was no test explicitly for `.connect()`, so created it under the `describe('.connect()')` name.

---

### Checklist

- [x] Does `npm test` pass with this change (including linting)? ([tests](https://github.com/franciscop/node-redis/actions/runs/5911314679))
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?