### PR TITLE
Export CommandParser from client index file and fix doc

### DIFF
--- a/docs/programmability.md
+++ b/docs/programmability.md
@@ -25,9 +25,8 @@ FUNCTION LOAD "#!lua name=library\nredis.register_function{function_name='add', 
 Load the prior redis function on the _redis server_ before running the example below.
 
 ```typescript
-import { CommandParser } from '@redis/client/lib/client/parser';
-import { NumberReply } from '@redis/client/lib/RESP/types';
-import { createClient, RedisArgument } from 'redis';
+import { CommandParser, createClient, RedisArgument } from '@redis/client';
+import { NumberReply } from '@redis/client/dist/lib/RESP/types.js';
 
 const client = createClient({
   functions: {
@@ -58,9 +57,8 @@ await client.library.add('key', '2'); // 3
 The following is an end-to-end example of the prior concept.
 
 ```typescript
-import { CommandParser } from '@redis/client/lib/client/parser';
-import { NumberReply } from '@redis/client/lib/RESP/types';
-import { createClient, defineScript, RedisArgument } from 'redis';
+import { CommandParser, createClient, defineScript, RedisArgument } from '@redis/client';
+import { NumberReply } from '@redis/client/dist/lib/RESP/types.js';
 
 const client = createClient({
   scripts: {

--- a/packages/client/index.ts
+++ b/packages/client/index.ts
@@ -1,4 +1,12 @@
-export { RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping/*, CommandPolicies*/, RedisArgument } from './lib/RESP/types';
+export {
+  /* CommandPolicies, */
+  RedisArgument,
+  RedisFunctions,
+  RedisModules,
+  RedisScripts,
+  RespVersions,
+  TypeMapping,
+} from './lib/RESP/types';
 export { RESP_TYPES } from './lib/RESP/decoder';
 export { VerbatimString } from './lib/RESP/verbatim-string';
 export { defineScript } from './lib/lua-script';

--- a/packages/client/index.ts
+++ b/packages/client/index.ts
@@ -7,6 +7,7 @@ export * from './lib/errors';
 import RedisClient, { RedisClientOptions, RedisClientType } from './lib/client';
 export { RedisClientOptions, RedisClientType };
 export const createClient = RedisClient.create;
+export { CommandParser } from './lib/client/parser';
 
 import { RedisClientPool, RedisPoolOptions, RedisClientPoolType } from './lib/client/pool';
 export { RedisClientPoolType, RedisPoolOptions };


### PR DESCRIPTION
### Description

* Export CommandParser from client index file
* Tidy up long export line in client index file
* Adapt and fix wrong examples in programmability doc

---

### Checklist

- [X] Does `npm test` pass with this change (including linting)?
- [X] Is the new or changed code fully tested?
- [X] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
