### PR TITLE
understand that null responses can be returned for the key/value array

### DIFF
--- a/packages/search/lib/commands/SEARCH.ts
+++ b/packages/search/lib/commands/SEARCH.ts
@@ -73,11 +73,14 @@ export type SearchRawReply = Array<any>;
 export function transformReply(reply: SearchRawReply, withoutDocuments: boolean): SearchReply {
     const documents = [];
     let i = 1;
+
     while (i < reply.length) {
         documents.push({
-            id: reply[i++],
-            value: withoutDocuments ? Object.create(null) : documentValue(reply[i++])
+            id: reply[i],
+            value: withoutDocuments || reply[i+1] == null ? Object.create(null) : documentValue(reply[i+1])
         });
+
+        i += 2;
     }
 
     return {


### PR DESCRIPTION
in #2772 users noted that we are throwing a javascript exception as we are trying to apply .length to a null and hence that fails.

we have 2 options.  First, we can just elide these results from the response we give the user, but this wouldn't correspond to the ft.search documentation.  Therefore, instead, as redis doesn't return a document, but a null, we should do the same, and return an empty null object for these documents.  It's up to the user to handle them

fixes #2772 

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
