### PR TITLE
add ISEMPTY field support to FT.CREATE

### DIFF
--- a/packages/search/lib/commands/CREATE.spec.ts
+++ b/packages/search/lib/commands/CREATE.spec.ts
@@ -69,24 +69,74 @@ describe('FT.CREATE', () => {
             ['FT.CREATE', 'index', 'SCHEMA', 'field', 'TEXT', 'WITHSUFFIXTRIE']
           );
         });
+
+        it('with ISEMPTY', () => {
+          assert.deepEqual(
+            CREATE.transformArguments('index', {
+              field: {
+                type: SCHEMA_FIELD_TYPE.TEXT,
+                MISSING_VAUES: {
+                  IS_EMPTY: true
+                }
+              }
+            }),
+            ['FT.CREATE', 'index', 'SCHEMA', 'field', 'TEXT', 'ISEMPTY']
+          );
+        });
       });
 
-      it('NUMERIC', () => {
-        assert.deepEqual(
-          CREATE.transformArguments('index', {
-            field: SCHEMA_FIELD_TYPE.NUMERIC
-          }),
-          ['FT.CREATE', 'index', 'SCHEMA', 'field', 'NUMERIC']
-        );
+      describe('NUMERIC', () => {
+        describe('transformArguments', () => {
+          it('no options', () => {
+            assert.deepEqual(
+              CREATE.transformArguments('index', {
+                field: SCHEMA_FIELD_TYPE.NUMERIC
+              }),
+              ['FT.CREATE', 'index', 'SCHEMA', 'field', 'NUMERIC']
+            );
+          });
+
+          it('with ISEMPTY', () => {
+            assert.deepEqual(
+              CREATE.transformArguments('index', {
+                field: {
+                  type: SCHEMA_FIELD_TYPE.NUMERIC,
+                  MISSING_VAUES: {
+                    IS_EMPTY: true
+                  }
+                }
+              }),
+              ['FT.CREATE', 'index', 'SCHEMA', 'field', 'NUMERIC', 'ISEMPTY']
+            );
+          });
+        });
       });
 
-      it('GEO', () => {
-        assert.deepEqual(
-          CREATE.transformArguments('index', {
-            field: SCHEMA_FIELD_TYPE.GEO
-          }),
-          ['FT.CREATE', 'index', 'SCHEMA', 'field', 'GEO']
-        );
+      describe('GEO', () => {
+        describe('transformArguments', () => {
+          it('no options', () => {
+            assert.deepEqual(
+              CREATE.transformArguments('index', {
+                field: SCHEMA_FIELD_TYPE.GEO
+              }),
+              ['FT.CREATE', 'index', 'SCHEMA', 'field', 'GEO']
+            );
+          });
+
+          it('with ISEMPTY', () => {
+            assert.deepEqual(
+              CREATE.transformArguments('index', {
+                field: {
+                  type: SCHEMA_FIELD_TYPE.GEO,
+                  MISSING_VAUES: {
+                    IS_EMPTY: true
+                  }
+                }
+              }),
+              ['FT.CREATE', 'index', 'SCHEMA', 'field', 'GEO', 'ISEMPTY']
+            );
+          });
+        });
       });
 
       describe('TAG', () => {
@@ -147,6 +197,20 @@ describe('FT.CREATE', () => {
             ['FT.CREATE', 'index', 'SCHEMA', 'field', 'TAG', 'WITHSUFFIXTRIE']
           );
         });
+
+        it('with ISEMPTY', () => {
+          assert.deepEqual(
+            CREATE.transformArguments('index', {
+              field: {
+                type: SCHEMA_FIELD_TYPE.TAG,
+                MISSING_VAUES: {
+                  IS_EMPTY: true
+                }
+              }
+            }),
+            ['FT.CREATE', 'index', 'SCHEMA', 'field', 'TAG', 'ISEMPTY']
+          );
+        });
       });
 
       describe('VECTOR', () => {
@@ -193,6 +257,25 @@ describe('FT.CREATE', () => {
             ]
           );
         });
+
+        it('with ISEMPTY', () => {
+          assert.deepEqual(
+            CREATE.transformArguments('index', {
+              field: {
+                type: SCHEMA_FIELD_TYPE.VECTOR,
+                ALGORITHM: SCHEMA_VECTOR_FIELD_ALGORITHM.HNSW,
+                TYPE: 'FLOAT32',
+                DIM: 2,
+                DISTANCE_METRIC: 'L2',
+                MISSING_VAUES: {
+                  IS_EMPTY: true
+                }
+              }
+            }),
+            ['FT.CREATE', 'index', 'SCHEMA', 'field', 'VECTOR', 'HNSW', '7', 'TYPE', 
+            'FLOAT32', 'DIM', '2', 'DISTANCE_METRIC', 'L2', 'ISEMPTY']
+          );
+        });
       });
 
       describe('GEOSHAPE', () => {
@@ -229,6 +312,21 @@ describe('FT.CREATE', () => {
             ['FT.CREATE', 'index', 'SCHEMA', 'field', 'GEOSHAPE', 'COORD_SYSTEM', 'SPHERICAL']
           );
         });
+
+        it('with ISEMPTY', () => {
+          assert.deepEqual(
+            CREATE.transformArguments('index', {
+              field: {
+                type: SCHEMA_FIELD_TYPE.GEOSHAPE,
+                MISSING_VAUES: {
+                  IS_EMPTY: true
+                }
+              }
+            }),
+            ['FT.CREATE', 'index', 'SCHEMA', 'field', 'GEOSHAPE', 'ISEMPTY']
+          );
+        });
+
       });
   
       it('with AS', () => {


### PR DESCRIPTION
first part of supporting what to do with "missing" values that has been implemented in RedisSearch