### PR TITLE
fix: #2522 max call stack size exceeded on MSET function

### DIFF
--- a/packages/client/lib/commands/MSET.ts
+++ b/packages/client/lib/commands/MSET.ts
@@ -8,17 +8,17 @@ export type MSetArguments =
     Record<string, RedisCommandArgument>;
 
 export function transformArguments(toSet: MSetArguments): RedisCommandArguments {
-    const args: RedisCommandArguments = ['MSET'];
 
     if (Array.isArray(toSet)) {
-        args.push(...toSet.flat());
+        return ['MSET', ...toSet.flat()]
     } else {
+        const args: RedisCommandArguments = ['MSET'];
         for (const key of Object.keys(toSet)) {
             args.push(key, toSet[key]);
         }
+        return args;
     }
 
-    return args;
 }
 
 export declare function transformReply(): RedisCommandArgument;


### PR DESCRIPTION
Passing an array with several items to mset will throw a Maximum call stack size exceeded exception on args.push
