### PR TITLE
Creating CODEOWNERS for documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+doctests/* @dmaier-redislabs


### PR DESCRIPTION
This pull request uses the [CODEOWNERS mechanism](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) to define a dedicated owner for the redis.io examples. Ultimately, the people in this file should be able to override CI based on possible false positives in tests, if they are unrelated.