### PR TITLE
fix `cluster.sUnsubscribe` - make `listener` optional

### DIFF
--- a/packages/client/lib/cluster/index.ts
+++ b/packages/client/lib/cluster/index.ts
@@ -20,12 +20,12 @@ export interface RedisClusterOptions<
     S extends RedisScripts = Record<string, never>
 > extends RedisExtensions<M, F, S> {
     /**
-     * Should contain details for some of the cluster nodes that the client will use to discover 
+     * Should contain details for some of the cluster nodes that the client will use to discover
      * the "cluster topology". We recommend including details for at least 3 nodes here.
      */
     rootNodes: Array<RedisClusterClientOptions>;
     /**
-     * Default values used for every client in the cluster. Use this to specify global values, 
+     * Default values used for every client in the cluster. Use this to specify global values,
      * for example: ACL credentials, timeouts, TLS configuration etc.
      */
     defaults?: Partial<RedisClusterClientOptions>;
@@ -45,7 +45,7 @@ export interface RedisClusterOptions<
     /**
      * Mapping between the addresses in the cluster (see `CLUSTER SHARDS`) and the addresses the client should connect to
      * Useful when the cluster is running on another network
-     * 
+     *
      */
     nodeAddressMap?: NodeAddressMap;
 }
@@ -98,7 +98,7 @@ export default class RedisCluster<
     readonly #options: RedisClusterOptions<M, F, S>;
 
     readonly #slots: RedisClusterSlots<M, F, S>;
-    
+
     get slots() {
         return this.#slots.slots;
     }
@@ -310,7 +310,7 @@ export default class RedisCluster<
         listener?: PubSubListener<boolean>,
         bufferMode?: T
     ) {
-        return this.#slots.executeUnsubscribeCommand(client => 
+        return this.#slots.executeUnsubscribeCommand(client =>
             client.UNSUBSCRIBE(channels, listener, bufferMode)
         );
     }
@@ -333,7 +333,7 @@ export default class RedisCluster<
         listener?: PubSubListener<T>,
         bufferMode?: T
     ) {
-        return this.#slots.executeUnsubscribeCommand(client => 
+        return this.#slots.executeUnsubscribeCommand(client =>
             client.PUNSUBSCRIBE(patterns, listener, bufferMode)
         );
     }
@@ -344,7 +344,7 @@ export default class RedisCluster<
         channels: string | Array<string>,
         listener: PubSubListener<T>,
         bufferMode?: T
-    ) { 
+    ) {
         const maxCommandRedirections = this.#options.maxCommandRedirections ?? 16,
             firstChannel = Array.isArray(channels) ? channels[0] : channels;
         let client = await this.#slots.getShardedPubSubClient(firstChannel);
@@ -371,7 +371,7 @@ export default class RedisCluster<
 
     SUNSUBSCRIBE<T extends boolean = false>(
         channels: string | Array<string>,
-        listener: PubSubListener<T>,
+        listener?: PubSubListener<T>,
         bufferMode?: T
     ) {
         return this.#slots.executeShardedUnsubscribeCommand(
@@ -391,7 +391,7 @@ export default class RedisCluster<
     }
 
     nodeClient(node: ShardNode<M, F, S>) {
-        return this.#slots.nodeClient(node); 
+        return this.#slots.nodeClient(node);
     }
 
     getRandomNode() {


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
- I don't see any good reason for cluster.client.sUnsubscribe function must hasve listener.
- So, I changed cluster.client.sUnsubscribe definition. (Make listener optional)
<!-- Why does it matter to you? What problem are you trying to solve? -->
- When sUnsubscribe is called, client.unsubscribe is called. [#](https://github.com/redis/node-redis/blob/master/packages/client/lib/cluster/cluster-slots.ts#L608)
- It finally goes to pubSub.unsubscribe. [#](https://github.com/redis/node-redis/blob/master/packages/client/lib/client/pub-sub.ts#L209)
- If we register listener on sUnsubscribe, pubSubClient's isActive is true due to pre-registered listener. [#](https://github.com/redis/node-redis/blob/master/packages/client/lib/client/pub-sub.ts#L258)
- So, command is not actually issued. [#](https://github.com/redis/node-redis/blob/master/packages/client/lib/client/pub-sub.ts#L263)
- And, also not disconnected. [#](https://github.com/redis/node-redis/blob/master/packages/client/lib/cluster/cluster-slots.ts#L616)
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
