### PR TITLE
Support the MAXAGE option for CLIENT KILL

### DIFF
--- a/packages/client/lib/commands/CLIENT_KILL.spec.ts
+++ b/packages/client/lib/commands/CLIENT_KILL.spec.ts
@@ -106,5 +106,15 @@ describe('CLIENT KILL', () => {
                 ['CLIENT', 'KILL', 'TYPE', 'master', 'SKIPME']
             );
         });
+
+        it('MAX_AGE', () => {
+            assert.deepEqual(
+                transformArguments({
+                    filter: ClientKillFilters.MAX_AGE,
+                    maxAge: 5
+                }),
+                ['CLIENT', 'KILL', 'MAXAGE', '5']
+            );
+        });
     });
 });

--- a/packages/client/lib/commands/CLIENT_KILL.ts
+++ b/packages/client/lib/commands/CLIENT_KILL.ts
@@ -6,7 +6,8 @@ export enum ClientKillFilters {
     ID = 'ID',
     TYPE = 'TYPE',
     USER = 'USER',
-    SKIP_ME = 'SKIPME'
+    SKIP_ME = 'SKIPME',
+    MAX_AGE = 'MAXAGE'
 }
 
 interface KillFilter<T extends ClientKillFilters> {
@@ -37,7 +38,11 @@ type KillSkipMe = ClientKillFilters.SKIP_ME | (KillFilter<ClientKillFilters.SKIP
     skipMe: boolean;
 });
 
-type KillFilters = KillAddress | KillLocalAddress | KillId | KillType | KillUser | KillSkipMe;
+interface KillMaxAge extends KillFilter<ClientKillFilters.MAX_AGE> {
+    maxAge: number;
+}
+
+type KillFilters = KillAddress | KillLocalAddress | KillId | KillType | KillUser | KillSkipMe | KillMaxAge;
 
 export function transformArguments(filters: KillFilters | Array<KillFilters>): RedisCommandArguments {
     const args = ['CLIENT', 'KILL'];
@@ -61,7 +66,7 @@ function pushFilter(args: RedisCommandArguments, filter: KillFilters): void {
 
     args.push(filter.filter);
 
-    switch(filter.filter) {
+    switch (filter.filter) {
         case ClientKillFilters.ADDRESS:
             args.push(filter.address);
             break;
@@ -83,11 +88,15 @@ function pushFilter(args: RedisCommandArguments, filter: KillFilters): void {
             break;
 
         case ClientKillFilters.USER:
-                args.push(filter.username);
-                break;
+            args.push(filter.username);
+            break;
 
         case ClientKillFilters.SKIP_ME:
             args.push(filter.skipMe ? 'yes' : 'no');
+            break;
+
+        case ClientKillFilters.MAX_AGE:
+            args.push(filter.maxAge.toString());
             break;
     }
 }


### PR DESCRIPTION
### Description

Issue #2706

Starting with Redis 7.6, the CLIENT KILL command has a new option, called MAXAGE, to kill clients older than a given age. Add support for this new option.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
