### PR TITLE
Send client user-agent during connection, via CLIENT SETINFO

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -139,7 +139,7 @@ describe('Client', () => {
         }, {
             ...GLOBAL.SERVERS.PASSWORD,
             clientOptions: {
-     1           ...GLOBAL.SERVERS.PASSWORD.clientOptions,
+                ...GLOBAL.SERVERS.PASSWORD.clientOptions,
                 disableClientInfo: true
             },
             minimumDockerVersion: [7, 2]

--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -10,6 +10,8 @@ import { once } from 'events';
 import { ClientKillFilters } from '../commands/CLIENT_KILL';
 import { promisify } from 'util';
 
+import {version} from '../../package.json';
+
 export const SQUARE_SCRIPT = defineScript({
     SCRIPT: 'return ARGV[1] * ARGV[1];',
     NUMBER_OF_KEYS: 0,
@@ -117,6 +119,44 @@ describe('Client', () => {
         }, {
             ...GLOBAL.SERVERS.PASSWORD,
             disableClientSetup: true
+        });
+
+        testUtils.testWithClient('should set default lib name and version', async client => {
+            const clientInfo = await client.clientInfo();
+
+            assert.equal(clientInfo.libName, 'node-redis');
+            assert.equal(clientInfo.libVer, version);
+        }, {
+            ...GLOBAL.SERVERS.PASSWORD,
+            minimumDockerVersion: [7, 2]
+        });
+
+        testUtils.testWithClient('disable sending lib name and version', async client => {
+            const clientInfo = await client.clientInfo();
+
+            assert.equal(clientInfo.libName, '');
+            assert.equal(clientInfo.libVer, '');
+        }, {
+            ...GLOBAL.SERVERS.PASSWORD,
+            clientOptions: {
+     1           ...GLOBAL.SERVERS.PASSWORD.clientOptions,
+                disableClientInfo: true
+            },
+            minimumDockerVersion: [7, 2]
+        });
+
+        testUtils.testWithClient('send client name tag', async client => {
+            const clientInfo = await client.clientInfo();
+
+            assert.equal(clientInfo.libName, 'node-redis(test)');
+            assert.equal(clientInfo.libVer, version);
+        }, {
+            ...GLOBAL.SERVERS.PASSWORD,
+            clientOptions: {
+                ...GLOBAL.SERVERS.PASSWORD.clientOptions,
+                clientInfoTag: "test"
+            },
+            minimumDockerVersion: [7, 2]
         });
     });
 

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -69,7 +69,7 @@ export interface RedisClientOptions<
      */
     pingInterval?: number;
     /**
-     * Don't send client info to Redis server
+     * If set to true, disables sending client identifier (user-agent like message) to the redis server
      */
     disableClientInfo?: boolean;
     /**

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -11,10 +11,12 @@ import { ScanCommandOptions } from '../commands/SCAN';
 import { HScanTuple } from '../commands/HSCAN';
 import { attachCommands, attachExtensions, fCallArguments, transformCommandArguments, transformCommandReply, transformLegacyCommandArguments } from '../commander';
 import { Pool, Options as PoolOptions, createPool } from 'generic-pool';
-import { ClientClosedError, ClientOfflineError, DisconnectsClientError } from '../errors';
+import { ClientClosedError, ClientOfflineError, DisconnectsClientError, ErrorReply } from '../errors';
 import { URL } from 'url';
 import { TcpSocketConnectOpts } from 'net';
 import { PubSubType, PubSubListener, PubSubTypeListeners, ChannelListeners } from './pub-sub';
+
+import {version} from '../../package.json';
 
 export interface RedisClientOptions<
     M extends RedisModules = RedisModules,
@@ -66,6 +68,14 @@ export interface RedisClientOptions<
      * Useful with Redis deployments that do not use TCP Keep-Alive.
      */
     pingInterval?: number;
+    /**
+     * Don't send client info to Redis server
+     */
+    disableClientInfo?: boolean;
+    /**
+     * Tag to append to library name that is sent to the Redis server
+     */
+    clientInfoTag?: string;
 }
 
 type WithCommands = {
@@ -273,6 +283,33 @@ export default class RedisClient<
                     )
                 );
             }
+
+            if (!this.#options?.disableClientInfo) {
+                promises.push(
+                    this.#queue.addCommand(
+                        [  'CLIENT', 'SETINFO', 'LIB-VER', version],
+                        { asap: true }
+                    ).catch(err => {
+                        if (!(err instanceof ErrorReply)) {
+                            throw err;
+                        }
+                    })
+                );
+
+                promises.push(
+                    this.#queue.addCommand(
+                        [
+                           'CLIENT', 'SETINFO', 'LIB-NAME',
+                            this.#options?.clientInfoTag ? `node-redis(${this.#options.clientInfoTag})` : 'node-redis'
+                        ],
+                        { asap: true }
+                    ).catch(err => {
+                        if (!(err instanceof ErrorReply)) {
+                            throw err;
+                        }
+                    })
+                );
+              }
 
             if (this.#options?.name) {
                 promises.push(

--- a/packages/client/lib/commands/CLIENT_INFO.ts
+++ b/packages/client/lib/commands/CLIENT_INFO.ts
@@ -31,6 +31,9 @@ export interface ClientInfoReply {
     user?: string; // 6.0
     redir?: number; // 6.2
     resp?: number; // 7.0
+    // 7.2
+    libName?: string;
+    libVer?: string;
 }
 
 const CLIENT_INFO_REGEX = /([^\s=]+)=([^\s]*)/g;
@@ -62,7 +65,9 @@ export function transformReply(rawReply: string): ClientInfoReply {
         totMem: Number(map['tot-mem']),
         events: map.events,
         cmd: map.cmd,
-        user: map.user
+        user: map.user,
+        libName: map['lib-name'],
+        libVer: map['lib-ver'],
     };
 
     if (map.laddr !== undefined) {

--- a/packages/client/lib/test-utils.ts
+++ b/packages/client/lib/test-utils.ts
@@ -4,7 +4,8 @@ import { promiseTimeout } from './utils';
 
 const utils = new TestUtils({
   dockerImageName: 'redis',
-  dockerImageVersionArgument: 'redis-version'
+  dockerImageVersionArgument: 'redis-version',
+  defaultDockerVersion: '7.2'
 });
 
 export default utils;

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -5,7 +5,8 @@
   },
   "include": [
     "./index.ts",
-    "./lib/**/*.ts"
+    "./lib/**/*.ts",
+    "./package.json"
   ],
   "exclude": [
     "./lib/test-utils.ts",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -4,7 +4,8 @@
     "declaration": true,
     "allowJs": true,
     "useDefineForClassFields": true,
-    "esModuleInterop": false
+    "esModuleInterop": false,
+    "resolveJsonModule": true
   },
   "ts-node": {
     "files": true


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

client is able to provide it's "user agent" to redis server.

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

closes #2573 
closes #2612 
closes #2456 