### PR TITLE
Update cmds-hash.js

### DIFF
--- a/doctests/cmds-hash.js
+++ b/doctests/cmds-hash.js
@@ -55,7 +55,7 @@ const res8 = await client.hGet('myhash', 'field1')
 console.log(res8) // foo
 
 const res9 = await client.hGet('myhash', 'field2')
-console.log(res9) // foo
+console.log(res9) // null
 
 // REMOVE_START
 assert.equal(res7, 1);


### PR DESCRIPTION

### Update on HGET Docs page - Nodejs Tab

The comment besides the line `console.log(res9)`  under nodejs tab in the examples subsection on this page [https://redis.io/docs/latest/commands/hget/](https://redis.io/docs/latest/commands/hget/) should `null` not `foo`
