### PR TITLE
revert the 'total' count logic in AGGREGATE response introduced in #2952

### DIFF
--- a/packages/search/lib/commands/AGGREGATE.ts
+++ b/packages/search/lib/commands/AGGREGATE.ts
@@ -156,7 +156,10 @@ export default {
       }
   
       return {
-        total: results.length,
+        //  https://redis.io/docs/latest/commands/ft.aggregate/#return
+        //  FT.AGGREGATE returns an array reply where each row is an array reply and represents a single aggregate result.
+        // The integer reply at position 1 does not represent a valid value.
+        total: Number(rawReply[0]),
         results
       };
     },

--- a/packages/search/lib/commands/PROFILE_AGGREGATE.spec.ts
+++ b/packages/search/lib/commands/PROFILE_AGGREGATE.spec.ts
@@ -45,7 +45,9 @@ describe('PROFILE AGGREGATE', () => {
     const res = await client.ft.profileAggregate('index', '*');
 
     const normalizedRes = normalizeObject(res);
-    assert.equal(normalizedRes.results.total, 2);
+    // TODO uncomment after https://redis.io/docs/latest/commands/ft.aggregate/#return
+    // starts returning valid values
+    // assert.equal(normalizedRes.results.total, 2);
 
     assert.ok(normalizedRes.profile[0] === 'Shards');
     assert.ok(Array.isArray(normalizedRes.profile[1]));
@@ -73,7 +75,10 @@ describe('PROFILE AGGREGATE', () => {
     const normalizeObject = obj => JSON.parse(JSON.stringify(obj));
     const res = await client.ft.profileAggregate('index', '*');
     const normalizedRes = normalizeObject(res);
-    assert.equal(normalizedRes.results.total, 2);
+
+    // TODO uncomment after https://redis.io/docs/latest/commands/ft.aggregate/#return
+    // starts returning valid values
+    // assert.equal(normalizedRes.results.total, 2);
 
     assert.ok(Array.isArray(normalizedRes.profile));
     assert.equal(normalizedRes.profile[0][0], 'Total profile time');
@@ -103,8 +108,11 @@ describe('PROFILE AGGREGATE', () => {
     const normalizeObject = obj => JSON.parse(JSON.stringify(obj));
     const res = await client.ft.profileAggregate('index', '*');
 
+    // TODO uncomment after https://redis.io/docs/latest/commands/ft.aggregate/#return
+    // starts returning valid values
+    // assert.equal(res.Results.total_results, 2);
+
     const normalizedRes = normalizeObject(res);
-    assert.equal(normalizedRes.Results.total_results, 2);
     assert.ok(normalizedRes.Profile.Shards);
   }, GLOBAL.SERVERS.OPEN_3);
 });


### PR DESCRIPTION
> FT.AGGREGATE returns an array reply where each row is an array reply and represents a single aggregate result.
The integer reply at position 1 does not represent a valid value.

https://redis.io/docs/latest/commands/ft.aggregate/#return

