### PR TITLE
fix(client): cache subsequent clients

### DIFF
--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -207,7 +207,7 @@ export default class RedisClient<
     }
   }
 
-  static #SingleEntryCache = new SingleEntryCache()
+  static #SingleEntryCache = new SingleEntryCache<any, any>()
 
   static factory<
     M extends RedisModules = {},

--- a/packages/client/lib/client/pool.ts
+++ b/packages/client/lib/client/pool.ts
@@ -8,6 +8,7 @@ import { attachConfig, functionArgumentsPrefix, getTransformReply, scriptArgumen
 import { CommandOptions } from './commands-queue';
 import RedisClientMultiCommand, { RedisClientMultiCommandType } from './multi-command';
 import { BasicCommandParser } from './parser';
+import SingleEntryCache from '../single-entry-cache';
 
 export interface RedisPoolOptions {
   /**
@@ -110,6 +111,8 @@ export class RedisClientPool<
     };
   }
 
+  static #SingleEntryCache = new SingleEntryCache();
+
   static create<
     M extends RedisModules,
     F extends RedisFunctions,
@@ -120,17 +123,21 @@ export class RedisClientPool<
     clientOptions?: RedisClientOptions<M, F, S, RESP, TYPE_MAPPING>,
     options?: Partial<RedisPoolOptions>
   ) {
-    const Pool = attachConfig({
-      BaseClass: RedisClientPool,
-      commands: COMMANDS,
-      createCommand: RedisClientPool.#createCommand,
-      createModuleCommand: RedisClientPool.#createModuleCommand,
-      createFunctionCommand: RedisClientPool.#createFunctionCommand,
-      createScriptCommand: RedisClientPool.#createScriptCommand,
-      config: clientOptions
-    });
 
-    Pool.prototype.Multi = RedisClientMultiCommand.extend(clientOptions);
+    let Pool = RedisClientPool.#SingleEntryCache.get(clientOptions);
+    if(!Pool) {
+      Pool = attachConfig({
+        BaseClass: RedisClientPool,
+        commands: COMMANDS,
+        createCommand: RedisClientPool.#createCommand,
+        createModuleCommand: RedisClientPool.#createModuleCommand,
+        createFunctionCommand: RedisClientPool.#createFunctionCommand,
+        createScriptCommand: RedisClientPool.#createScriptCommand,
+        config: clientOptions
+      });
+      Pool.prototype.Multi = RedisClientMultiCommand.extend(clientOptions);
+      RedisClientPool.#SingleEntryCache.set(clientOptions, Pool);
+    }
 
     // returning a "proxy" to prevent the namespaces._self to leak between "proxies"
     return Object.create(

--- a/packages/client/lib/client/pool.ts
+++ b/packages/client/lib/client/pool.ts
@@ -111,7 +111,7 @@ export class RedisClientPool<
     };
   }
 
-  static #SingleEntryCache = new SingleEntryCache();
+  static #SingleEntryCache = new SingleEntryCache<any, any>();
 
   static create<
     M extends RedisModules,

--- a/packages/client/lib/cluster/index.ts
+++ b/packages/client/lib/cluster/index.ts
@@ -214,7 +214,7 @@ export default class RedisCluster<
     };
   }
 
-  static #SingleEntryCache = new SingleEntryCache();
+  static #SingleEntryCache = new SingleEntryCache<any, any>();
 
   static factory<
     M extends RedisModules = {},

--- a/packages/client/lib/single-entry-cache.spec.ts
+++ b/packages/client/lib/single-entry-cache.spec.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert';
+import SingleEntryCache from './single-entry-cache';
+
+describe('SingleEntryCache', () => {
+  let cache: SingleEntryCache;
+  beforeEach(() => {
+    cache = new SingleEntryCache();
+  });
+  
+  it('should return undefined when getting from empty cache', () => {
+    assert.strictEqual(cache.get({ key: 'value' }), undefined);
+  });
+
+  it('should return the cached instance when getting with the same key object', () => {
+    const keyObj = { key: 'value' };
+    const instance = { data: 'test data' };
+    
+    cache.set(keyObj, instance);
+    assert.strictEqual(cache.get(keyObj), instance);
+  });
+
+  it('should return undefined when getting with a different key object', () => {
+    const keyObj1 = { key: 'value1' };
+    const keyObj2 = { key: 'value2' };
+    const instance = { data: 'test data' };
+    
+    cache.set(keyObj1, instance);
+    assert.strictEqual(cache.get(keyObj2), undefined);
+  });
+
+  it('should update the cached instance when setting with the same key object', () => {
+    const keyObj = { key: 'value' };
+    const instance1 = { data: 'test data 1' };
+    const instance2 = { data: 'test data 2' };
+    
+    cache.set(keyObj, instance1);
+    assert.strictEqual(cache.get(keyObj), instance1);
+    
+    cache.set(keyObj, instance2);
+    assert.strictEqual(cache.get(keyObj), instance2);
+  });
+
+  it('should handle undefined key object', () => {
+    const instance = { data: 'test data' };
+    
+    cache.set(undefined, instance);
+    assert.strictEqual(cache.get(undefined), instance);
+  });
+
+  it('should handle complex objects as keys', () => {
+    const keyObj = { 
+      id: 123,
+      nested: { 
+        prop: 'value',
+        array: [1, 2, 3]
+      }
+    };
+    const instance = { data: 'complex test data' };
+    
+    cache.set(keyObj, instance);
+    assert.strictEqual(cache.get(keyObj), instance);
+  });
+
+  it('should consider objects with same properties but different order as different keys', () => {
+    const keyObj1 = { a: 1, b: 2 };
+    const keyObj2 = { b: 2, a: 1 }; // Same properties but different order
+    const instance = { data: 'test data' };
+    
+    cache.set(keyObj1, instance);
+    
+    assert.strictEqual(cache.get(keyObj2), undefined);
+  });
+});

--- a/packages/client/lib/single-entry-cache.spec.ts
+++ b/packages/client/lib/single-entry-cache.spec.ts
@@ -70,4 +70,16 @@ describe('SingleEntryCache', () => {
     
     assert.strictEqual(cache.get(keyObj2), undefined);
   });
+
+  it('should handle circular structures', () => {
+    const keyObj: any = {};
+    keyObj.self = keyObj;
+
+    const instance = { data: 'test data' };
+    
+    cache.set(keyObj, instance);
+    
+    assert.strictEqual(cache.get(keyObj), instance);
+  });
+
 });

--- a/packages/client/lib/single-entry-cache.ts
+++ b/packages/client/lib/single-entry-cache.ts
@@ -1,0 +1,25 @@
+export default class SingleEntryCache {
+  #cached?: any;
+  #key?: string;
+
+  /**
+   * Retrieves an instance from the cache based on the provided key object.
+   * 
+   * @param keyObj - The key object to look up in the cache.
+   * @returns The cached instance if found, undefined otherwise.
+   * 
+   * @remarks
+   * This method uses JSON.stringify for comparison, which may not work correctly
+   * if the properties in the key object are rearranged or reordered.
+   */
+  get(keyObj?: object) {
+    return JSON.stringify(keyObj) === this.#key
+      ? this.#cached
+      : undefined;
+  }
+
+  set(keyObj: object | undefined, obj: any) {
+    this.#cached = obj;
+    this.#key = JSON.stringify(keyObj);
+  }
+}

--- a/packages/client/lib/single-entry-cache.ts
+++ b/packages/client/lib/single-entry-cache.ts
@@ -1,19 +1,6 @@
-function makeCircularReplacer() {
-  const seen = new WeakSet();
-  return function serialize(_: string, value: any) {
-    if (value && typeof value === 'object') {
-      if (seen.has(value)) {
-        return 'circular';
-      }
-      seen.add(value);
-      return value;
-    }
-    return value;
-  }
-}
-export default class SingleEntryCache {
-  #cached?: any;
-  #key?: string;
+export default class SingleEntryCache<K, V> {
+  #cached?: V;
+  #serializedKey?: string;
 
   /**
    * Retrieves an instance from the cache based on the provided key object.
@@ -25,12 +12,26 @@ export default class SingleEntryCache {
    * This method uses JSON.stringify for comparison, which may not work correctly
    * if the properties in the key object are rearranged or reordered.
    */
-  get(keyObj?: object) {
-    return JSON.stringify(keyObj, makeCircularReplacer()) === this.#key ? this.#cached : undefined;
+  get(keyObj?: K): V | undefined {
+    return JSON.stringify(keyObj, makeCircularReplacer()) === this.#serializedKey ? this.#cached : undefined;
   }
 
-  set(keyObj: object | undefined, obj: any) {
+  set(keyObj:  K | undefined, obj: V) {
     this.#cached = obj;
-    this.#key = JSON.stringify(keyObj, makeCircularReplacer());
+    this.#serializedKey = JSON.stringify(keyObj, makeCircularReplacer());
+  }
+}
+
+function makeCircularReplacer() {
+  const seen = new WeakSet();
+  return function serialize(_: string, value: any) {
+    if (value && typeof value === 'object') {
+      if (seen.has(value)) {
+        return 'circular';
+      }
+      seen.add(value);
+      return value;
+    }
+    return value;
   }
 }

--- a/packages/client/lib/single-entry-cache.ts
+++ b/packages/client/lib/single-entry-cache.ts
@@ -1,25 +1,36 @@
+function makeCircularReplacer() {
+  const seen = new WeakSet();
+  return function serialize(_: string, value: any) {
+    if (value && typeof value === 'object') {
+      if (seen.has(value)) {
+        return 'circular';
+      }
+      seen.add(value);
+      return value;
+    }
+    return value;
+  }
+}
 export default class SingleEntryCache {
   #cached?: any;
   #key?: string;
 
   /**
    * Retrieves an instance from the cache based on the provided key object.
-   * 
+   *
    * @param keyObj - The key object to look up in the cache.
    * @returns The cached instance if found, undefined otherwise.
-   * 
+   *
    * @remarks
    * This method uses JSON.stringify for comparison, which may not work correctly
    * if the properties in the key object are rearranged or reordered.
    */
   get(keyObj?: object) {
-    return JSON.stringify(keyObj) === this.#key
-      ? this.#cached
-      : undefined;
+    return JSON.stringify(keyObj, makeCircularReplacer()) === this.#key ? this.#cached : undefined;
   }
 
   set(keyObj: object | undefined, obj: any) {
     this.#cached = obj;
-    this.#key = JSON.stringify(keyObj);
+    this.#key = JSON.stringify(keyObj, makeCircularReplacer());
   }
 }


### PR DESCRIPTION
we dont need to recreate a client if
its config hasnt changed

fixes #2954

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
