### PR TITLE
WIP - fix #2141 - cluster redirect if client closed

### DIFF
--- a/packages/client/lib/cluster/index.ts
+++ b/packages/client/lib/cluster/index.ts
@@ -100,19 +100,19 @@ export default class RedisCluster<
     readonly #slots: RedisClusterSlots<M, F, S>;
 
     get slots() {
-        return this.#slots.data.slots;
+        return this.#slots.state.slots;
     }
 
     get shards() {
-        return this.#slots.data.shards;
+        return this.#slots.state.shards;
     }
 
     get masters() {
-        return this.#slots.data.masters;
+        return this.#slots.state.masters;
     }
 
     get replicas() {
-        return this.#slots.data.replicas;
+        return this.#slots.state.replicas;
     }
 
     get nodeByAddress() {

--- a/packages/client/lib/cluster/index.ts
+++ b/packages/client/lib/cluster/index.ts
@@ -7,7 +7,7 @@ import { EventEmitter } from 'events';
 import RedisClusterMultiCommand, { InstantiableRedisClusterMultiCommandType, RedisClusterMultiCommandType } from './multi-command';
 import { RedisMultiQueuedCommand } from '../multi-command';
 import { PubSubListener } from '../client/pub-sub';
-import { ErrorReply, ClientClosedError } from '../errors';
+import { ClientClosedError, ErrorReply, ConnectionTimeoutError } from '../errors';
 
 export type RedisClusterClientOptions = Omit<
     RedisClientOptions,
@@ -100,19 +100,19 @@ export default class RedisCluster<
     readonly #slots: RedisClusterSlots<M, F, S>;
 
     get slots() {
-        return this.#slots.slots;
+        return this.#slots.data.slots;
     }
 
     get shards() {
-        return this.#slots.shards;
+        return this.#slots.data.shards;
     }
 
     get masters() {
-        return this.#slots.masters;
+        return this.#slots.data.masters;
     }
 
     get replicas() {
-        return this.#slots.replicas;
+        return this.#slots.data.replicas;
     }
 
     get nodeByAddress() {
@@ -243,6 +243,13 @@ export default class RedisCluster<
         isReadonly: boolean | undefined,
         executor: (client: RedisClientType<M, F, S>) => Promise<Reply>
     ): Promise<Reply> {
+        if (this.#slots.lastDiscovered + 10000 < Date.now()) {
+            const discover = async () => {
+                let client = await this.#slots.nodeClient(this.#slots.getRandomNode());
+                this.#slots.rediscover(client).catch(() => { /* ignore */ })
+            }
+            discover(); // don't wait for it
+        }
         const maxCommandRedirections = this.#options.maxCommandRedirections ?? 16;
         let client = await this.#slots.getClient(firstKey, isReadonly);
         for (let i = 0;; i++) {
@@ -250,9 +257,16 @@ export default class RedisCluster<
                 return await executor(client);
             } catch (err) {
                 if (err instanceof ClientClosedError) {
-                    // client was closed, try again with a random client
-                    client = await this.#slots.getClient(undefined, isReadonly);
-                    i-- // don't count this attempt as a redirection
+                    i-- // don't count this attempt
+
+                    // attempt to reconnect closed client
+                    client.connect().catch(() => { /* ignore */ });
+
+                    // try again with a different client
+                    let oldClient = client
+                    while (client === oldClient) {
+                        client = await this.#slots.getClient(undefined, isReadonly)
+                    }
                     continue;
                 }
 


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

Here is a rough attempt to resolve issues described in #2141 (I'm not an expert with TS and would like someone to take over this PR)

`createCluster` is currently unable to update slots when slots are out of date (when a master node goes down and a replica takes over)
This causes the client to throw `ClientClosedError` forever until the application is restarted.



This PR takes inspiration from https://github.com/redis/go-redis
- Whenever a command is executed, we check if the state has been last updated 10s ago [reference](https://github.com/redis/go-redis/blob/2512123b7686dca1f7f0208eaada6cdf3ef0189c/osscluster.go#L828) 
- Use concept of state struct to make lazy loading easier [reference](https://github.com/redis/go-redis/blob/2512123b7686dca1f7f0208eaada6cdf3ef0189c/osscluster.go#L601)
Related: https://github.com/redis/node-redis/issues/2141#issuecomment-1929245348

### Known issues

Do not use `isolated` - `commandOptions`; this breaks the client forever, the duplicated client from using this command option would keep using old node addresses and cause `Connection timeout` on each reconnection. This PR attempts to make changes only to the cluster client and won't make any fixes to this issue (this issue already exists prior this PR)
e.g.
```js
await client.xRead(
    commandOptions({
        isolated: true
    }),
    [
        {
            key: key,
            id:'0-0'
        }
    ],
    {
        COUNT: 100,
        BLOCK: 0
    }
);
```

### Try it out
For those interested in trying this client out you can install it using the following:
```js
# I'm using pnpm
"pnpm": {
  "overrides": {
    "@redis/client": "npm:@scorpionknifes/redis-client@^1.6.0"
  }
},
```
It is available here: https://www.npmjs.com/package/@scorpionknifes/redis-client

### Testing
I've tested this against docker, k8s
Writing tests for these is almost impossible cause it relies on simulating a Redis master going down. (aka no tests written for these)

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
