### PR TITLE
fix: XRangeOptions COUNT

### DIFF
--- a/doctests/dt-streams.js
+++ b/doctests/dt-streams.js
@@ -49,7 +49,7 @@ assert.equal(await client.xLen('race:france'), 3);
 // REMOVE_END
 
 // STEP_START xRange
-const res4 = await client.xRange('race:france', '1691765278160-0', '+', 2);
+const res4 = await client.xRange('race:france', '1691765278160-0', '+', {COUNT: 2});
 console.log(res4); // >>> [('1692629576966-0', {'rider': 'Castilla', 'speed': '30.2', 'position': '1', 'location_id': '1'}), ('1692629594113-0', {'rider': 'Norem', 'speed': '28.8', 'position': '3', 'location_id': '1'})]
 // STEP_END
 
@@ -121,22 +121,22 @@ console.log(res12); // >>> [('1692629576966-0', {'rider': 'Castilla', 'speed': '
 // STEP_END
 
 // STEP_START xRange_step_1
-const res13 = await client.xRange('race:france', '-', '+', 2);
+const res13 = await client.xRange('race:france', '-', '+', {COUNT: 2});
 console.log(res13); // >>> [('1692629576966-0', {'rider': 'Castilla', 'speed': '30.2', 'position': '1', 'location_id': '1'}), ('1692629594113-0', {'rider': 'Norem', 'speed': '28.8', 'position': '3', 'location_id': '1'})]
 // STEP_END
 
 // STEP_START xRange_step_2
-const res14 = await client.xRange('race:france', '(1692629594113-0', '+', 2);
+const res14 = await client.xRange('race:france', '(1692629594113-0', '+', {COUNT: 2});
 console.log(res14); // >>> [('1692629613374-0', {'rider': 'Prickett', 'speed': '29.7', 'position': '2', 'location_id': '1'}), ('1692629676124-0', {'rider': 'Castilla', 'speed': '29.9', 'position': '1', 'location_id': '2'})]
 // STEP_END
 
 // STEP_START xRange_empty
-const res15 = await client.xRange('race:france', '(1692629676124-0', '+', 2);
+const res15 = await client.xRange('race:france', '(1692629676124-0', '+', {COUNT: 2});
 console.log(res15); // >>> []
 // STEP_END
 
 // STEP_START xrevrange
-const res16 = await client.xRevRange('race:france', '+', '-', 1);
+const res16 = await client.xRevRange('race:france', '+', '-', {COUNT: 1});
 console.log(
   res16
 ); // >>> [('1692629676124-0', {'rider': 'Castilla', 'speed': '29.9', 'position': '1', 'location_id': '2'})]


### PR DESCRIPTION
### Description
> The COUNT in XRangeOptions is wrapped by an object, as follows：
``` ts
interface XRangeOptions {
    COUNT?: number;
}

export function transformArguments(
    key: RedisCommandArgument,
    start: RedisCommandArgument,
    end: RedisCommandArgument,
    options?: XRangeOptions
): RedisCommandArguments {
    const args = ['XRANGE', key, start, end];

    if (options?.COUNT) {
        args.push('COUNT', options.COUNT.toString());
    }

    return args;
}
```

And in examples by Node.js is a number, so i fix it.


---

### Checklist

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
