### PR TITLE
fDefault reconnect strategy uses exponential backoff and jitter

### DIFF
--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -12,7 +12,7 @@
 | socket.noDelay           | `true`                                   | Toggle [`Nagle's algorithm`](https://nodejs.org/api/net.html#net_socket_setnodelay_nodelay)                                                                                                                                                         |
 | socket.keepAlive         | `5000`                                   | Toggle [`keep-alive`](https://nodejs.org/api/net.html#net_socket_setkeepalive_enable_initialdelay) functionality                                                                                                                                    |
 | socket.tls               |                                          | See explanation and examples [below](#TLS)                                                                                                                                                                                                          |
-| socket.reconnectStrategy | `retries => Math.min(retries * 50, 500)` | A function containing the [Reconnect Strategy](#reconnect-strategy) logic                                                                                                                                                                           |
+| socket.reconnectStrategy | `((retries^2) * 50 ms) + 0-200 ms jitter` | A function containing the [Reconnect Strategy](#reconnect-strategy) logic                                                                                                                                                                           |
 | username                 |                                          | ACL username ([see ACL guide](https://redis.io/topics/acl))                                                                                                                                                                                         |
 | password                 |                                          | ACL password or the old "--requirepass" password                                                                                                                                                                                                    |
 | name                     |                                          | Client name ([see `CLIENT SETNAME`](https://redis.io/commands/client-setname))                                                                                                                                                                      |
@@ -34,12 +34,19 @@ When the socket closes unexpectedly (without calling `.quit()`/`.disconnect()`),
 2. `number` -> wait for `X` milliseconds before reconnecting.
 3. `(retries: number, cause: Error) => false | number | Error` -> `number` is the same as configuring a `number` directly, `Error` is the same as `false`, but with a custom error.
 
-By default the strategy is `Math.min(retries * 50, 500)`, but it can be overwritten like so:
+By default the strategy uses exponential backoff, but it can be overwritten like so:
 
 ```javascript
 createClient({
   socket: {
-    reconnectStrategy: retries => Math.min(retries * 50, 1000)
+    reconnectStrategy: retries => {
+        // Generate a random jitter between 0 – 200 ms:
+        const jitter = Math.floor(Math.random() * 200);
+        // Delay is an exponential back off, (times^2) * 50 ms, with a maximum value of 2000 ms:
+        const delay = Math.min(Math.pow(2, retries) * 50, 2000);
+
+        return delay + jitter;
+    }
   }
 });
 ```


### PR DESCRIPTION
### Description

The current default retry strategy increases delay linearly with no jitter. This can lead to a thundering herd problem if many clients lose their connection at once, which is common during events like a Redis upgrade.

A retry strategy that uses exponential backoff plus a random jitter helps mitigate this risk and [is recommended](https://aws.amazon.com/blogs/database/best-practices-redis-clients-and-amazon-elasticache-for-redis/) in many best practices documents for Redis clients, so I propose making this the default.

The default strategy I implemented will do the following:

* Delay will be equal to (n^2) * 50 ms where n is the current retry count, with a maximum value of 2000 ms.
* Jitter is a random value between 0 and 200 ms.

The millisecond values I choose are somewhat arbitrary, and I'm happy to change them if we think they're not right.

### Checklist

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?