### PR TITLE
Fix race condition when slots are re-calculated

### DIFF
--- a/packages/client/lib/cluster/cluster-slots.ts
+++ b/packages/client/lib/cluster/cluster-slots.ts
@@ -158,13 +158,13 @@ export default class RedisClusterSlots<
     }
 
     async #discover(rootNode?: RedisClusterClientOptions) {
-        this.#resetSlots();
         const addressesInUse = new Set<string>();
 
         try {
             const shards = await this.#getShards(rootNode),
                 promises: Array<Promise<unknown>> = [],
                 eagerConnect = this.#options.minimizeConnections !== true;
+            this.#resetSlots();
             for (const { from, to, master, replicas } of shards) {
                 const shard: Shard<M, F, S> = {
                     master: this.#initiateSlotNode(master, false, eagerConnect, addressesInUse, promises)


### PR DESCRIPTION
### Description

I was getting an error similar to <https://github.com/redis/node-redis/issues/2704>. 

What was happening for me is that I was creating a redis cluster client and then calling `client.eval()`. Since `eval` doesn't seem to be cluster-aware, it returned a `MOVE` error since it was routed to an incorrect node. This seems to cause a call to `discover()` to re-discover the hash slot mapping.

The bug I am trying to address is a race condition between when the internal data is cleared to when it's re-populated again. In the current implementation, there's an asynchronous command being run in-between, which means if any other command was run in between, would cause `this.slots[val]` of `cluster-slots.ts` (such as in `getSlotRandomNode()`) to return undefined and throw an exception.

```typescript
 async #discover(rootNode?: RedisClusterClientOptions) {
        this.#resetSlots(); // !!! Reset is being called here
        const addressesInUse = new Set<string>();

        try {
            const shards = await this.#getShards(rootNode), // !!! But there's an async command here
                promises: Array<Promise<unknown>> = [],
                eagerConnect = this.#options.minimizeConnections !== true;
            for (const { from, to, master, replicas } of shards) {
```

This changes moves when it is cleared so that it's cleared then populated, without any async stuff inbetween.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
