### PR TITLE
fix(clustered pubsub): check that `client.isOpen` before calling `client.disconnect()` when unsubscribing

### DIFF
--- a/packages/client/lib/cluster/cluster-slots.ts
+++ b/packages/client/lib/cluster/cluster-slots.ts
@@ -562,7 +562,7 @@ export default class RedisClusterSlots<
         const client = await this.getPubSubClient();
         await unsubscribe(client);
 
-        if (!client.isPubSubActive) {
+        if (!client.isPubSubActive && client.isOpen) {
             await client.disconnect();
             this.pubSubNode = undefined;
         }
@@ -613,7 +613,7 @@ export default class RedisClusterSlots<
         const client = await master.pubSubClient;
         await unsubscribe(client);
 
-        if (!client.isPubSubActive) {
+        if (!client.isPubSubActive && client.isOpen) {
             await client.disconnect();
             master.pubSubClient = undefined;
         }

--- a/packages/client/lib/cluster/index.spec.ts
+++ b/packages/client/lib/cluster/index.spec.ts
@@ -238,12 +238,10 @@ describe('Cluster', () => {
         
         testUtils.testWithCluster('concurrent UNSUBSCRIBE does not throw an error (#2685)', async cluster => {
             const listener = spy();
-
             await Promise.all([
                 cluster.subscribe('1', listener),
                 cluster.subscribe('2', listener)
             ]);
-
             await Promise.all([
                 cluster.unsubscribe('1', listener),
                 cluster.unsubscribe('2', listener)
@@ -340,12 +338,12 @@ describe('Cluster', () => {
         testUtils.testWithCluster('concurrent SUNSUBCRIBE does not throw an error (#2685)', async cluster => {
             const listener = spy();
             await Promise.all([
-                await cluster.sSubscribe('channel', listener),
-                await cluster.sSubscribe('channel2', listener)
+                await cluster.sSubscribe('1', listener),
+                await cluster.sSubscribe('2', listener)
             ]);
             await Promise.all([
-                cluster.sUnsubscribe('channel', listener),
-                cluster.sUnsubscribe('channel2', listener)
+                cluster.sUnsubscribe('1', listener),
+                cluster.sUnsubscribe('2', listener)
             ]);
         }, {
             ...GLOBAL.CLUSTERS.OPEN,

--- a/packages/client/lib/cluster/index.spec.ts
+++ b/packages/client/lib/cluster/index.spec.ts
@@ -236,18 +236,18 @@ describe('Cluster', () => {
             assert.equal(cluster.pubSubNode, undefined);
         }, GLOBAL.CLUSTERS.OPEN);
         
-        testUtils.testWithCluster('concurrent unsubscribe does not throw an error', async cluster => {
+        testUtils.testWithCluster('concurrent UNSUBSCRIBE does not throw an error (#2685)', async cluster => {
             const listener = spy();
 
-            await cluster.subscribe('channel', listener);
-            await cluster.subscribe('channel2', listener);
+            await Promise.all([
+                cluster.subscribe('1', listener),
+                cluster.subscribe('2', listener)
+            ]);
 
             await Promise.all([
-                cluster.unsubscribe('channel', listener),
-                cluster.unsubscribe('channel2', listener)
+                cluster.unsubscribe('1', listener),
+                cluster.unsubscribe('2', listener)
             ]);
-            
-            assert.equal(cluster.isOpen, false);
         }, GLOBAL.CLUSTERS.OPEN);
 
         testUtils.testWithCluster('psubscribe & punsubscribe', async cluster => {
@@ -337,19 +337,16 @@ describe('Cluster', () => {
             minimumDockerVersion: [7]
         });
 
-        testUtils.testWithCluster('concurrent sunsubscribe does not throw an error', async cluster => {
+        testUtils.testWithCluster('concurrent SUNSUBCRIBE does not throw an error (#2685)', async cluster => {
             const listener = spy();
-
-            await cluster.sSubscribe('channel', listener);
-            await cluster.sSubscribe('channel2', listener);
-
+            await Promise.all([
+                await cluster.sSubscribe('channel', listener),
+                await cluster.sSubscribe('channel2', listener)
+            ]);
             await Promise.all([
                 cluster.sUnsubscribe('channel', listener),
                 cluster.sUnsubscribe('channel2', listener)
-            ])
-
-
-            assert.equal(cluster.isOpen, false);
+            ]);
         }, {
             ...GLOBAL.CLUSTERS.OPEN,
             minimumDockerVersion: [7]

--- a/packages/client/lib/cluster/index.spec.ts
+++ b/packages/client/lib/cluster/index.spec.ts
@@ -235,6 +235,20 @@ describe('Cluster', () => {
 
             assert.equal(cluster.pubSubNode, undefined);
         }, GLOBAL.CLUSTERS.OPEN);
+        
+        testUtils.testWithCluster('concurrent unsubscribe does not throw an error', async cluster => {
+            const listener = spy();
+
+            await cluster.subscribe('channel', listener);
+            await cluster.subscribe('channel2', listener);
+
+            await Promise.all([
+                cluster.unsubscribe('channel', listener),
+                cluster.unsubscribe('channel2', listener)
+            ]);
+            
+            assert.equal(cluster.isOpen, false);
+        }, GLOBAL.CLUSTERS.OPEN);
 
         testUtils.testWithCluster('psubscribe & punsubscribe', async cluster => {
             const listener = spy();
@@ -318,6 +332,24 @@ describe('Cluster', () => {
 
             // 10328 is the slot of `channel`
             assert.equal(cluster.slots[10328].master.pubSubClient, undefined);
+        }, {
+            ...GLOBAL.CLUSTERS.OPEN,
+            minimumDockerVersion: [7]
+        });
+
+        testUtils.testWithCluster('concurrent sunsubscribe does not throw an error', async cluster => {
+            const listener = spy();
+
+            await cluster.sSubscribe('channel', listener);
+            await cluster.sSubscribe('channel2', listener);
+
+            await Promise.all([
+                cluster.sUnsubscribe('channel', listener),
+                cluster.sUnsubscribe('channel2', listener)
+            ])
+
+
+            assert.equal(cluster.isOpen, false);
         }, {
             ...GLOBAL.CLUSTERS.OPEN,
             minimumDockerVersion: [7]


### PR DESCRIPTION
### Description
This PR fixes this issue https://github.com/redis/node-redis/issues/2685 whereby concurrent requests to a redis cluster for any of `UNSUBSCRIBE`, `PUNSUBSCRIBE`, `SSUBSCRIBE` can result in `ClientClosedError` being thrown, due to a race condition between the concurrent requests to disconnect the socket.

It fixes the issue by checking if `client.isOpen` before calling `client.disconnect()` in `executeShardedUnsubscribeCommand` and `executeUnsubscribeCommand`

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
