### PR TITLE
Update Redis version to 8.0.1-pre

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,22 +7,22 @@ on:
       - v4.0
       - v5
     paths-ignore:
-      - '**/*.md'
+      - "**/*.md"
   pull_request:
     branches:
       - master
       - v4.0
       - v5
     paths-ignore:
-      - '**/*.md'
+      - "**/*.md"
 jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        node-version: [ '18', '20', '22' ]
-        redis-version: [ 'rs-7.2.0-v13', 'rs-7.4.0-v1', '8.0-RC2-pre' ]
+        node-version: ["18", "20", "22"]
+        redis-version: ["rs-7.2.0-v13", "rs-7.4.0-v1", "8.0.1-pre"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/packages/search/lib/commands/AGGREGATE.ts
+++ b/packages/search/lib/commands/AGGREGATE.ts
@@ -156,7 +156,7 @@ export default {
       }
   
       return {
-        total: Number(rawReply[0]),
+        total: results.length,
         results
       };
     },

--- a/packages/search/lib/commands/PROFILE_AGGREGATE.spec.ts
+++ b/packages/search/lib/commands/PROFILE_AGGREGATE.spec.ts
@@ -73,7 +73,7 @@ describe('PROFILE AGGREGATE', () => {
     const normalizeObject = obj => JSON.parse(JSON.stringify(obj));
     const res = await client.ft.profileAggregate('index', '*');
     const normalizedRes = normalizeObject(res);
-    assert.equal(normalizedRes.results.total, 1);
+    assert.equal(normalizedRes.results.total, 2);
 
     assert.ok(Array.isArray(normalizedRes.profile));
     assert.equal(normalizedRes.profile[0][0], 'Total profile time');


### PR DESCRIPTION
since >=8.0.1 
> FT.AGGREGATE returns an array reply where each row is an array reply
and represents a single aggregate result.
The integer reply at position 1 does not represent a valid value.

We now calculate the result length bazed on the number of results instead of the integer reply at pos 1