### PR TITLE
Disable readOnly for cluster s/pubsub client

### DIFF
--- a/packages/client/lib/cluster/cluster-slots.ts
+++ b/packages/client/lib/cluster/cluster-slots.ts
@@ -518,7 +518,7 @@ export default class RedisClusterSlots<
       node = index < this.masters.length ?
         this.masters[index] :
         this.replicas[index - this.masters.length],
-        client = this.#createClient(node, index >= this.masters.length);
+        client = this.#createClient(node, false);
       
     this.pubSubNode = {
       address: node.address,
@@ -563,7 +563,7 @@ export default class RedisClusterSlots<
   }
 
   async #initiateShardedPubSubClient(master: MasterNode<M, F, S, RESP, TYPE_MAPPING>) {
-    const client = this.#createClient(master, true)
+    const client = this.#createClient(master, false)
       .on('server-sunsubscribe', async (channel, listeners) => {
         try {
           await this.rediscover(client);


### PR DESCRIPTION
### Description
Ensure that the client used for s/pubsub does not use replicas 

### Checklist

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

