### PR TITLE
fix: loosen @azure/identity constraint for @redis/entraid

### DIFF
--- a/packages/entraid/package.json
+++ b/packages/entraid/package.json
@@ -17,7 +17,7 @@
     "test": "nyc -r text-summary -r lcov mocha -r tsx './lib/**/*.spec.ts'"
   },
   "dependencies": {
-    "@azure/identity": "4.7.0",
+    "@azure/identity": "^4.7.0",
     "@azure/msal-node": "^2.16.1"
   },
   "peerDependencies": {


### PR DESCRIPTION
### Description

This loosens the dependency constraint applied to `@azure/identity` so that versions other than 4.7.0 only can be used.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
