### PR TITLE
add support for all hash field expiration commands

### DIFF
--- a/packages/client/lib/cluster/commands.ts
+++ b/packages/client/lib/cluster/commands.ts
@@ -53,6 +53,9 @@ import * as GETRANGE from '../commands/GETRANGE';
 import * as GETSET from '../commands/GETSET';
 import * as HDEL from '../commands/HDEL';
 import * as HEXISTS from '../commands/HEXISTS';
+import * as HEXPIRE from '../commands/HEXPIRE';
+import * as HEXPIREAT from '../commands/HEXPIREAT';
+import * as HEXPIRETIME from '../commands/HEXPIRETIME';
 import * as HGET from '../commands/HGET';
 import * as HGETALL from '../commands/HGETALL';
 import * as HINCRBY from '../commands/HINCRBY';
@@ -60,6 +63,11 @@ import * as HINCRBYFLOAT from '../commands/HINCRBYFLOAT';
 import * as HKEYS from '../commands/HKEYS';
 import * as HLEN from '../commands/HLEN';
 import * as HMGET from '../commands/HMGET';
+import * as HPERSIST from '../commands/HPERSIST';
+import * as HPEXPIRE from '../commands/HPEXPIRE';
+import * as HPEXPIREAT from '../commands/HPEXPIREAT';
+import * as HPEXPIRETIME from '../commands/HPEXPIRETIME';
+import * as HPTTL from '../commands/HPTTL';
 import * as HRANDFIELD_COUNT_WITHVALUES from '../commands/HRANDFIELD_COUNT_WITHVALUES';
 import * as HRANDFIELD_COUNT from '../commands/HRANDFIELD_COUNT';
 import * as HRANDFIELD from '../commands/HRANDFIELD';
@@ -67,6 +75,7 @@ import * as HSCAN from '../commands/HSCAN';
 import * as HSET from '../commands/HSET';
 import * as HSETNX from '../commands/HSETNX';
 import * as HSTRLEN from '../commands/HSTRLEN';
+import * as HTTL from '../commands/HTTL';
 import * as HVALS from '../commands/HVALS';
 import * as INCR from '../commands/INCR';
 import * as INCRBY from '../commands/INCRBY';
