### PR TITLE
[CAE-342] Initial sentinel issues fix

### DIFF
--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -325,6 +325,14 @@ export default class RedisClient<
     return this._self.#watchEpoch !== undefined;
   }
 
+  get watchEpoch() {
+    return this._self.#watchEpoch
+  }
+
+  setWatchEpoch(watchEpoch: number | undefined) {
+    this._self.#watchEpoch = watchEpoch
+  }
+
   setDirtyWatch(msg: string) {
     this._self.#dirtyWatch = msg;
   }

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -325,12 +325,8 @@ export default class RedisClient<
     return this._self.#watchEpoch !== undefined;
   }
 
-  get watchEpoch() {
-    return this._self.#watchEpoch
-  }
-
-  setWatchEpoch(watchEpoch: number | undefined) {
-    this._self.#watchEpoch = watchEpoch
+  get isDirtyWatch() {
+    return this._self.#dirtyWatch !== undefined
   }
 
   setDirtyWatch(msg: string) {

--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -486,7 +486,7 @@ async function steadyState(frame: SentinelFramework) {
       });
   
       // by taking a lease, we know we will block on master as no clients are available, but as read occuring, means replica read occurs
-      it('replica reads', async function () {
+      it.skip('replica reads', async function () {
         this.timeout(30000);
   
         sentinel = frame.getSentinelClient({ replicaPoolSize: 1 });
@@ -723,7 +723,7 @@ async function steadyState(frame: SentinelFramework) {
         tracer.push("multi was rejected");
       });
   
-      it('plain pubsub - channel', async function () {
+      it.skip('plain pubsub - channel', async function () {
         this.timeout(30000);
   
         sentinel = frame.getSentinelClient();
@@ -762,7 +762,7 @@ async function steadyState(frame: SentinelFramework) {
         assert.equal(tester, false);
       });
   
-      it('plain pubsub - pattern', async function () {
+      it.skip('plain pubsub - pattern', async function () {
         this.timeout(30000);
   
         sentinel = frame.getSentinelClient();

--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -78,7 +78,7 @@ async function steadyState(frame: SentinelFramework) {
 }
 
 ["redis-sentinel-test-password", undefined].forEach(function (password) {
-  describe.skip(`Sentinel - password = ${password}`, () => {
+  describe(`Sentinel - password = ${password}`, () => {
     const config: RedisSentinelConfig = { sentinelName: "test", numberOfNodes: 3, password: password };
     const frame = new SentinelFramework(config);
     let tracer = new Array<string>();
@@ -441,7 +441,7 @@ async function steadyState(frame: SentinelFramework) {
         assert.equal(await promise, null);
       });
 
-      it('reserve client, takes a client out of pool', async function () {
+      it.skip('reserve client, takes a client out of pool', async function () {
         this.timeout(30000);
   
         sentinel = frame.getSentinelClient({ masterPoolSize: 2, reserveClient: true });

--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -197,6 +197,11 @@ async function steadyState(frame: SentinelFramework) {
   
         await assert.doesNotReject(sentinel.get('x'));
       });
+
+      it('failed to connect', async function() {
+        sentinel = frame.getSentinelClient({sentinelRootNodes: [{host: "127.0.0.1", port: 1010}], maxCommandRediscovers: 0})
+        await assert.rejects(sentinel.connect());
+      });
   
       it('try to connect multiple times', async function () {
         sentinel = frame.getSentinelClient();

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -1107,12 +1107,10 @@ class RedisSentinelInternal<
       this.#trace(`transform: opening a new master`);
       const masterPromises = [];
       const masterWatches: Array<boolean> = [];
-      const watchEpochs: Array<number|undefined> = [];
 
       this.#trace(`transform: destroying old masters if open`);
       for (const client of this.#masterClients) {
-        masterWatches.push(client.isWatching);
-        watchEpochs.push(client.watchEpoch);
+        masterWatches.push(client.isWatching || client.isDirtyWatch);
 
         if (client.isOpen) {
           client.destroy()
@@ -1138,7 +1136,6 @@ class RedisSentinelInternal<
         });
 
         if (masterWatches[i]) {
-          client.setWatchEpoch(watchEpochs[i])
           client.setDirtyWatch("sentinel config changed in middle of a WATCH Transaction");
         }
         this.#masterClients.push(client);

--- a/packages/client/lib/sentinel/test-util.ts
+++ b/packages/client/lib/sentinel/test-util.ts
@@ -180,9 +180,14 @@ export class SentinelFramework extends DockerBase {
     RedisScripts,
     RespVersions, 
     TypeMapping>>, errors = true) {
-    if (opts?.sentinelRootNodes !== undefined) {
-      throw new Error("cannot specify sentinelRootNodes here");
-    }
+    // remove this safeguard
+    // in order to test the case when
+    // connecting to sentinel fails
+
+    // if (opts?.sentinelRootNodes !== undefined) {
+    //   throw new Error("cannot specify sentinelRootNodes here");
+    // }
+
     if (opts?.name !== undefined) {
       throw new Error("cannot specify sentinel db name here");
     }


### PR DESCRIPTION
### Description

Fixed a couple of issues with the sentinel implementation

1. Indefinite reconnects without taking into consideration `maxCommandRediscovers`
2. Client losing it's `watch` status if there are multiple topology changes during a transaction

Fixed an issue with the testing setup itself, using the new docker image and setting the `requirepass` and `masterauth` configuration settings in a persistent way.

Enabled the majority of sentinel tests, added new test for fix #1.
Still skipping some tests that are flaky and prone to failing 

---

### Checklist

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

