### PR TITLE
fix(ts): xtrim threshold accepts string

### DIFF
--- a/packages/client/lib/commands/XTRIM.ts
+++ b/packages/client/lib/commands/XTRIM.ts
@@ -10,7 +10,7 @@ interface XTrimOptions {
 export function transformArguments(
     key: RedisCommandArgument,
     strategy: 'MAXLEN' | 'MINID',
-    threshold: number,
+    threshold: number | string,
     options?: XTrimOptions
 ): RedisCommandArguments {
     const args = ['XTRIM', key, strategy];


### PR DESCRIPTION
### Description

The [`XTRIM` command](https://redis.io/docs/latest/commands/xtrim/) accepts a streamId that is a string:

```
XTRIM foo MINID "1725522294258-0"
```

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
