### PR TITLE
clientKillMaxAge typo, replace MANAGE by MAXAGE

### DIFF
--- a/packages/client/lib/commands/CLIENT_KILL.ts
+++ b/packages/client/lib/commands/CLIENT_KILL.ts
@@ -40,7 +40,7 @@ export type ClientKillSkipMe = CLIENT_KILL_FILTERS['SKIP_ME'] | (ClientKillFilte
   skipMe: boolean;
 });
 
-export interface ClientKillMaxAge extends ClientKillFilterCommon<CLIENT_KILL_FILTERS['MANAGE']> {
+export interface ClientKillMaxAge extends ClientKillFilterCommon<CLIENT_KILL_FILTERS['MAXAGE']> {
   maxAge: number;
 }
 


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> In the commit https://github.com/redis/node-redis/commit/85d5bf4125b8c4c5bd1fc91a2c1e5d0cf0600405, a typographical error was introduced in the creation of the ClientKillMaxAge interface.
---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

@leibale, can you check this please
