### PR TITLE
Handle null tuple for redisearch document

### DIFF
--- a/packages/search/lib/commands/SEARCH.ts
+++ b/packages/search/lib/commands/SEARCH.ts
@@ -202,6 +202,10 @@ export interface SearchReply {
 function documentValue(tuples: any) {
   const message = Object.create(null);
 
+  if (tuples == null) {
+    return message;
+  }
+
   let i = 0;
   while (i < tuples.length) {
       const key = tuples[i++],


### PR DESCRIPTION
### Description

Recently, I updated to the latest version of RediSearch (2.10.7). I started getting a particular error that originates from within the redisearch module:

```
Cannot read properties of null (reading 'length') TypeError: Cannot read properties of null (reading 'length')
    at documentValue (/app/node_modules/.pnpm/@redis+search@1.2.0_@redis+client@1.6.0/node_modules/@redis/search/dist/commands/SEARCH.js:29:23)
    at Object.transformReply (/app/node_modules/.pnpm/@redis+search@1.2.0_@redis+client@1.6.0/node_modules/@redis/search/dist/commands/SEARCH.js:17:61)
    at transformCommandReply (/app/node_modules/.pnpm/@redis+client@1.6.0/node_modules/@redis/client/dist/lib/commander.js:89:20)
    at Commander.commandsExecutor (/app/node_modules/.pnpm/@redis+client@1.6.0/node_modules/@redis/client/dist/lib/client/index.js:190:54)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

This error seems to have originated from [this change](https://github.com/RediSearch/RediSearch/pull/4803). Instead of returning an empty array `[]`, `None` is returned. The library does not handle this case, and so the error is thrown.

This PR checks if the document is NULL, and if it is, return the object. This would give the same behavior as before.

---

### Checklist

- [ ] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
