### PR TITLE
Tests: Update docker image for subpackages

### DIFF
--- a/packages/bloom/lib/test-utils.ts
+++ b/packages/bloom/lib/test-utils.ts
@@ -2,15 +2,15 @@ import TestUtils from '@redis/test-utils';
 import RedisBloomModules from '.';
 
 export default new TestUtils({
-    dockerImageName: 'redislabs/rebloom',
+    dockerImageName: 'redis/redis-stack-server',
     dockerImageVersionArgument: 'redisbloom-version',
-    defaultDockerVersion: 'edge'
+    defaultDockerVersion: '7.2.0-v10'
 });
 
 export const GLOBAL = {
     SERVERS: {
         OPEN: {
-            serverArguments: ['--loadmodule /usr/lib/redis/modules/redisbloom.so'],
+            serverArguments: ['--loadmodule /opt/redis-stack/lib/redisbloom.so', '--protected-mode no'],
             clientOptions: {
                 modules: RedisBloomModules
             }

--- a/packages/json/lib/test-utils.ts
+++ b/packages/json/lib/test-utils.ts
@@ -2,15 +2,15 @@ import TestUtils from '@redis/test-utils';
 import RedisJSON from '.';
 
 export default new TestUtils({
-    dockerImageName: 'redislabs/rejson',
+    dockerImageName: 'redis/redis-stack-server',
     dockerImageVersionArgument: 'rejson-version',
-    defaultDockerVersion: '2.6.9'
+    defaultDockerVersion: '7.2.0-v10'
 });
 
 export const GLOBAL = {
     SERVERS: {
         OPEN: {
-            serverArguments: ['--loadmodule /usr/lib/redis/modules/rejson.so'],
+            serverArguments: ['--loadmodule /opt/redis-stack/lib/rejson.so', '--protected-mode no'],
             clientOptions: {
                 modules: {
                     json: RedisJSON

--- a/packages/time-series/lib/test-utils.ts
+++ b/packages/time-series/lib/test-utils.ts
@@ -2,14 +2,14 @@ import TestUtils from '@redis/test-utils';
 import TimeSeries from '.';
 
 export default new TestUtils({
-    dockerImageName: 'redislabs/redistimeseries',
+    dockerImageName: 'redis/redis-stack-server',
     dockerImageVersionArgument: 'timeseries-version'
 });
 
 export const GLOBAL = {
     SERVERS: {
         OPEN: {
-            serverArguments: ['--loadmodule /usr/lib/redis/modules/redistimeseries.so'],
+            serverArguments: ['--loadmodule /opt/redis-stack/lib/redistimeseries.so', '--protected-mode no'],
             clientOptions: {
                 modules: {
                     ts: TimeSeries


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

- Current docker images used in tests have been deprecated 
- Recommended docker images to be used are redis-stack 
- To keep the test-suite up to date, changing the docker image and using the latest image to run the tests
- Not updating redisgraph (eol) and search (breaking features) 
---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
    - Existing tests pass for both old and new docker versions
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