@@ -321,6 +330,12 @@ export default {
     hDel: HDEL,
     HEXISTS,
     hExists: HEXISTS,
+    HEXPIRE,
+    hExpire: HEXPIRE,
+    HEXPIREAT,
+    hExpireAt: HEXPIREAT,
+    HEXPIRETIME,
+    hExpireTime: HEXPIRETIME,
     HGET,
     hGet: HGET,
     HGETALL,
@@ -335,6 +350,16 @@ export default {
     hLen: HLEN,
     HMGET,
     hmGet: HMGET,
+    HPERSIST,
+    hPersist: HPERSIST,
+    HPEXPIRE,
+    hpExpire: HPEXPIRE,
+    HPEXPIREAT,
+    hpExpireAt: HPEXPIREAT,
+    HPEXPIRETIME,
+    hpExpireTime: HPEXPIRETIME,
+    HPTTL,
+    hpTTL: HPTTL,
     HRANDFIELD_COUNT_WITHVALUES,
     hRandFieldCountWithValues: HRANDFIELD_COUNT_WITHVALUES,
     HRANDFIELD_COUNT,
@@ -349,6 +374,8 @@ export default {
     hSetNX: HSETNX,
     HSTRLEN,
     hStrLen: HSTRLEN,
+    HTTL,
+    hTTL: HTTL,
     HVALS,
     hVals: HVALS,
     INCR,

--- a/packages/client/lib/commands/HEXPIRE.spec.ts
+++ b/packages/client/lib/commands/HEXPIRE.spec.ts
@@ -1,0 +1,40 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './HEXPIRE';
+import { HASH_EXPIRATION_TIME } from './HEXPIRETIME';
+
+describe('HEXPIRE', () => {
+  testUtils.isVersionGreaterThanHook([7, 4]);
+
+  describe('transformArguments', () => {
+    it('string', () => {
+      assert.deepEqual(
+        transformArguments('key', 'field', 1),
+        ['HEXPIRE', 'key', '1', 'FIELDS', '1', 'field']
+      );
+    });
+
+    it('array', () => {
+      assert.deepEqual(
+        transformArguments('key', ['field1', 'field2'], 1),
+        ['HEXPIRE', 'key', '1', 'FIELDS', '2', 'field1', 'field2']
+      );
+    });
+
+    it('with set option', () => {
+      assert.deepEqual(
+        transformArguments('key', ['field1'], 1, 'NX'),
+        ['HEXPIRE', 'key', '1', 'NX', 'FIELDS', '1', 'field1']
+      );
+    });
+  });
+
+  testUtils.testWithClient('hexpire', async client => {
+    assert.deepEqual(
+      await client.hExpire('key', ['field1'], 0),
+      [ HASH_EXPIRATION_TIME.FieldNotExists ]
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN
+  });
+});

--- a/packages/client/lib/commands/HEXPIRE.ts
+++ b/packages/client/lib/commands/HEXPIRE.ts
@@ -1,0 +1,44 @@
+import { RedisCommandArgument } from '.';
+import { pushVerdictArgument } from './generic-transformers';
+
+/**
+ * @readonly
+ * @enum {number}
+ */
+export const HASH_EXPIRATION = {
+  /** @property {number} */
+  /** The field does not exist */
+  FieldNotExists: -2,
+  /** @property {number} */
+  /** Specified NX | XX | GT | LT condition not met */
+  ConditionNotMet: 0,
+  /** @property {number} */
+  /** Expiration time was set or updated */
+  Updated: 1,
+  /** @property {number} */
+  /** Field deleted because the specified expiration time is in the past */
+  Deleted: 2
+} as const;
+  
+export type HashExpiration = typeof HASH_EXPIRATION[keyof typeof HASH_EXPIRATION];
+
+export const FIRST_KEY_INDEX = 1;
+
+export function transformArguments(
+  key: RedisCommandArgument, 
+  fields: RedisCommandArgument| Array<RedisCommandArgument>,
+  seconds: number,
+  mode?: 'NX' | 'XX' | 'GT' | 'LT',
+) {
+  const args = ['HEXPIRE', key, seconds.toString()];
+
+  if (mode) {
+    args.push(mode);
+  }
+
+  args.push('FIELDS');
+
+  return pushVerdictArgument(args, fields);
+}
+
+export declare function transformReply(): Array<HashExpiration>;

--- a/packages/client/lib/commands/HEXPIREAT.spec.ts
+++ b/packages/client/lib/commands/HEXPIREAT.spec.ts
@@ -1,0 +1,49 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './HEXPIREAT';
+import { HASH_EXPIRATION_TIME } from './HEXPIRETIME';
+
+describe('HEXPIREAT', () => {
+  testUtils.isVersionGreaterThanHook([7, 4]);
+
+  describe('transformArguments', () => {
+    it('string + number', () => {
+      assert.deepEqual(
+        transformArguments('key', 'field', 1),
+        ['HEXPIREAT', 'key', '1', 'FIELDS', '1', 'field']
+      );
+    });
+
+    it('array + number', () => {
+      assert.deepEqual(
+        transformArguments('key', ['field1', 'field2'], 1),
+        ['HEXPIREAT', 'key', '1', 'FIELDS', '2', 'field1', 'field2']
+      );
+    });
+
+    it('date', () => {
+      const d = new Date();
+
+      assert.deepEqual(
+        transformArguments('key', ['field1'], d),
+        ['HEXPIREAT', 'key', Math.floor(d.getTime() / 1000).toString(), 'FIELDS', '1', 'field1']
+      );
+    });
+
+    it('with set option', () => {
+      assert.deepEqual(
+        transformArguments('key', 'field1', 1, 'GT'),
+        ['HEXPIREAT', 'key', '1', 'GT', 'FIELDS', '1', 'field1']
+      );
+    });
+  });
+
+  testUtils.testWithClient('expireAt', async client => {
+    assert.deepEqual(
+      await client.hExpireAt('key', 'field1', 1),
+      [ HASH_EXPIRATION_TIME.FieldNotExists ]
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+  });
+});

--- a/packages/client/lib/commands/HEXPIREAT.ts
+++ b/packages/client/lib/commands/HEXPIREAT.ts
@@ -1,0 +1,28 @@
+import { RedisCommandArgument } from '.';
+import { pushVerdictArgument, transformEXAT } from './generic-transformers';
+import { HashExpiration } from './HEXPIRE';
+
+export const FIRST_KEY_INDEX = 1;
+
+export function transformArguments(
+  key: RedisCommandArgument,
+  fields: RedisCommandArgument | Array<RedisCommandArgument>,
+  timestamp: number | Date,
+  mode?: 'NX' | 'XX' | 'GT' | 'LT'
+) {
+  const args = [
+    'HEXPIREAT',
+    key,
+    transformEXAT(timestamp)
+  ];
+
+  if (mode) {
+    args.push(mode);
+  }
+
+  args.push('FIELDS')
+
+  return pushVerdictArgument(args, fields);
+}
+
+export declare function transformReply(): Array<HashExpiration>;

--- a/packages/client/lib/commands/HEXPIRETIME.spec.ts
+++ b/packages/client/lib/commands/HEXPIRETIME.spec.ts
@@ -1,0 +1,32 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { HASH_EXPIRATION_TIME, transformArguments } from './HEXPIRETIME';
+
+describe('HEXPIRETIME', () => {
+  testUtils.isVersionGreaterThanHook([7, 4]);
+
+  describe('transformArguments', () => {
+    it('string', () => {
+      assert.deepEqual(
+        transformArguments('key', 'field'),
+        ['HEXPIRETIME', 'key', 'FIELDS', '1', 'field']
+      );
+    });
+
+    it('array', () => {
+      assert.deepEqual(
+        transformArguments('key', ['field1', 'field2']),
+        ['HEXPIRETIME', 'key', 'FIELDS', '2', 'field1', 'field2']
+      );
+    });
+  })
+
+  testUtils.testWithClient('hExpireTime', async client => {
+    assert.deepEqual(
+      await client.hExpireTime('key', 'field1'),
+      [ HASH_EXPIRATION_TIME.FieldNotExists ]
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+  });
+});

--- a/packages/client/lib/commands/HEXPIRETIME.ts
+++ b/packages/client/lib/commands/HEXPIRETIME.ts
@@ -1,0 +1,21 @@
+import { RedisCommandArgument } from '.';
+import { pushVerdictArgument } from './generic-transformers';
+
+export const HASH_EXPIRATION_TIME = {
+  /** @property {number} */
+  /** The field does not exist */
+  FieldNotExists: -2,
+  /** @property {number} */
+  /** The field exists but has no associated expire */
+  NoExpiration: -1,
+} as const;
+
+export const FIRST_KEY_INDEX = 1
+
+export const IS_READ_ONLY = true;
+
+export function transformArguments(key: RedisCommandArgument, fields: RedisCommandArgument | Array<RedisCommandArgument>) {
+  return pushVerdictArgument(['HEXPIRETIME', key, 'FIELDS'], fields);
+}
+
+export declare function transformReply(): Array<number>;

--- a/packages/client/lib/commands/HPERSIST.spec.ts
+++ b/packages/client/lib/commands/HPERSIST.spec.ts
@@ -1,0 +1,33 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './HPERSIST';
+import { HASH_EXPIRATION_TIME } from './HEXPIRETIME';
+
+describe('HPERSIST', () => {
+  testUtils.isVersionGreaterThanHook([7, 4]);
+  
+  describe('transformArguments', () => {
+    it('string', () => {
+      assert.deepEqual(
+        transformArguments('key', 'field'),
+        ['HPERSIST', 'key', 'FIELDS', '1', 'field']
+      );
+    });
+
+    it('array', () => {
+      assert.deepEqual(
+        transformArguments('key', ['field1', 'field2']),
+        ['HPERSIST', 'key', 'FIELDS', '2', 'field1', 'field2']
+      );
+    });
+  })
+
+  testUtils.testWithClient('hPersist', async client => {
+    assert.deepEqual(
+      await client.hPersist('key', 'field1'),
+      [ HASH_EXPIRATION_TIME.FieldNotExists ]
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+  });
+});

--- a/packages/client/lib/commands/HPERSIST.ts
+++ b/packages/client/lib/commands/HPERSIST.ts
@@ -1,0 +1,10 @@
+import { RedisCommandArgument } from '.';
+import { pushVerdictArgument } from './generic-transformers';
+
+export const FIRST_KEY_INDEX = 1;
+
+export function transformArguments(key: RedisCommandArgument, fields: RedisCommandArgument | Array<RedisCommandArgument>) {
+  return pushVerdictArgument(['HPERSIST', key, 'FIELDS'], fields);
+}
+
+export declare function transformReply(): Array<number> | null;

--- a/packages/client/lib/commands/HPEXPIRE.spec.ts
+++ b/packages/client/lib/commands/HPEXPIRE.spec.ts
@@ -1,0 +1,40 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './HPEXPIRE';
+import { HASH_EXPIRATION_TIME } from './HEXPIRETIME';
+
+describe('HEXPIRE', () => {
+  testUtils.isVersionGreaterThanHook([7, 4]);
+
+  describe('transformArguments', () => {
+    it('string', () => {
+      assert.deepEqual(
+        transformArguments('key', 'field', 1),
+        ['HPEXPIRE', 'key', '1', 'FIELDS', '1', 'field']
+      );
+    });
+
+    it('array', () => {
+      assert.deepEqual(
+        transformArguments('key', ['field1', 'field2'], 1),
+        ['HPEXPIRE', 'key', '1', 'FIELDS', '2', 'field1', 'field2']
+      );
+    });
+
+    it('with set option', () => {
+      assert.deepEqual(
+        transformArguments('key', ['field1'], 1, 'NX'),
+        ['HPEXPIRE', 'key', '1', 'NX', 'FIELDS', '1', 'field1']
+      );
+    });
+  });
+
+  testUtils.testWithClient('hexpire', async client => {
+    assert.deepEqual(
+      await client.hpExpire('key', ['field1'], 0),
+      [ HASH_EXPIRATION_TIME.FieldNotExists ]
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN
+  });
+});

--- a/packages/client/lib/commands/HPEXPIRE.ts
+++ b/packages/client/lib/commands/HPEXPIRE.ts
@@ -1,0 +1,24 @@
+import { RedisCommandArgument } from '.';
+import { pushVerdictArgument } from './generic-transformers';
+import { HashExpiration } from "./HEXPIRE";
+
+export const FIRST_KEY_INDEX = 1;
+
+export function transformArguments(
+  key: RedisCommandArgument, 
+  fields: RedisCommandArgument | Array<RedisCommandArgument>,
+  ms: number,
+  mode?: 'NX' | 'XX' | 'GT' | 'LT',
+) {
+  const args = ['HPEXPIRE', key, ms.toString()];
+
+  if (mode) {
+    args.push(mode);
+  }
+
+  args.push('FIELDS')
+
+  return pushVerdictArgument(args, fields);
+}
+
+export declare function transformReply(): Array<HashExpiration> | null;

--- a/packages/client/lib/commands/HPEXPIREAT.spec.ts
+++ b/packages/client/lib/commands/HPEXPIREAT.spec.ts
@@ -1,0 +1,48 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './HPEXPIREAT';
+import { HASH_EXPIRATION_TIME } from './HEXPIRETIME';
+
+describe('HPEXPIREAT', () => {
+  testUtils.isVersionGreaterThanHook([7, 4]);
+
+  describe('transformArguments', () => {
+    it('string + number', () => {
+      assert.deepEqual(
+        transformArguments('key', 'field', 1),
+        ['HPEXPIREAT', 'key', '1', 'FIELDS', '1', 'field']
+      );
+    });
+
+    it('array + number', () => {
+      assert.deepEqual(
+        transformArguments('key', ['field1', 'field2'], 1),
+        ['HPEXPIREAT', 'key', '1', 'FIELDS', '2', 'field1', 'field2']
+      );
+    });
+
+    it('date', () => {
+      const d = new Date();
+      assert.deepEqual(
+        transformArguments('key', ['field1'], d),
+        ['HPEXPIREAT', 'key', d.getTime().toString(), 'FIELDS', '1', 'field1']
+      );
+    });
+
+    it('with set option', () => {
+      assert.deepEqual(
+        transformArguments('key', ['field1'], 1, 'XX'),
+        ['HPEXPIREAT', 'key', '1', 'XX', 'FIELDS', '1', 'field1']
+      );
+    });
+  });
+
+  testUtils.testWithClient('hpExpireAt', async client => {
+    assert.deepEqual(
+      await client.hpExpireAt('key', ['field1'], 1),
+      [ HASH_EXPIRATION_TIME.FieldNotExists ]
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+  });
+});

--- a/packages/client/lib/commands/HPEXPIREAT.ts
+++ b/packages/client/lib/commands/HPEXPIREAT.ts
@@ -1,0 +1,25 @@
+import { RedisCommandArgument } from '.';
+import { pushVerdictArgument, transformEXAT, transformPXAT } from './generic-transformers';
+import { HashExpiration } from './HEXPIRE';
+
+export const FIRST_KEY_INDEX = 1;
+export const IS_READ_ONLY = true;
+
+export function transformArguments(
+  key: RedisCommandArgument,
+  fields: RedisCommandArgument | Array<RedisCommandArgument>,
+  timestamp: number | Date,
+  mode?: 'NX' | 'XX' | 'GT' | 'LT'
+) {
+  const args = ['HPEXPIREAT', key, transformPXAT(timestamp)];
+
+  if (mode) {
+    args.push(mode);
+  }
+
+  args.push('FIELDS')
+
+  return pushVerdictArgument(args, fields);
+}
+
+export declare function transformReply(): Array<HashExpiration> | null;

--- a/packages/client/lib/commands/HPEXPIRETIME.spec.ts
+++ b/packages/client/lib/commands/HPEXPIRETIME.spec.ts
@@ -1,0 +1,33 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './HPEXPIRETIME';
+import { HASH_EXPIRATION_TIME } from './HEXPIRETIME';
+
+describe('HPEXPIRETIME', () => {
+  testUtils.isVersionGreaterThanHook([7, 4]);
+
+  describe('transformArguments', () => {
+    it('string', () => {
+      assert.deepEqual(
+        transformArguments('key', 'field'),
+        ['HPEXPIRETIME', 'key', 'FIELDS', '1', 'field']
+      );
+    });
+
+    it('array', () => {
+      assert.deepEqual(
+        transformArguments('key', ['field1', 'field2']),
+        ['HPEXPIRETIME', 'key', 'FIELDS', '2', 'field1', 'field2']
+      );
+    });
+  });
+
+  testUtils.testWithClient('hpExpireTime', async client => {
+    assert.deepEqual(
+      await client.hpExpireTime('key', 'field1'),
+      [ HASH_EXPIRATION_TIME.FieldNotExists ]
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN
+  });
+});

--- a/packages/client/lib/commands/HPEXPIRETIME.ts
+++ b/packages/client/lib/commands/HPEXPIRETIME.ts
@@ -1,0 +1,11 @@
+import { RedisCommandArgument } from '.';
+import { pushVerdictArgument } from './generic-transformers';
+
+export const FIRST_KEY_INDEX = 1;
+export const IS_READ_ONLY = true;
+
+export function transformArguments(key: RedisCommandArgument, fields: RedisCommandArgument | Array<RedisCommandArgument>) {
+  return pushVerdictArgument(['HPEXPIRETIME', key, 'FIELDS'], fields);
+}
+
+export declare function transformReply(): Array<number> | null;

--- a/packages/client/lib/commands/HPTTL.spec.ts
+++ b/packages/client/lib/commands/HPTTL.spec.ts
@@ -1,0 +1,33 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './HPTTL';
+import { HASH_EXPIRATION_TIME } from './HEXPIRETIME';
+
+describe('HPTTL', () => {
+  testUtils.isVersionGreaterThanHook([7, 4]);
+
+  describe('transformArguments', () => {
+    it('string', () => {
+      assert.deepEqual(
+        transformArguments('key', 'field'),
+        ['HPTTL', 'key', 'FIELDS', '1', 'field']
+      );
+    });
+
+    it('array', () => {
+      assert.deepEqual(
+        transformArguments('key', ['field1', 'field2']),
+        ['HPTTL', 'key', 'FIELDS', '2', 'field1', 'field2']
+      );
+    });
+  });
+
+  testUtils.testWithClient('hpTTL', async client => {
+    assert.deepEqual(
+      await client.hpTTL('key', 'field1'),
+      [ HASH_EXPIRATION_TIME.FieldNotExists ]
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN
+  });
+});

--- a/packages/client/lib/commands/HPTTL.ts
+++ b/packages/client/lib/commands/HPTTL.ts
@@ -1,0 +1,11 @@
+import { RedisCommandArgument } from '.';
+import { pushVerdictArgument } from './generic-transformers';
+
+export const FIRST_KEY_INDEX = 1;
+export const IS_READ_ONLY =  true;
+
+export function transformArguments(key: RedisCommandArgument, fields: RedisCommandArgument | Array<RedisCommandArgument>) {
+  return pushVerdictArgument(['HPTTL', key, 'FIELDS'], fields);
+}
+
+export declare function transformReply(): Array<number> | null;

--- a/packages/client/lib/commands/HTTL.spec.ts
+++ b/packages/client/lib/commands/HTTL.spec.ts
@@ -1,0 +1,34 @@
+import { strict as assert } from 'node:assert';
+import testUtils, { GLOBAL } from '../test-utils';
+import { transformArguments } from './HTTL';
+import { HASH_EXPIRATION_TIME } from './HEXPIRETIME';
+
+describe('HTTL', () => {
+  testUtils.isVersionGreaterThanHook([7, 4]);
+
+  describe('transformArguments', () => {
+    it('string', () => {
+      assert.deepEqual(
+        transformArguments('key', 'field'),
+        ['HTTL', 'key', 'FIELDS', '1', 'field']
+      );
+    });
+
+    it('array', () => {
+      assert.deepEqual(
+        transformArguments('key', ['field1', 'field2']),
+        ['HTTL', 'key', 'FIELDS', '2', 'field1', 'field2']
+      );
+    });
+  
+  });
+
+  testUtils.testWithClient('hTTL', async client => {
+    assert.deepEqual(
+      await client.hTTL('key', 'field1'),
+      [ HASH_EXPIRATION_TIME.FieldNotExists ]
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN
+  });
+});

--- a/packages/client/lib/commands/HTTL.ts
+++ b/packages/client/lib/commands/HTTL.ts
@@ -1,0 +1,11 @@
+import { RedisCommandArgument } from '.';
+import { pushVerdictArgument } from './generic-transformers';
+
+export const FIRST_KEY_INDEX = 1;
+export const IS_READ_ONLY = true;
+
+export function transformArguments(key: RedisCommandArgument, fields: RedisCommandArgument | Array<RedisCommandArgument>) {
+  return pushVerdictArgument(['HTTL', key, 'FIELDS'], fields);
+}
+
+export declare function transformReply(): Array<number> | null;

--- a/packages/client/lib/test-utils.ts
+++ b/packages/client/lib/test-utils.ts
@@ -5,7 +5,7 @@ import { promiseTimeout } from './utils';
 const utils = new TestUtils({
   dockerImageName: 'redis',
   dockerImageVersionArgument: 'redis-version',
-  defaultDockerVersion: '7.2'
+  defaultDockerVersion: '7.4-rc2'
 });
 
 export default utils;


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
