### PR TITLE
cache clientId on socket connection, to not require it to be awaited

### DIFF
--- a/packages/client/lib/commands/index.ts
+++ b/packages/client/lib/commands/index.ts
@@ -33,7 +33,6 @@ import BZPOPMIN from './BZPOPMIN';
 import CLIENT_CACHING from './CLIENT_CACHING';
 import CLIENT_GETNAME from './CLIENT_GETNAME';
 import CLIENT_GETREDIR from './CLIENT_GETREDIR';
-import CLIENT_ID from './CLIENT_ID';
 import CLIENT_INFO from './CLIENT_INFO';
 import CLIENT_KILL from './CLIENT_KILL';
 import CLIENT_LIST from './CLIENT_LIST';
@@ -403,8 +402,6 @@ export default {
   clientGetName: CLIENT_GETNAME,
   CLIENT_GETREDIR,
   clientGetRedir: CLIENT_GETREDIR,
-  CLIENT_ID,
-  clientId: CLIENT_ID,
   CLIENT_INFO,
   clientInfo: CLIENT_INFO,
   CLIENT_KILL,


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

clientId will be removed from a redis command sent over the wire each time (and therefore need to be awaited) and instead cached.  This moves it from the dynamic RedisClientType to the static RedisClient making it more usable for internal functionality.

I don't think this should break backwards compatibility as await on number should in effect be the same thing as await on Promise<number> (but I might be wrong?)

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
