### PR TITLE
feat: added commandTimeout option

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -34,6 +34,7 @@ describe('Client', () => {
         },
         username: 'user',
         password: 'secret',
+        commandTimeout: 1000,
         database: 0,
         credentialsProvider: {
           type: 'async-credentials-provider',


### PR DESCRIPTION
### Description

 Some calls to redis took too long in our app by this feature this calls can be aborted.
The PR adds a commandTimeout to the `RedisClientOptions`. If the commandTimeout is set in the createClient, then a timeout is set in the `_executeCommand` function. 
The redisClient is used in the RateLimiterRedis in our app. In the case of a timeout the RateLimiterRedis insurance is supposed to be used as fallback. Therefore a `Promise.race` does not work.

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
