### PR TITLE
asking / command can be separated on cluster redirect.

### DIFF
--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -812,7 +812,8 @@ export default class RedisClient<
    */
   async _executeMulti(
     commands: Array<RedisMultiQueuedCommand>,
-    selectedDB?: number
+    selectedDB?: number,
+    options?: CommandOptions
   ) {
     const dirtyWatch = this._self.#dirtyWatch;
     this._self.#dirtyWatch = undefined;
@@ -831,9 +832,10 @@ export default class RedisClient<
       throw new WatchError('Client reconnected after WATCH');
     }
 
-    const typeMapping = this._commandOptions?.typeMapping,
-      chainId = Symbol('MULTI Chain'),
-      promises = [
+    const chainId = options?.chainId ? options.chainId : Symbol('MULTI Chain');
+    const typeMapping = options?.typeMapping ? options.typeMapping : this._commandOptions?.typeMapping;
+
+    const promises = [
         this._self.#queue.addCommand(['MULTI'], { chainId }),
       ];
 

--- a/packages/client/lib/cluster/index.ts
+++ b/packages/client/lib/cluster/index.ts
@@ -539,8 +539,12 @@ export default class RedisCluster<
     type Multi = new (...args: ConstructorParameters<typeof RedisClusterMultiCommand>) => RedisClusterMultiCommandType<[], M, F, S, RESP, TYPE_MAPPING>;
     return new ((this as any).Multi as Multi)(
       async (firstKey, isReadonly, commands) => {
-        const client = await this._self.#slots.getClient(firstKey, isReadonly);
-        return client._executeMulti(commands);
+        return this._self.#execute(
+          firstKey,
+          isReadonly,
+          this._self._commandOptions,
+          (client, opts) => client._executeMulti(commands, undefined, opts)
+        )
       },
       async (firstKey, isReadonly, commands) => {
         const client = await this._self.#slots.getClient(firstKey, isReadonly);


### PR DESCRIPTION
this handles normal commands, but it doesn't handle the multi (exec or pipeline) cases.

unsure if pipeline makes sense in the context of cluster because of this (i.e. can get exception in middle, and will have no idea which commands were executed).  Handling pipeline might require a total rewrite.

to handle multi, I think we will have to pass an optional chainId into the executeMulti(), and only set chainId if it's undefined.  With multi, it either all executes or none of it executes, so an exception will be meaningful.