### PR TITLE
support timeseries array labels

### DIFF
--- a/packages/time-series/lib/commands/index.ts
+++ b/packages/time-series/lib/commands/index.ts
@@ -179,7 +179,7 @@ export function pushDuplicatePolicy(args: RedisCommandArguments, duplicatePolicy
 export type RawLabels = Array<[label: string, value: string]>;
 
 export type Labels = {
-    [label: string]: string;
+    [label: string]: string | Array<string>;
 };
 
 export function transformLablesReply(reply: RawLabels): Labels {
@@ -197,7 +197,13 @@ export function pushLabelsArgument(args: RedisCommandArguments, labels?: Labels)
         args.push('LABELS');
 
         for (const [label, value] of Object.entries(labels)) {
-            args.push(label, value);
+            if (Array.isArray(value)) {
+                for (const item of value) {
+                    args.push(label, item);
+                }
+            } else {
+                args.push(label, value);
+            }
         }
     }
 


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

purpose:
support timeseries array labels

problem:
currently `client.ts.create()` is allow `LABELS` options for only  `{ [key: string]: string }`.
so, cannot use multiple label with same key like:
```
TS.CREATE MyKey labels hashtag=helloworld hashtag=ineed hashtag=multiple hashtag=labels
```

solve:
this PR is allow `Array<string>` too.
```
const LABELS = {
  hashtag: ['helloworld', 'ineed', 'multiple', 'labels'],
  someother: 'mykey'
}
await client.ts.create('MyKey', { LABELS })
```
I couldn't find any related issues. sorry for my search availity.

I think this feature will help make the code better.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
