### PR TITLE
Add support for `JSON.MSET`

### DIFF
--- a/packages/json/lib/commands/MSET.spec.ts
+++ b/packages/json/lib/commands/MSET.spec.ts
@@ -1,0 +1,19 @@
+import { strict as assert } from 'assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './MSET';
+
+describe('MSET', () => {
+    it('transformArguments', () => {
+        assert.deepEqual(
+            transformArguments(['1', '2'], '$', [{ a: 1 }, { b: 2 }]),
+            ['JSON.MSET', '1', '$', '{ "a":"1" } ', '2', '$', '{ "b":"2"} ']
+        );
+    });
+
+    testUtils.testWithClient('client.json.mGet', async client => {
+        assert.deepEqual(
+            await client.json.mGet(["1", "2"], "$", [{ a: 1 }, { b: 2 }]),
+          [null, null]
+        );
+    }, GLOBAL.SERVERS.OPEN);
+});

--- a/packages/json/lib/commands/MSET.spec.ts
+++ b/packages/json/lib/commands/MSET.spec.ts
@@ -5,15 +5,31 @@ import { transformArguments } from './MSET';
 describe('MSET', () => {
     it('transformArguments', () => {
         assert.deepEqual(
-            transformArguments(['1', '2'], '$', [{ a: 1 }, { b: 2 }]),
-            ['JSON.MSET', '1', '$', '{ "a":"1" } ', '2', '$', '{ "b":"2"} ']
+            transformArguments([{
+                key: '1',
+                path: '$',
+                value: 1
+            }, {
+                key: '2',
+                path: '$',
+                value: '2'
+            }]),
+            ['JSON.MSET', '1', '$', '1', '2', '$', '"2"']
         );
     });
 
-    testUtils.testWithClient('client.json.mGet', async client => {
+    testUtils.testWithClient('client.json.mSet', async client => {
         assert.deepEqual(
-            await client.json.mGet(["1", "2"], "$", [{ a: 1 }, { b: 2 }]),
-          [null, null]
+            await client.json.mSet([{
+                key: '1',
+                path: '$',
+                value: 1
+            }, {
+                key: '2',
+                path: '$',
+                value: '2'
+            }]),
+            'OK'
         );
     }, GLOBAL.SERVERS.OPEN);
 });

--- a/packages/json/lib/commands/MSET.ts
+++ b/packages/json/lib/commands/MSET.ts
@@ -18,7 +18,7 @@ export function transformArguments(items: Array<JsonMSetItem>): Array<string> {
         const item = items[i];
         args[argsIndex++] = item.key;
         args[argsIndex++] = item.path;
-        args[argsIndex++] = transformRedisJsonArgument(item.json);
+        args[argsIndex++] = transformRedisJsonArgument(item.value);
     }
 
     return args;

--- a/packages/json/lib/commands/MSET.ts
+++ b/packages/json/lib/commands/MSET.ts
@@ -1,5 +1,5 @@
 import { RedisJSON, transformRedisJsonArgument } from '.';
-import { RedisCommandArgument, RedisCommandArguments } from '@redis/client/dist/lib/commands';
+import { RedisCommandArgument } from '@redis/client/dist/lib/commands';
 
 export const FIRST_KEY_INDEX = 1;
 
@@ -10,6 +10,7 @@ interface JsonMSetItem {
 }
 
 export function transformArguments(items: Array<JsonMSetItem>): Array<string> {
+  
     const args = new Array(1 + items.length * 3);
     args[0] = 'JSON.MSET';
 

--- a/packages/json/lib/commands/MSET.ts
+++ b/packages/json/lib/commands/MSET.ts
@@ -1,0 +1,24 @@
+import { RedisJSON, transformRedisJsonArgument } from ".";
+
+export const FIRST_KEY_INDEX = 1;
+
+export function transformArguments(
+    keys: Array<string>,
+    path: string,
+    json: Array<RedisJSON>
+): Array<string> {
+    
+    if (keys.length != json.length)
+        throw new Error("Number of keys and json objects must be equal");
+
+    let args: Array<string> = ["JSON.SET"];
+
+    // walk through the key array, adding the key, the path and the json objects, calling transformRedisJsonArgument for each
+    for (let i = 0; i < keys.length; i++) {
+        args.push(keys[i], path, transformRedisJsonArgument(json[i]));
+    }
+
+    return args;
+}
+
+export declare function transformReply(): "OK" | null;

--- a/packages/json/lib/commands/MSET.ts
+++ b/packages/json/lib/commands/MSET.ts
@@ -1,24 +1,27 @@
-import { RedisJSON, transformRedisJsonArgument } from ".";
+import { RedisJSON, transformRedisJsonArgument } from '.';
+import { RedisCommandArgument, RedisCommandArguments } from '@redis/client/dist/lib/commands';
 
 export const FIRST_KEY_INDEX = 1;
 
-export function transformArguments(
-    keys: Array<string>,
-    path: string,
-    json: Array<RedisJSON>
-): Array<string> {
-    
-    if (keys.length != json.length)
-        throw new Error("Number of keys and json objects must be equal");
+interface JsonMSetItem {
+    key: RedisCommandArgument;
+    path: RedisCommandArgument;
+    value: RedisJSON;
+}
 
-    let args: Array<string> = ["JSON.SET"];
+export function transformArguments(items: Array<JsonMSetItem>): Array<string> {
+    const args = new Array(1 + items.length * 3);
+    args[0] = 'JSON.MSET';
 
-    // walk through the key array, adding the key, the path and the json objects, calling transformRedisJsonArgument for each
-    for (let i = 0; i < keys.length; i++) {
-        args.push(keys[i], path, transformRedisJsonArgument(json[i]));
+    let argsIndex = 1;
+    for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        args[argsIndex++] = item.key;
+        args[argsIndex++] = item.path;
+        args[argsIndex++] = transformRedisJsonArgument(item.json);
     }
 
     return args;
 }
 
-export declare function transformReply(): "OK" | null;
+export declare function transformReply(): 'OK';

--- a/packages/json/lib/commands/index.ts
+++ b/packages/json/lib/commands/index.ts
@@ -9,6 +9,7 @@ import * as DEL from './DEL';
 import * as FORGET from './FORGET';
 import * as GET from './GET';
 import * as MGET from './MGET';
+import * as MSET from './MSET';
 import * as NUMINCRBY from './NUMINCRBY';
 import * as NUMMULTBY from './NUMMULTBY';
 import * as OBJKEYS from './OBJKEYS';
@@ -42,6 +43,8 @@ export default {
     get: GET,
     MGET,
     mGet: MGET,
+    MSET,
+    mSet: MSET,
     NUMINCRBY,
     numIncrBy: NUMINCRBY,
     NUMMULTBY,


### PR DESCRIPTION
MSET command added. Requires all keys to have the same JSON Path, which might fit most use cases, but is a limitation.  Optionally we could make the path an array as well to support all use cases.

### Description

Adding support for JSON.MSET - this implementation uses a single path, which may be limiting. If desired we could make this an array as well.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
