### PR TITLE
docs: update the default credential provider for more efficient credentials

### DIFF
--- a/packages/entraid/README.md
+++ b/packages/entraid/README.md
@@ -18,8 +18,8 @@ Secure token-based authentication for Redis clients using Microsoft Entra ID (fo
 
 
 ```bash
-npm install "@redis/client@5.0.0-next.6"
-npm install "@redis/entraid@5.0.0-next.6"
+npm install "@redis/client@5.0.0-next.7"
+npm install "@redis/entraid@5.0.0-next.7"
 ```
 
 ## Getting Started
@@ -92,11 +92,11 @@ The DefaultAzureCredential from @azure/identity provides a simplified authentica
 
 ```typescript
 import { createClient } from '@redis/client';
-import { DefaultAzureCredential } from '@azure/identity';
-import { EntraIdCredentialsProviderFactory, REDIS_SCOPE_DEFAULT } from '@redis/entraid/dist/lib/entra-id-credentials-provider-factory';
+import { getDefaultAzureCredential } from '@azure/identity';
+import { EntraIdCredentialsProviderFactory, REDIS_SCOPE_DEFAULT } from '@redis/entraid';
 
 // Create a DefaultAzureCredential instance
-const credential = new DefaultAzureCredential();
+const credential = getDefaultAzureCredential();
 
 // Create a provider using DefaultAzureCredential
 const provider = EntraIdCredentialsProviderFactory.createForDefaultAzureCredential({


### PR DESCRIPTION

### Description

Minor update to the @redis/entraid package to include a more efficient way to create the default credential, as well as updating the current version of the library that needs to be used.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
