### PR TITLE
Add support for `FT.SEARCH NOCONTENT`

### DIFF
--- a/packages/search/lib/commands/SEARCH.spec.ts
+++ b/packages/search/lib/commands/SEARCH.spec.ts
@@ -12,6 +12,13 @@ describe('SEARCH', () => {
             );
         });
 
+        it('with NOCONTENT', () => {
+            assert.deepEqual(
+                transformArguments('index', 'query', { NOCONTENT: true }),
+                ['FT.SEARCH', 'index', 'query', 'NOCONTENT']
+            );
+        });
+
         it('with VERBATIM', () => {
             assert.deepEqual(
                 transformArguments('index', 'query', { VERBATIM: true }),

--- a/packages/search/lib/commands/SEARCH.spec.ts
+++ b/packages/search/lib/commands/SEARCH.spec.ts
@@ -12,13 +12,6 @@ describe('SEARCH', () => {
             );
         });
 
-        it('with NOCONTENT', () => {
-            assert.deepEqual(
-                transformArguments('index', 'query', { NOCONTENT: true }),
-                ['FT.SEARCH', 'index', 'query', 'NOCONTENT']
-            );
-        });
-
         it('with VERBATIM', () => {
             assert.deepEqual(
                 transformArguments('index', 'query', { VERBATIM: true }),

--- a/packages/search/lib/commands/SEARCH.ts
+++ b/packages/search/lib/commands/SEARCH.ts
@@ -6,7 +6,7 @@ export const FIRST_KEY_INDEX = 1;
 export const IS_READ_ONLY = true;
 
 export interface SearchOptions {
-    // NOCONTENT?: true; TODO
+    NOCONTENT?: true;
     VERBATIM?: true;
     NOSTOPWORDS?: true;
     // WITHSCORES?: true;

--- a/packages/search/lib/commands/SEARCH.ts
+++ b/packages/search/lib/commands/SEARCH.ts
@@ -6,7 +6,6 @@ export const FIRST_KEY_INDEX = 1;
 export const IS_READ_ONLY = true;
 
 export interface SearchOptions {
-    NOCONTENT?: true;
     VERBATIM?: true;
     NOSTOPWORDS?: true;
     // WITHSCORES?: true;

--- a/packages/search/lib/commands/SEARCH_NOCONTENT.spec.ts
+++ b/packages/search/lib/commands/SEARCH_NOCONTENT.spec.ts
@@ -1,0 +1,36 @@
+import { strict as assert } from 'assert';
+import { SchemaFieldTypes } from '.';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './SEARCH_NOCONTENT';
+
+describe('SEARCH_NOCONTENT', () => {
+    describe('transformArguments', () => {
+        it('without options', () => {
+            assert.deepEqual(
+                transformArguments('index', 'query'),
+                ['FT.SEARCH', 'index', 'query', 'NOCONTENT']
+            );
+        });
+    });
+
+    describe('client.ft.searchNoContent', () => {
+        testUtils.testWithClient('returns total and keys', async client => {
+            await Promise.all([
+                client.ft.create('index', {
+                    field: SchemaFieldTypes.NUMERIC
+                }),
+                client.hSet('1', 'field', 'field1'),
+                client.hSet('2', 'field', 'field2'),
+                client.hSet('3', 'field', 'field3')
+            ]);
+
+            assert.deepEqual(
+                await client.ft.searchNoContent('index', '*'),
+                {
+                    total: 3,
+                    documents: ['1','2','3']
+                }
+            );
+        }, GLOBAL.SERVERS.OPEN);
+    });
+});

--- a/packages/search/lib/commands/SEARCH_NOCONTENT.spec.ts
+++ b/packages/search/lib/commands/SEARCH_NOCONTENT.spec.ts
@@ -26,7 +26,7 @@ describe('SEARCH_NOCONTENT', () => {
         testUtils.testWithClient('returns total and keys', async client => {
             await Promise.all([
                 client.ft.create('index', {
-                    field: SchemaFieldTypes.NUMERIC
+                    field: SchemaFieldTypes.TEXT
                 }),
                 client.hSet('1', 'field', 'field1'),
                 client.hSet('2', 'field', 'field2'),

--- a/packages/search/lib/commands/SEARCH_NOCONTENT.spec.ts
+++ b/packages/search/lib/commands/SEARCH_NOCONTENT.spec.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
 import { SchemaFieldTypes } from '.';
 import testUtils, { GLOBAL } from '../test-utils';
-import { transformArguments } from './SEARCH_NOCONTENT';
+import { transformArguments, transformReply } from './SEARCH_NOCONTENT';
 
 describe('SEARCH_NOCONTENT', () => {
     describe('transformArguments', () => {
@@ -13,7 +13,16 @@ describe('SEARCH_NOCONTENT', () => {
         });
     });
 
-    describe('client.ft.searchNoContent', () => {
+    describe('transformReply', () => {
+        it('returns total and keys', () => {
+            assert.deepEqual(transformReply([3, '1', '2', '3']), {
+                total: 3,
+                documents: ['1', '2', '3']
+            })
+        });
+    });
+
+    describe.skip('client.ft.searchNoContent', () => {
         testUtils.testWithClient('returns total and keys', async client => {
             await Promise.all([
                 client.ft.create('index', {

--- a/packages/search/lib/commands/SEARCH_NOCONTENT.spec.ts
+++ b/packages/search/lib/commands/SEARCH_NOCONTENT.spec.ts
@@ -22,7 +22,7 @@ describe('SEARCH_NOCONTENT', () => {
         });
     });
 
-    describe.skip('client.ft.searchNoContent', () => {
+    describe('client.ft.searchNoContent', () => {
         testUtils.testWithClient('returns total and keys', async client => {
             await Promise.all([
                 client.ft.create('index', {

--- a/packages/search/lib/commands/SEARCH_NOCONTENT.ts
+++ b/packages/search/lib/commands/SEARCH_NOCONTENT.ts
@@ -1,0 +1,30 @@
+import { RedisCommandArguments } from "@redis/client/dist/lib/commands";
+import { pushSearchOptions } from ".";
+import { SearchOptions, SearchRawReply } from "./SEARCH";
+
+export const FIRST_KEY_INDEX = 1;
+
+export const IS_READ_ONLY = true;
+
+export function transformArguments(
+    index: string,
+    query: string,
+    options?: SearchOptions
+): RedisCommandArguments {
+    return pushSearchOptions(
+        ['FT.SEARCH', index, query, 'NOCONTENT'],
+        options
+    );
+}
+
+export interface SearchNonContentReply {
+    total: number;
+    documents: Array<string>;
+};
+
+export function transformReply(reply: SearchRawReply): SearchNonContentReply {
+    return {
+        total: reply[0],
+        documents: reply.slice(1)
+    };
+}

--- a/packages/search/lib/commands/SEARCH_NOCONTENT.ts
+++ b/packages/search/lib/commands/SEARCH_NOCONTENT.ts
@@ -17,12 +17,12 @@ export function transformArguments(
     );
 }
 
-export interface SearchNonContentReply {
+export interface SearchNoContentReply {
     total: number;
     documents: Array<string>;
 };
 
-export function transformReply(reply: SearchRawReply): SearchNonContentReply {
+export function transformReply(reply: SearchRawReply): SearchNoContentReply {
     return {
         total: reply[0],
         documents: reply.slice(1)

--- a/packages/search/lib/commands/index.ts
+++ b/packages/search/lib/commands/index.ts
@@ -395,6 +395,10 @@ export function pushSearchOptions(
     args: RedisCommandArguments,
     options?: SearchOptions
 ): RedisCommandArguments {
+    if (options?.NOCONTENT) {
+        args.push('NOCONTENT');
+    }
+
     if (options?.VERBATIM) {
         args.push('VERBATIM');
     }

--- a/packages/search/lib/commands/index.ts
+++ b/packages/search/lib/commands/index.ts
@@ -20,6 +20,7 @@ import * as INFO from './INFO';
 import * as PROFILESEARCH from './PROFILE_SEARCH';
 import * as PROFILEAGGREGATE from './PROFILE_AGGREGATE';
 import * as SEARCH from './SEARCH';
+import * as SEARCH_NOCONTENT from './SEARCH_NOCONTENT';
 import * as SPELLCHECK from './SPELLCHECK';
 import * as SUGADD from './SUGADD';
 import * as SUGDEL from './SUGDEL';
@@ -80,6 +81,8 @@ export default {
     profileAggregate: PROFILEAGGREGATE,
     SEARCH,
     search: SEARCH,
+    SEARCH_NOCONTENT,
+    searchNoContent: SEARCH_NOCONTENT,
     SPELLCHECK,
     spellCheck: SPELLCHECK,
     SUGADD,
@@ -395,10 +398,6 @@ export function pushSearchOptions(
     args: RedisCommandArguments,
     options?: SearchOptions
 ): RedisCommandArguments {
-    if (options?.NOCONTENT) {
-        args.push('NOCONTENT');
-    }
-
     if (options?.VERBATIM) {
         args.push('VERBATIM');
     }


### PR DESCRIPTION
### Description
This PR implements the TODO item at 
 
https://github.com/redis/node-redis/blob/294cbf8367295ac81cbe51ce2932493ab80493f1/packages/search/lib/commands/SEARCH.ts#L9

Similar to [#2488
](https://github.com/redis/node-redis/pull/2488)

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
