### PR TITLE
createClient url+tls invariant violation check

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -58,7 +58,8 @@ describe('Client', () => {
                 {
                     socket: {
                         host: 'localhost',
-                        port: 6379
+                        port: 6379,
+                        tls: false
                     },
                     username: 'user',
                     password: 'secret',
@@ -103,8 +104,54 @@ describe('Client', () => {
                 {
                     socket: {
                         host: 'localhost',
+                        tls: false
                     }
                 }
+            );
+        });
+    });
+
+    describe('parseOptions', () => {
+        it('should throw error if tls socket option is set to true and the url protocol is "redis:"', () => {
+            assert.throws(
+                () => RedisClient.parseOptions({
+                    url: 'redis://localhost',
+                    socket: {
+                        tls: true
+                    }
+                }),
+                TypeError
+            );
+        });
+        it('should throw error if tls socket option is set to false and the url protocol is "rediss:"', () => {
+            assert.throws(
+                () => RedisClient.parseOptions({
+                    url: 'rediss://localhost',
+                    socket: {
+                        tls: false
+                    }
+                }),
+                TypeError
+            );
+        });
+        it('should not throw when tls socket option and url protocol matches"', () => {
+            assert.equal(
+                RedisClient.parseOptions({
+                    url: 'rediss://localhost',
+                    socket: {
+                        tls: true
+                    }
+                }).socket.tls,
+                true
+            );
+            assert.equal(
+                RedisClient.parseOptions({
+                    url: 'redis://localhost',
+                    socket: {
+                        tls: false
+                    }
+                }).socket.tls,
+                false
             );
         });
     });

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -157,20 +157,44 @@ export default class RedisClient<
         return new (RedisClient.extend(options))(options);
     }
 
-    static parseURL(url: string): RedisClientOptions {
+    static parseOptions<O extends RedisClientOptions>(options: O): O {
+        if (options?.url) {
+            const parsed = RedisClient.parseURL(options.url);
+            if (options.socket) {
+                if (options.socket.tls !== undefined && options.socket.tls !== parsed.socket.tls) {
+                    throw new TypeError(`tls socket option is set to ${options.socket.tls} which is mismatch with protocol or the URL ${options.url} passed`)
+                }
+                parsed.socket = Object.assign(options.socket, parsed.socket);
+            }
+
+            Object.assign(options, parsed);
+        }
+        return options;
+    }
+
+    static parseURL(url: string): RedisClientOptions & {
+        socket: Exclude<RedisClientOptions['socket'], undefined> & {
+            tls: boolean
+        }
+    } {
         // https://www.iana.org/assignments/uri-schemes/prov/redis
         const { hostname, port, protocol, username, password, pathname } = new URL(url),
-            parsed: RedisClientOptions = {
+            parsed: RedisClientOptions & {
+              socket: Exclude<RedisClientOptions['socket'], undefined> & {
+                tls: boolean
+              }
+            } = {
                 socket: {
-                    host: hostname
+                    host: hostname,
+                    tls: false
                 }
             };
 
-        if (protocol === 'rediss:') {
-            (parsed.socket as RedisTlsSocketOptions).tls = true;
-        } else if (protocol !== 'redis:') {
+        if (protocol !== 'redis:' && protocol !== 'rediss:') {
             throw new TypeError('Invalid protocol');
         }
+
+        parsed.socket.tls = protocol === 'rediss:';
 
         if (port) {
             (parsed.socket as TcpSocketConnectOpts).port = Number(port);
@@ -239,17 +263,12 @@ export default class RedisClient<
     }
 
     #initiateOptions(options?: RedisClientOptions<M, F, S>): RedisClientOptions<M, F, S> | undefined {
-        if (options?.url) {
-            const parsed = RedisClient.parseURL(options.url);
-            if (options.socket) {
-                parsed.socket = Object.assign(options.socket, parsed.socket);
-            }
-
-            Object.assign(options, parsed);
-        }
-
         if (options?.database) {
             this.#selectedDB = options.database;
+        }
+
+        if (options) {
+            return RedisClient.parseOptions(options);
         }
 
         return options;


### PR DESCRIPTION
### Description

on url `rediss:..` + tls: false passed or on url: `redis:` + rls: true passed, the lib blows up during connection with a non-descriptive error

I explicitly check for this invariant violation during initialisation

- parseOptions was added to make it testable and to avoid the pesky `this.#selectedDB = options.database;` in `#initiateOptions` I dare not to touch
- parseOptions is supposed to check cross-field invariants that parseUrl alone won't be able to do
- parseUrl explicitly states on type-level that it affects `tls` (it did this anyways, implicitly, by blowing up the connection on wrong tls passed)
- parseOptions mutates its arguments as well as returns the mutated value in accord with how `#initiateOptions` was implemented (let me know if you'd like me to not-mutate the argument; I'd actually prefer it this way)
- the technical change is that initialization will now set `tls` explicitly to boolean if it wasn't set but an `url` was passed: reasons are both technical (I needed to test without changing your interfaces much) and logical: `tls` undefined with URL: `redis[s]:` seems to be an incorrect invariant anyways

Options:

- not throw any errors, silently overriding user-given value - I prefer to fail-fast, because the instance will fail anyways on connection

---

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

