### PR TITLE
Support the NOVALUES option of HSCAN

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -808,7 +808,10 @@ describe('Client', () => {
         }
 
         assert.deepEqual(keys.sort(sort), expectedKeys);
-    }, GLOBAL.SERVERS.OPEN);
+    }, {
+        ...GLOBAL.SERVERS.OPEN,
+        minimumDockerVersion: [7, 4]
+    });
 
     testUtils.testWithClient('sScanIterator', async client => {
         const members = new Set<string>();

--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -788,6 +788,28 @@ describe('Client', () => {
         assert.deepEqual(hash, results);
     }, GLOBAL.SERVERS.OPEN);
 
+    testUtils.testWithClient('hScanNoValuesIterator', async client => {
+        const hash: Record<string, string> = {};
+        const expectedKeys: Array<string> = [];
+        for (let i = 0; i < 100; i++) {
+            hash[i.toString()] = i.toString();
+            expectedKeys.push(i.toString());
+        }
+
+        await client.hSet('key', hash);
+
+        const keys: Array<string> = [];
+        for await (const key of client.hScanNoValuesIterator('key')) {
+            keys.push(key);
+        }
+
+        function sort(a: string, b: string) {
+            return Number(a) - Number(b);
+        }
+
+        assert.deepEqual(keys.sort(sort), expectedKeys);
+    }, GLOBAL.SERVERS.OPEN);
+
     testUtils.testWithClient('sScanIterator', async client => {
         const members = new Set<string>();
         for (let i = 0; i < 100; i++) {

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -1,5 +1,5 @@
 import COMMANDS from './commands';
-import { RedisCommand, RedisCommandArguments, RedisCommandRawReply, RedisCommandReply, RedisFunctions, RedisModules, RedisExtensions, RedisScript, RedisScripts, RedisCommandSignature, ConvertArgumentType, RedisFunction, ExcludeMappedString, RedisCommands } from '../commands';
+import { RedisCommand, RedisCommandArgument, RedisCommandArguments, RedisCommandRawReply, RedisCommandReply, RedisFunctions, RedisModules, RedisExtensions, RedisScript, RedisScripts, RedisCommandSignature, ConvertArgumentType, RedisFunction, ExcludeMappedString, RedisCommands } from '../commands';
 import RedisSocket, { RedisSocketOptions, RedisTlsSocketOptions } from './socket';
 import RedisCommandsQueue, { QueueCommandOptions } from './commands-queue';
 import RedisClientMultiCommand, { RedisClientMultiCommandType } from './multi-command';
@@ -816,6 +816,17 @@ export default class RedisClient<
             cursor = reply.cursor;
             for (const tuple of reply.tuples) {
                 yield tuple;
+            }
+        } while (cursor !== 0);
+    }
+
+    async* hScanNoValuesIterator(key: string, options?: ScanOptions): AsyncIterable<ConvertArgumentType<RedisCommandArgument, string>> {
+        let cursor = 0;
+        do {
+            const reply = await (this as any).hScanNoValues(key, cursor, options);
+            cursor = reply.cursor;
+            for (const k of reply.keys) {
+                yield k;
             }
         } while (cursor !== 0);
     }

--- a/packages/client/lib/cluster/commands.ts
+++ b/packages/client/lib/cluster/commands.ts
@@ -64,6 +64,7 @@ import * as HRANDFIELD_COUNT_WITHVALUES from '../commands/HRANDFIELD_COUNT_WITHV
 import * as HRANDFIELD_COUNT from '../commands/HRANDFIELD_COUNT';
 import * as HRANDFIELD from '../commands/HRANDFIELD';
 import * as HSCAN from '../commands/HSCAN';
+import * as HSCAN_NOVALUES from '../commands/HSCAN_NOVALUES';
 import * as HSET from '../commands/HSET';
 import * as HSETNX from '../commands/HSETNX';
 import * as HSTRLEN from '../commands/HSTRLEN';
@@ -343,6 +344,8 @@ export default {
     hRandField: HRANDFIELD,
     HSCAN,
     hScan: HSCAN,
+    HSCAN_NOVALUES,
+    hScanNoValues: HSCAN_NOVALUES,
     HSET,
     hSet: HSET,
     HSETNX,

--- a/packages/client/lib/commands/HSCAN.ts
+++ b/packages/client/lib/commands/HSCAN.ts
@@ -16,7 +16,7 @@ export function transformArguments(
     ], cursor, options);
 }
 
-type HScanRawReply = [RedisCommandArgument, Array<RedisCommandArgument>];
+export type HScanRawReply = [RedisCommandArgument, Array<RedisCommandArgument>];
 
 export interface HScanTuple {
     field: RedisCommandArgument;

--- a/packages/client/lib/commands/HSCAN_NOVALUES.spec.ts
+++ b/packages/client/lib/commands/HSCAN_NOVALUES.spec.ts
@@ -3,6 +3,8 @@ import testUtils, { GLOBAL } from '../test-utils';
 import { transformArguments, transformReply } from './HSCAN_NOVALUES';
 
 describe('HSCAN_NOVALUES', () => {
+    testUtils.isVersionGreaterThanHook([7, 4]);
+    
     describe('transformArguments', () => {
         it('cusror only', () => {
             assert.deepEqual(

--- a/packages/client/lib/commands/HSCAN_NOVALUES.spec.ts
+++ b/packages/client/lib/commands/HSCAN_NOVALUES.spec.ts
@@ -1,13 +1,13 @@
 import { strict as assert } from 'assert';
 import testUtils, { GLOBAL } from '../test-utils';
-import { transformArguments, transformReply } from './HSCAN';
+import { transformArguments, transformReply } from './HSCAN_NOVALUES';
 
-describe('HSCAN', () => {
+describe('HSCAN_NOVALUES', () => {
     describe('transformArguments', () => {
         it('cusror only', () => {
             assert.deepEqual(
                 transformArguments('key', 0),
-                ['HSCAN', 'key', '0']
+                ['HSCAN', 'key', '0', 'NOVALUES']
             );
         });
 
@@ -16,7 +16,7 @@ describe('HSCAN', () => {
                 transformArguments('key', 0, {
                     MATCH: 'pattern'
                 }),
-                ['HSCAN', 'key', '0', 'MATCH', 'pattern']
+                ['HSCAN', 'key', '0', 'MATCH', 'pattern', 'NOVALUES']
             );
         });
 
@@ -25,52 +25,39 @@ describe('HSCAN', () => {
                 transformArguments('key', 0, {
                     COUNT: 1
                 }),
-                ['HSCAN', 'key', '0', 'COUNT', '1']
-            );
-        });
-
-        it('with MATCH & COUNT', () => {
-            assert.deepEqual(
-                transformArguments('key', 0, {
-                    MATCH: 'pattern',
-                    COUNT: 1
-                }),
-                ['HSCAN', 'key', '0', 'MATCH', 'pattern', 'COUNT', '1']
+                ['HSCAN', 'key', '0', 'COUNT', '1', 'NOVALUES']
             );
         });
     });
 
     describe('transformReply', () => {
-        it('without tuples', () => {
+        it('without keys', () => {
             assert.deepEqual(
                 transformReply(['0', []]),
                 {
                     cursor: 0,
-                    tuples: []
+                    keys: []
                 }
             );
         });
 
-        it('with tuples', () => {
+        it('with keys', () => {
             assert.deepEqual(
-                transformReply(['0', ['field', 'value']]),
+                transformReply(['0', ['key1', 'key2']]),
                 {
                     cursor: 0,
-                    tuples: [{
-                        field: 'field',
-                        value: 'value'
-                    }]
+                    keys: ['key1', 'key2']
                 }
             );
         });
     });
 
-    testUtils.testWithClient('client.hScan', async client => {
+    testUtils.testWithClient('client.hScanNoValues', async client => {
         assert.deepEqual(
-            await client.hScan('key', 0),
+            await client.hScanNoValues('key', 0),
             {
                 cursor: 0,
-                tuples: []
+                keys: []
             }
         );
 
@@ -80,10 +67,10 @@ describe('HSCAN', () => {
         ]);
 
         assert.deepEqual(
-            await client.hScan('key', 0),
+            await client.hScanNoValues('key', 0),
             {
                 cursor: 0,
-                tuples: [{field: 'a', value: '1'}, {field: 'b', value: '2'}]
+                keys: ['a', 'b']
             }
         );
     }, GLOBAL.SERVERS.OPEN);

--- a/packages/client/lib/commands/HSCAN_NOVALUES.ts
+++ b/packages/client/lib/commands/HSCAN_NOVALUES.ts
@@ -1,0 +1,27 @@
+import { RedisCommandArgument, RedisCommandArguments } from '.';
+import { ScanOptions } from './generic-transformers';
+import { HScanRawReply, transformArguments as transformHScanArguments } from './HSCAN';
+
+export { FIRST_KEY_INDEX, IS_READ_ONLY } from './HSCAN';
+
+export function transformArguments(
+    key: RedisCommandArgument,
+    cursor: number,
+    options?: ScanOptions
+): RedisCommandArguments {
+    const args = transformHScanArguments(key, cursor, options);
+    args.push('NOVALUES');
+    return args;
+}
+
+interface HScanNoValuesReply {
+    cursor: number;
+    keys: Array<RedisCommandArgument>;
+}
+
+export function transformReply([cursor, rawData]: HScanRawReply): HScanNoValuesReply {
+    return {
+        cursor: Number(cursor),
+        keys: [...rawData]
+    };
+}


### PR DESCRIPTION
### Description

Issue #2705

The NOVALUES option instructs HSCAN to only return keys, without their values.
The new option will become available from Redis 7.6.

### Checklist

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?