### PR TITLE
Add latency reset command

### DIFF
--- a/packages/client/lib/client/commands.ts
+++ b/packages/client/lib/client/commands.ts
@@ -88,6 +88,7 @@ import * as LATENCY_DOCTOR from '../commands/LATENCY_DOCTOR';
 import * as LATENCY_GRAPH from '../commands/LATENCY_GRAPH';
 import * as LATENCY_HISTORY from '../commands/LATENCY_HISTORY';
 import * as LATENCY_LATEST from '../commands/LATENCY_LATEST';
+import * as LATENCY_RESET from '../commands/LATENCY_RESET';
 import * as LOLWUT from '../commands/LOLWUT';
 import * as MEMORY_DOCTOR from '../commands/MEMORY_DOCTOR';
 import * as MEMORY_MALLOC_STATS from '../commands/MEMORY_MALLOC-STATS';
@@ -303,6 +304,8 @@ export default {
     latencyHistory: LATENCY_HISTORY,
     LATENCY_LATEST,
     latencyLatest: LATENCY_LATEST,
+    LATENCY_RESET,
+    latencyReset: LATENCY_RESET,
     LOLWUT,
     lolwut: LOLWUT,
     MEMORY_DOCTOR,

--- a/packages/client/lib/commands/LATENCY_RESET.spec.ts
+++ b/packages/client/lib/commands/LATENCY_RESET.spec.ts
@@ -1,0 +1,21 @@
+import { strict as assert } from "assert";
+import testUtils, { GLOBAL } from "../test-utils";
+import { transformArguments } from "./LATENCY_RESET";
+
+describe("LATENCY RESET", () => {
+  it("transformArguments", () => {
+    assert.deepEqual(transformArguments("command"), ["LATENCY", "RESET", "command"]);
+    assert.deepEqual(transformArguments(), ["LATENCY", "RESET"]);
+    assert.deepEqual(transformArguments(["command", "aof-stat"]), ["LATENCY", "RESET", "command", "aof-stat"]);
+  });
+
+  testUtils.testWithClient(
+    "client.latencyReset",
+    async (client) => {
+      await Promise.all([client.configSet("latency-monitor-threshold", "1"), client.sendCommand(["DEBUG", "SLEEP", "0.001"])]);
+
+      assert.equal(typeof (await client.latencyReset("command")), "number");
+    },
+    GLOBAL.SERVERS.OPEN
+  );
+});

--- a/packages/client/lib/commands/LATENCY_RESET.ts
+++ b/packages/client/lib/commands/LATENCY_RESET.ts
@@ -1,0 +1,28 @@
+import { RedisCommandArguments } from ".";
+import { pushVerdictArguments } from "./generic-transformers";
+
+export type EventType =
+  | "active-defrag-cycle"
+  | "aof-fsync-always"
+  | "aof-stat"
+  | "aof-rewrite-diff-write"
+  | "aof-rename"
+  | "aof-write"
+  | "aof-write-active-child"
+  | "aof-write-alone"
+  | "aof-write-pending-fsync"
+  | "command"
+  | "expire-cycle"
+  | "eviction-cycle"
+  | "eviction-del"
+  | "fast-command"
+  | "fork"
+  | "rdb-unlink-temp-file";
+
+export function transformArguments(events?: EventType | Array<EventType>): RedisCommandArguments {
+  if (events === undefined) return ["LATENCY", "RESET"];
+
+  return pushVerdictArguments(["LATENCY", "RESET"], events);
+}
+
+export declare function transformReply(): number;


### PR DESCRIPTION
### Description

Issue: #1958 

I have added the implementation of the following command to the project [LATENCY RESET](https://redis.io/commands/latency-reset/).

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
