### PR TITLE
Fix pool task removal

### DIFF
--- a/packages/client/lib/client/linked-list.ts
+++ b/packages/client/lib/client/linked-list.ts
@@ -2,6 +2,7 @@ export interface DoublyLinkedNode<T> {
   value: T;
   previous: DoublyLinkedNode<T> | undefined;
   next: DoublyLinkedNode<T> | undefined;
+  removed?: boolean;
 }
 
 export class DoublyLinkedList<T> {
@@ -77,10 +78,17 @@ export class DoublyLinkedList<T> {
     } else {
       this.#head = this.#tail = undefined;
     }
+
+    node.removed = true;
     return node.value;
   }
 
   remove(node: DoublyLinkedNode<T>) {
+    if (node.removed) {
+      throw new Error("removing an already removed node");
+    }
+    node.removed = true;
+
     --this.#length;
 
     if (this.#tail === node) {
@@ -114,6 +122,7 @@ export class DoublyLinkedList<T> {
 export interface SinglyLinkedNode<T> {
   value: T;
   next: SinglyLinkedNode<T> | undefined;
+  removed?: boolean;
 }
 
 export class SinglyLinkedList<T> {
@@ -151,6 +160,11 @@ export class SinglyLinkedList<T> {
   }
 
   remove(node: SinglyLinkedNode<T>, parent: SinglyLinkedNode<T> | undefined) {
+    if (node.removed) {
+      throw new Error("removing an already removed node");
+    }
+    node.removed = true;
+
     --this.#length;
 
     if (this.#head === node) {
@@ -177,6 +191,7 @@ export class SinglyLinkedList<T> {
       this.#head = node.next;
     }
 
+    node.removed = true;
     return node.value;
   }
 

--- a/packages/client/lib/client/pool.ts
+++ b/packages/client/lib/client/pool.ts
@@ -375,6 +375,7 @@ export class RedisClientPool<
   #returnClient(node: DoublyLinkedNode<RedisClientType<M, F, S, RESP, TYPE_MAPPING>>) {
     const task = this.#tasksQueue.shift();
     if (task) {
+      clearTimeout(task.timeout);
       this.#executeTask(node, task.resolve, task.reject, task.fn);
       return;
     }


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

When the pool added pending tasks, it did so with a timeout timer, that could remove it from the pending queue.  However, it never cleared this timer if the task is executed.  Resulting in items being removed multiple times from list and thereby breaking it.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
