### PR TITLE
fix createCluster - copy `options.defaults.socket` before modifying it

### DIFF
--- a/packages/client/lib/cluster/cluster-slots.ts
+++ b/packages/client/lib/cluster/cluster-slots.ts
@@ -269,10 +269,10 @@ export default class RedisClusterSlots<
         if (this.#options.defaults) {
             let socket;
             if (this.#options.defaults.socket) {
-                socket = options?.socket ? {
+                socket = {
                     ...this.#options.defaults.socket,
-                    ...options.socket
-                } : { ...this.#options.defaults.socket };
+                    ...options?.socket
+                };
             } else {
                 socket = options?.socket;
             }

--- a/packages/client/lib/cluster/cluster-slots.ts
+++ b/packages/client/lib/cluster/cluster-slots.ts
@@ -272,7 +272,7 @@ export default class RedisClusterSlots<
                 socket = options?.socket ? {
                     ...this.#options.defaults.socket,
                     ...options.socket
-                } : { ...this.#options.defaults.socket};
+                } : { ...this.#options.defaults.socket };
             } else {
                 socket = options?.socket;
             }

--- a/packages/client/lib/cluster/cluster-slots.ts
+++ b/packages/client/lib/cluster/cluster-slots.ts
@@ -272,7 +272,7 @@ export default class RedisClusterSlots<
                 socket = options?.socket ? {
                     ...this.#options.defaults.socket,
                     ...options.socket
-                } : this.#options.defaults.socket;
+                } : { ...this.#options.defaults.socket};
             } else {
                 socket = options?.socket;
             }


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

https://github.com/redis/node-redis/pull/2373 introduced a bug into the creation of cluster clients. The issue is that provided options for creating a socket are changed. The function `clientOptionsDefaults` in `cluster-slots.ts` is called twice once with `disableReconnect` `false` and the second call is the real call for creating clients but the function `clientOptionsDefaults` is overriding `this.#options.defaults.socket` at line 289 because `result.socket` is the same reference as `this.#options.defaults.socket`


fix https://github.com/redis/node-redis/issues/2721

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [X] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
