### PR TITLE
refactor(test-utils): remove TypeScript ignore directives for socket port

### DIFF
--- a/packages/test-utils/lib/index.ts
+++ b/packages/test-utils/lib/index.ts
@@ -250,8 +250,6 @@ export default class TestUtils {
         ...options.clientOptions,
         socket: {
           ...options.clientOptions?.socket,
-          // TODO
-          // @ts-ignore
           port: (await dockerPromise).port
         }
       });
@@ -325,8 +323,6 @@ export default class TestUtils {
         ...options.clientOptions,
         socket: {
           ...options.clientOptions?.socket,
-          // TODO
-          // @ts-ignore
           port: (await dockerPromise).port
         }
       }, options.poolOptions);


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

Remove ts-ignore from (test-utils) index.ts file
The "dockerPromise" property "port" matches the socket options "port" property (type: number)
Types match with no issues, tsx runs with no issues, all tests run with no issues.
Nothing else is mentioned about this todo, so I assumed it was related to the types.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
