### PR TITLE
fix(handshake): ignore errors on client.setinfo

### DIFF
--- a/packages/client/lib/errors.ts
+++ b/packages/client/lib/errors.ts
@@ -70,11 +70,7 @@ export class ErrorReply extends Error {
   }
 }
 
-export class SimpleError extends ErrorReply {
-  isUnknownSubcommand(): boolean {
-    return this.message.toLowerCase().indexOf('err unknown subcommand') !== -1;
-  }
-}
+export class SimpleError extends ErrorReply {}
 
 export class BlobError extends ErrorReply {}
 


### PR DESCRIPTION
As per the documentation (https://redis.io/docs/latest/commands/client-setinfo):

Client libraries are expected to pipeline this command after authentication on all connections and ignore failures since they could be connected to an older version that doesn't support them.

Turns out different versions of redis server return different errors, so its better to catch all.

fixes #2968

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
