### PR TITLE
[CAE-827] Changed ft create vector types to union, added support for int8/uint8

### DIFF
--- a/packages/search/lib/commands/CREATE.spec.ts
+++ b/packages/search/lib/commands/CREATE.spec.ts
@@ -473,4 +473,87 @@ describe('FT.CREATE', () => {
       'OK'
     );
   }, GLOBAL.SERVERS.OPEN);
+
+  testUtils.testWithClientIfVersionWithinRange([[7], 'LATEST'], 'client.ft.create vector types floats', async client => {
+    assert.equal(
+      await client.ft.create("index_float32", {
+        field: {
+          ALGORITHM: "FLAT",
+          TYPE: "FLOAT32",
+          DIM: 1,
+          DISTANCE_METRIC: 'COSINE',
+          type: 'VECTOR'
+        },
+      }),
+      "OK"
+    );
+
+    assert.equal(
+      await client.ft.create("index_float64", {
+        field: {
+          ALGORITHM: "FLAT",
+          TYPE: "FLOAT64",
+          DIM: 1,
+          DISTANCE_METRIC: 'COSINE',
+          type: 'VECTOR'
+        },
+      }),
+      "OK"
+    );
+
+    assert.equal(
+      await client.ft.create("index_float16", {
+        field: {
+          ALGORITHM: "FLAT",
+          TYPE: "FLOAT16",
+          DIM: 1,
+          DISTANCE_METRIC: 'COSINE',
+          type: 'VECTOR'
+        },
+      }),
+      "OK"
+    );
+
+    assert.equal(
+      await client.ft.create("index_bloat16", {
+        field: {
+          ALGORITHM: "FLAT",
+          TYPE: "BFLOAT16",
+          DIM: 1,
+          DISTANCE_METRIC: 'COSINE',
+          type: 'VECTOR'
+        },
+      }),
+      "OK"
+    );
+  }, GLOBAL.SERVERS.OPEN);
+
+
+  testUtils.testWithClientIfVersionWithinRange([[8], 'LATEST'], 'client.ft.create vector types ints', async client => {
+    assert.equal(
+      await client.ft.create("index_int8", {
+        field: {
+          ALGORITHM: "FLAT",
+          TYPE: "INT8",
+          DIM: 1,
+          DISTANCE_METRIC: 'COSINE',
+          type: 'VECTOR'
+        },
+      }),
+      "OK"
+    );
+
+    assert.equal(
+      await client.ft.create("index_uint8", {
+        field: {
+          ALGORITHM: "FLAT",
+          TYPE: "UINT8",
+          DIM: 1,
+          DISTANCE_METRIC: 'COSINE',
+          type: 'VECTOR'
+        },
+      }),
+      "OK"
+    );
+  }, GLOBAL.SERVERS.OPEN);
 });

--- a/packages/search/lib/commands/CREATE.spec.ts
+++ b/packages/search/lib/commands/CREATE.spec.ts
@@ -474,7 +474,7 @@ describe('FT.CREATE', () => {
     );
   }, GLOBAL.SERVERS.OPEN);
 
-  testUtils.testWithClientIfVersionWithinRange([[7], 'LATEST'], 'client.ft.create vector types floats', async client => {
+  testUtils.testWithClientIfVersionWithinRange([[7], 'LATEST'], 'client.ft.create vector types big floats', async client => {
     assert.equal(
       await client.ft.create("index_float32", {
         field: {
@@ -500,7 +500,10 @@ describe('FT.CREATE', () => {
       }),
       "OK"
     );
+  }, GLOBAL.SERVERS.OPEN);
 
+
+  testUtils.testWithClientIfVersionWithinRange([[8], 'LATEST'], 'client.ft.create vector types small floats and ints', async client => {
     assert.equal(
       await client.ft.create("index_float16", {
         field: {
@@ -526,10 +529,7 @@ describe('FT.CREATE', () => {
       }),
       "OK"
     );
-  }, GLOBAL.SERVERS.OPEN);
-
-
-  testUtils.testWithClientIfVersionWithinRange([[8], 'LATEST'], 'client.ft.create vector types ints', async client => {
+   
     assert.equal(
       await client.ft.create("index_int8", {
         field: {

--- a/packages/search/lib/commands/CREATE.ts
+++ b/packages/search/lib/commands/CREATE.ts
@@ -61,7 +61,7 @@ export type SchemaVectorFieldAlgorithm = typeof SCHEMA_VECTOR_FIELD_ALGORITHM[ke
 
 interface SchemaVectorField extends SchemaField<typeof SCHEMA_FIELD_TYPE['VECTOR']> {
   ALGORITHM: SchemaVectorFieldAlgorithm;
-  TYPE: string;
+  TYPE: 'FLOAT32' | 'FLOAT64' | 'BFLOAT16' | 'FLOAT16' | 'INT8' | 'UINT8';
   DIM: number;
   DISTANCE_METRIC: 'L2' | 'IP' | 'COSINE';
   INITIAL_CAP?: number;


### PR DESCRIPTION
### Description

Changed the vector type field from string to union with all supported versions (including int8 and uint8)

---

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

