### PR TITLE
move some usage of RedisArgument arrays to ReadonlyArray

### DIFF
--- a/packages/client/lib/RESP/encoder.ts
+++ b/packages/client/lib/RESP/encoder.ts
@@ -2,7 +2,7 @@ import { RedisArgument } from './types';
 
 const CRLF = '\r\n';
 
-export default function encodeCommand(args: Array<RedisArgument>): Array<RedisArgument> {
+export default function encodeCommand(args: ReadonlyArray<RedisArgument>): ReadonlyArray<RedisArgument> {
   const toWrite: Array<RedisArgument> = [];
 
   let strings = '*' + args.length + CRLF;

--- a/packages/client/lib/client/commands-queue.ts
+++ b/packages/client/lib/client/commands-queue.ts
@@ -1,7 +1,7 @@
 import { SinglyLinkedList, DoublyLinkedNode, DoublyLinkedList } from './linked-list';
 import encodeCommand from '../RESP/encoder';
 import { Decoder, PUSH_TYPE_MAPPING, RESP_TYPES } from '../RESP/decoder';
-import { CommandArguments, TypeMapping, ReplyUnion, RespVersions } from '../RESP/types';
+import { TypeMapping, ReplyUnion, RespVersions, RedisArgument } from '../RESP/types';
 import { ChannelListeners, PubSub, PubSubCommand, PubSubListener, PubSubType, PubSubTypeListeners } from './pub-sub';
 import { AbortError, ErrorReply } from '../errors';
 import { MonitorCallback } from '.';
@@ -17,7 +17,7 @@ export interface CommandOptions<T = TypeMapping> {
 }
 
 export interface CommandToWrite extends CommandWaitingForReply {
-  args: CommandArguments;
+  args: ReadonlyArray<RedisArgument>;
   chainId: symbol | undefined;
   abort: {
     signal: AbortSignal;
@@ -117,7 +117,7 @@ export default class RedisCommandsQueue {
   }
 
   addCommand<T>(
-    args: CommandArguments,
+    args: ReadonlyArray<RedisArgument>,
     options?: CommandOptions
   ): Promise<T> {
     if (this.#maxLength && this.#toWrite.length + this.#waitingForReply.length >= this.#maxLength) {
@@ -346,7 +346,7 @@ export default class RedisCommandsQueue {
   *commandsToWrite() {
     let toSend = this.#toWrite.shift();
     while (toSend) {
-      let encoded: CommandArguments;
+      let encoded: ReadonlyArray<RedisArgument>
       try {
         encoded = encodeCommand(toSend.args);
       } catch (err) {

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -574,7 +574,7 @@ export default class RedisClient<
   }
 
   sendCommand<T = ReplyUnion>(
-    args: Array<RedisArgument>,
+    args: ReadonlyArray<RedisArgument>,
     options?: CommandOptions
   ): Promise<T> {
     if (!this._self.#socket.isOpen) {

--- a/packages/client/lib/client/socket.ts
+++ b/packages/client/lib/client/socket.ts
@@ -271,7 +271,7 @@ export default class RedisSocket extends EventEmitter {
     });
   }
 
-  write(iterable: Iterable<Array<RedisArgument>>) {
+  write(iterable: Iterable<ReadonlyArray<RedisArgument>>) {
     if (!this.#socket) return;
     
     this.#socket.cork();


### PR DESCRIPTION
motivated by wanting to return a read only array from the parser object