### PR TITLE
Adapt legacy sentinel tests to use the new test utils

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -89,8 +89,8 @@ describe('Client', () => {
         && expected?.credentialsProvider?.type === 'async-credentials-provider') {
 
         // Compare the actual output of the credentials functions
-        const resultCreds = await result.credentialsProvider.credentials();
-        const expectedCreds = await expected.credentialsProvider.credentials();
+        const resultCreds = await result.credentialsProvider?.credentials();
+        const expectedCreds = await expected.credentialsProvider?.credentials();
         assert.deepEqual(resultCreds, expectedCreds);
       } else {
         assert.fail('Credentials provider type mismatch');

--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -171,7 +171,7 @@ describe('RedisSentinel', () => {
   });
 });
 
-describe.skip(`test with scripts`, () => {
+describe(`test with scripts`, () => {
   testUtils.testWithClientSentinel('with script', async sentinel => {
     const [, reply] = await Promise.all([
       sentinel.set('key', '2'),
@@ -197,8 +197,7 @@ describe.skip(`test with scripts`, () => {
   }, GLOBAL.SENTINEL.WITH_SCRIPT)
 });
 
-
-describe.skip(`test with functions`, () => {
+describe(`test with functions`, () => {
   testUtils.testWithClientSentinel('with function', async sentinel => {
     await sentinel.functionLoad(
       MATH_FUNCTION.code,
@@ -238,7 +237,7 @@ describe.skip(`test with functions`, () => {
   }, GLOBAL.SENTINEL.WITH_FUNCTION);
 });
 
-describe.skip(`test with modules`, () => {
+describe(`test with modules`, () => {
   testUtils.testWithClientSentinel('with module', async sentinel => {
     const resp = await sentinel.bf.add('key', 'item')
     assert.equal(resp, true);
@@ -260,7 +259,7 @@ describe.skip(`test with modules`, () => {
   }, GLOBAL.SENTINEL.WITH_MODULE);
 });
 
-describe.skip(`test with replica pool size 1`, () => {
+describe(`test with replica pool size 1`, () => {
   testUtils.testWithClientSentinel('client lease', async sentinel => {
     sentinel.on("error", () => { });
 
@@ -302,7 +301,7 @@ describe.skip(`test with replica pool size 1`, () => {
   }, GLOBAL.SENTINEL.WITH_REPLICA_POOL_SIZE_1);
 });
 
-describe.skip(`test with masterPoolSize 2, reserve client true`, () => {
+describe(`test with masterPoolSize 2, reserve client true`, () => {
   // TODO: flaky test, sometimes fails with `promise1 === null`
   testUtils.testWithClientSentinel('reserve client, takes a client out of pool', async sentinel => {
     const promise1 = sentinel.use(
@@ -325,7 +324,7 @@ describe.skip(`test with masterPoolSize 2, reserve client true`, () => {
   }, Object.assign(GLOBAL.SENTINEL.WITH_RESERVE_CLIENT_MASTER_POOL_SIZE_2, {skipTest: true}));
 });
 
-describe.skip(`test with masterPoolSize 2`, () => {
+describe(`test with masterPoolSize 2`, () => {
   testUtils.testWithClientSentinel('multple clients', async sentinel => {
     sentinel.on("error", () => { });
 
@@ -383,6 +382,8 @@ describe.skip(`test with masterPoolSize 2`, () => {
 // sentinel
 // it should somehow replicate the `SentinelFramework` object functionallities
 async function steadyState(frame: SentinelFramework) {
+  // wait a bit to ensure that sentinels are seeing eachother
+  await setTimeout(2000)
   let checkedMaster = false;
   let checkedReplicas = false;
   while (!checkedMaster || !checkedReplicas) {
@@ -463,7 +464,6 @@ describe('legacy tests', () => {
       }
       setImmediate(deltaMeasurer);
       await frame.spawnRedisSentinel();
-
       await frame.getAllRunning();
       await steadyState(frame);
       longestTestDelta = 0;
@@ -856,7 +856,6 @@ describe('legacy tests', () => {
 
     it('shutdown sentinel node', async function () {
       this.timeout(60000);
-
       sentinel = frame.getSentinelClient();
       sentinel.setTracer(tracer);
       sentinel.on("error", () => { });
@@ -1013,7 +1012,7 @@ describe('legacy tests', () => {
       this.timeout(30000);
       const csc = new BasicPooledClientSideCache();
 
-      sentinel = frame.getSentinelClient({nodeClientOptions: {RESP: 3}, clientSideCache: csc, masterPoolSize: 5});
+      sentinel = frame.getSentinelClient({nodeClientOptions: {RESP: 3 as const}, RESP: 3 as const, clientSideCache: csc, masterPoolSize: 5});
       await sentinel.connect();
 
       await sentinel.set('x', 1);

--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -376,11 +376,6 @@ describe(`test with masterPoolSize 2`, () => {
   }, GLOBAL.SENTINEL.WITH_MASTER_POOL_SIZE_2);
 });
 
-
-// TODO: Figure out how to modify the test utils
-// so it would have fine grained controll over
-// sentinel
-// it should somehow replicate the `SentinelFramework` object functionallities
 async function steadyState(frame: SentinelFramework) {
   // wait a bit to ensure that sentinels are seeing eachother
   await setTimeout(2000)

--- a/packages/client/lib/sentinel/index.spec.ts
+++ b/packages/client/lib/sentinel/index.spec.ts
@@ -171,7 +171,7 @@ describe('RedisSentinel', () => {
   });
 });
 
-describe(`test with scripts`, () => {
+describe.skip(`test with scripts`, () => {
   testUtils.testWithClientSentinel('with script', async sentinel => {
     const [, reply] = await Promise.all([
       sentinel.set('key', '2'),
@@ -198,7 +198,7 @@ describe(`test with scripts`, () => {
 });
 
 
-describe(`test with functions`, () => {
+describe.skip(`test with functions`, () => {
   testUtils.testWithClientSentinel('with function', async sentinel => {
     await sentinel.functionLoad(
       MATH_FUNCTION.code,
@@ -238,7 +238,7 @@ describe(`test with functions`, () => {
   }, GLOBAL.SENTINEL.WITH_FUNCTION);
 });
 
-describe(`test with modules`, () => {
+describe.skip(`test with modules`, () => {
   testUtils.testWithClientSentinel('with module', async sentinel => {
     const resp = await sentinel.bf.add('key', 'item')
     assert.equal(resp, true);
@@ -260,7 +260,7 @@ describe(`test with modules`, () => {
   }, GLOBAL.SENTINEL.WITH_MODULE);
 });
 
-describe(`test with replica pool size 1`, () => {
+describe.skip(`test with replica pool size 1`, () => {
   testUtils.testWithClientSentinel('client lease', async sentinel => {
     sentinel.on("error", () => { });
 
@@ -302,7 +302,7 @@ describe(`test with replica pool size 1`, () => {
   }, GLOBAL.SENTINEL.WITH_REPLICA_POOL_SIZE_1);
 });
 
-describe(`test with masterPoolSize 2, reserve client true`, () => {
+describe.skip(`test with masterPoolSize 2, reserve client true`, () => {
   // TODO: flaky test, sometimes fails with `promise1 === null`
   testUtils.testWithClientSentinel('reserve client, takes a client out of pool', async sentinel => {
     const promise1 = sentinel.use(
@@ -325,7 +325,7 @@ describe(`test with masterPoolSize 2, reserve client true`, () => {
   }, Object.assign(GLOBAL.SENTINEL.WITH_RESERVE_CLIENT_MASTER_POOL_SIZE_2, {skipTest: true}));
 });
 
-describe(`test with masterPoolSize 2`, () => {
+describe.skip(`test with masterPoolSize 2`, () => {
   testUtils.testWithClientSentinel('multple clients', async sentinel => {
     sentinel.on("error", () => { });
 
@@ -430,7 +430,7 @@ async function steadyState(frame: SentinelFramework) {
   }
 }
 
-describe.skip('legacy tests', () => {
+describe('legacy tests', () => {
   const config: RedisSentinelConfig = { sentinelName: "test", numberOfNodes: 3, password: undefined };
   const frame = new SentinelFramework(config);
   let tracer = new Array<string>();
@@ -439,41 +439,30 @@ describe.skip('legacy tests', () => {
   let longestTestDelta = 0;
   let last: number;
 
-  before(async function () {
-    this.timeout(15000);
-
-    last = Date.now();
-
-    function deltaMeasurer() {
-      const delta = Date.now() - last;
-      if (delta > longestDelta) {
-        longestDelta = delta;
-      }
-      if (delta > longestTestDelta) {
-        longestTestDelta = delta;
-      }
-      if (!stopMeasuringBlocking) {
-        last = Date.now();
-        setImmediate(deltaMeasurer);
-      }
-    }
-    setImmediate(deltaMeasurer);
-    await frame.spawnRedisSentinel();
-  });
-
-  after(async function () {
-    this.timeout(15000);
-
-    stopMeasuringBlocking = true;
-
-    await frame.cleanup();
-  })
 
   describe('Sentinel Client', function () {
     let sentinel: RedisSentinelType<RedisModules, RedisFunctions, RedisScripts, RespVersions, TypeMapping> | undefined;
 
     beforeEach(async function () {
-      this.timeout(0);
+      this.timeout(15000);
+
+      last = Date.now();
+  
+      function deltaMeasurer() {
+        const delta = Date.now() - last;
+        if (delta > longestDelta) {
+          longestDelta = delta;
+        }
+        if (delta > longestTestDelta) {
+          longestTestDelta = delta;
+        }
+        if (!stopMeasuringBlocking) {
+          last = Date.now();
+          setImmediate(deltaMeasurer);
+        }
+      }
+      setImmediate(deltaMeasurer);
+      await frame.spawnRedisSentinel();
 
       await frame.getAllRunning();
       await steadyState(frame);
@@ -522,6 +511,10 @@ describe.skip('legacy tests', () => {
         await sentinel.destroy();
         sentinel = undefined;
       }
+
+      stopMeasuringBlocking = true;
+  
+      await frame.cleanup();
     })
 
     it('use', async function () {

--- a/packages/client/lib/test-utils.ts
+++ b/packages/client/lib/test-utils.ts
@@ -14,7 +14,7 @@ const utils = TestUtils.createFromConfig({
 
 export default utils;
 
-const DEBUG_MODE_ARGS = utils.isVersionGreaterThan([7]) ?
+export const DEBUG_MODE_ARGS = utils.isVersionGreaterThan([7]) ?
   ['--enable-debug-command', 'yes'] :
   [];
 

--- a/packages/test-utils/lib/dockers.ts
+++ b/packages/test-utils/lib/dockers.ts
@@ -419,8 +419,8 @@ export async function spawnSentinelNode(
 
   let sentinelConfig = `port ${port}
 sentinel monitor ${sentinelName} 127.0.0.1 ${masterPort} 2
-sentinel down-after-milliseconds ${sentinelName} 5000
-sentinel failover-timeout ${sentinelName} 6000
+sentinel down-after-milliseconds ${sentinelName} 500
+sentinel failover-timeout ${sentinelName} 1000
 `;
   if (password !== undefined) {
     sentinelConfig += `requirepass ${password}\n`;

--- a/packages/test-utils/lib/index.ts
+++ b/packages/test-utils/lib/index.ts
@@ -25,6 +25,7 @@ import { hideBin } from 'yargs/helpers';
 
 import * as fs from 'node:fs';
 import * as os from 'node:os';
+import * as path from 'node:path';
 
 interface TestUtilsConfig {
   /**
@@ -573,8 +574,11 @@ export default class TestUtils {
   ): Promise<Array<RedisServerDocker>> {
     const sentinels: Array<RedisServerDocker> = [];
     for (let i = 0; i < count; i++) {
-      const tmpDir = fs.mkdtempSync(os.tmpdir())
+      const appPrefix = 'sentinel-config-dir';
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), appPrefix));
+
       sentinels.push(await spawnSentinelNode(this.#DOCKER_IMAGE, options.serverArguments, masterPort, sentinelName, tmpDir))
+      
       if (tmpDir) {
         fs.rmSync(tmpDir, { recursive: true });
       }

--- a/packages/test-utils/lib/index.ts
+++ b/packages/test-utils/lib/index.ts
@@ -19,10 +19,12 @@ import {
   RedisClusterType
 } from '@redis/client/index';
 import { RedisNode } from '@redis/client/lib/sentinel/types'
-import { spawnRedisServer, spawnRedisCluster, spawnRedisSentinel, RedisServerDockerOptions } from './dockers';
+import { spawnRedisServer, spawnRedisCluster, spawnRedisSentinel, RedisServerDockerOptions, RedisServerDocker, spawnSentinelNode, spawnRedisServerDocker } from './dockers';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 
 interface TestUtilsConfig {
   /**
@@ -395,19 +397,19 @@ export default class TestUtils {
   S extends RedisScripts = {},
   RESP extends RespVersions = 2,
   TYPE_MAPPING extends TypeMapping = {}
->(
-  range: ([minVersion: Array<number>, maxVersion: Array<number>] | [minVersion: Array<number>, 'LATEST']),
-  title: string,
-  fn: (sentinel: RedisSentinelType<M, F, S, RESP, TYPE_MAPPING>) => unknown,
-  options: SentinelTestOptions<M, F, S, RESP, TYPE_MAPPING>
-): void {
+  >(
+    range: ([minVersion: Array<number>, maxVersion: Array<number>] | [minVersion: Array<number>, 'LATEST']),
+    title: string,
+    fn: (sentinel: RedisSentinelType<M, F, S, RESP, TYPE_MAPPING>) => unknown,
+    options: SentinelTestOptions<M, F, S, RESP, TYPE_MAPPING>
+  ): void {
 
-  if (this.isVersionInRange(range[0], range[1] === 'LATEST' ? [Infinity, Infinity, Infinity] : range[1])) {
-    return this.testWithClientSentinel(`${title}  [${range[0].join('.')}] - [${(range[1] === 'LATEST') ? range[1] : range[1].join(".")}] `, fn, options)
-  } else {
-    console.warn(`Skipping test ${title} because server version ${this.#VERSION_NUMBERS.join('.')} is not within range ${range[0].join(".")} - ${range[1] !== 'LATEST' ? range[1].join(".") : 'LATEST'}`)
+    if (this.isVersionInRange(range[0], range[1] === 'LATEST' ? [Infinity, Infinity, Infinity] : range[1])) {
+      return this.testWithClientSentinel(`${title}  [${range[0].join('.')}] - [${(range[1] === 'LATEST') ? range[1] : range[1].join(".")}] `, fn, options)
+    } else {
+      console.warn(`Skipping test ${title} because server version ${this.#VERSION_NUMBERS.join('.')} is not within range ${range[0].join(".")} - ${range[1] !== 'LATEST' ? range[1].join(".") : 'LATEST'}`)
+    }
   }
-}
 
   testWithClientPool<
     M extends RedisModules = {},
@@ -540,5 +542,44 @@ export default class TestUtils {
   ) {
     this.testWithClient(`client.${title}`, fn, options.client);
     this.testWithCluster(`cluster.${title}`, fn, options.cluster);
+  }
+
+
+  spawnRedisServer<
+    M extends RedisModules = {},
+    F extends RedisFunctions = {},
+    S extends RedisScripts = {},
+    RESP extends RespVersions = 2,
+    TYPE_MAPPING extends TypeMapping = {}
+    // POLICIES extends CommandPolicies = {}
+  >(
+    options: ClientPoolTestOptions<M, F, S, RESP, TYPE_MAPPING>
+  ): Promise<RedisServerDocker> {
+    return spawnRedisServerDocker(this.#DOCKER_IMAGE, options.serverArguments)
+  }
+
+  async spawnRedisSentinels<
+    M extends RedisModules = {},
+    F extends RedisFunctions = {},
+    S extends RedisScripts = {},
+    RESP extends RespVersions = 2,
+    TYPE_MAPPING extends TypeMapping = {}
+    // POLICIES extends CommandPolicies = {}
+  >(
+    options: ClientPoolTestOptions<M, F, S, RESP, TYPE_MAPPING>,
+    masterPort: number,
+    sentinelName: string,
+    count: number
+  ): Promise<Array<RedisServerDocker>> {
+    const sentinels: Array<RedisServerDocker> = [];
+    for (let i = 0; i < count; i++) {
+      const tmpDir = fs.mkdtempSync(os.tmpdir())
+      sentinels.push(await spawnSentinelNode(this.#DOCKER_IMAGE, options.serverArguments, masterPort, sentinelName, tmpDir))
+      if (tmpDir) {
+        fs.rmSync(tmpDir, { recursive: true });
+      }
+    }
+    
+    return sentinels
   }
 }


### PR DESCRIPTION
### Description

Modified the sentinel test-util framework to be a wrapper of the generic test-utils. This allows us to create containers based on the command line arguments (used for testing with different redis versions in our CI/CD pipeline)


### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
