### PR TITLE
Added support for WITHDIST option in pushGeoRadiusArguments

### DIFF
--- a/packages/client/lib/commands/generic-transformers.ts
+++ b/packages/client/lib/commands/generic-transformers.ts
@@ -321,6 +321,10 @@ export function pushGeoRadiusArguments(
         args.push(options.SORT);
     }
 
+    if (options?.WITHDIST) {
+        args.push(options.WITHDIST);
+    }
+
     pushGeoCountArgument(args, options?.COUNT);
 
     return args;


### PR DESCRIPTION
### Description

> Added a simple support for WITHDIST to the pushGeoRadiusArguments. This lets users use this option according to the Redis specification. 

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
