### PR TITLE
Disable readOnly for cluster s/pubsub client 4.7

### DIFF
--- a/packages/client/lib/cluster/cluster-slots.ts
+++ b/packages/client/lib/cluster/cluster-slots.ts
@@ -535,7 +535,7 @@ export default class RedisClusterSlots<
     
         this.pubSubNode = {
             address: node.address,
-            client: this.#createClient(node, true)
+            client: this.#createClient(node, false)
                 .then(async client => {
                     if (toResubscribe) {
                         await Promise.all([
@@ -574,7 +574,7 @@ export default class RedisClusterSlots<
     }
 
     #initiateShardedPubSubClient(master: MasterNode<M, F, S>) {
-        const promise = this.#createClient(master, true)
+        const promise = this.#createClient(master, false)
             .then(client => {
                 client.on('server-sunsubscribe', async (channel, listeners) => {
                     try {


### PR DESCRIPTION
### Description

Ensure that the client used for s/pubsub does not send ReadOnly commands

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

