### PR TITLE
feat: Add command timeout

### DIFF
--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -29,6 +29,7 @@
 | isolationPoolOptions         |                                          | An object that configures a pool of isolated connections, If you frequently need isolated connections, consider using [createClientPool](https://github.com/redis/node-redis/blob/master/docs/pool.md#creating-a-pool) instead                                                                                                     |
 | pingInterval                 |                                          | Send `PING` command at interval (in ms). Useful with ["Azure Cache for Redis"](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-best-practices-connection#idle-timeout)                                                          |
 | disableClientInfo            | `false`                                  | Disables `CLIENT SETINFO LIB-NAME node-redis` and `CLIENT SETINFO LIB-VER X.X.X` commands                                                                                                                                                           | 
+| commandTimeout               |                                          | Throw an error and abort a command if it takes longer than the specified time (in milliseconds).                                                                                                                                                    |
 
 ## Reconnect Strategy
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
         "@release-it/bumper": "^7.0.5",
         "@types/mocha": "^10.0.6",
-        "@types/node": "^20.11.16",
+        "@types/node": "^20.19.1",
         "gh-pages": "^6.1.1",
         "mocha": "^10.2.0",
         "nyc": "^15.1.0",
@@ -1657,11 +1657,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.11.16",
+      "version": "20.19.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
+      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/parse-path": {
@@ -6987,7 +6989,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
     "@release-it/bumper": "^7.0.5",
     "@types/mocha": "^10.0.6",
-    "@types/node": "^20.11.16",
+    "@types/node": "^20.19.1",
     "gh-pages": "^6.1.1",
     "mocha": "^10.2.0",
     "nyc": "^15.1.0",

--- a/packages/client/lib/client/commands-queue.ts
+++ b/packages/client/lib/client/commands-queue.ts
@@ -144,7 +144,7 @@ export default class RedisCommandsQueue {
     if (this.#maxLength && this.#toWrite.length + this.#waitingForReply.length >= this.#maxLength) {
       return Promise.reject(new Error('The queue is full'));
     } else if (options?.abortSignal?.aborted) {
-      return Promise.reject(new AbortError());
+      return Promise.reject(new AbortError(options?.abortSignal?.reason));
     }
 
     return new Promise((resolve, reject) => {
@@ -165,7 +165,7 @@ export default class RedisCommandsQueue {
           signal,
           listener: () => {
             this.#toWrite.remove(node);
-            value.reject(new AbortError());
+            value.reject(new AbortError(signal.reason));
           }
         };
         signal.addEventListener('abort', value.abort.listener, { once: true });

--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -283,11 +283,11 @@ describe('Client', () => {
     });
 
   testUtils.testWithClient('CommandTimeoutError', async client => {
-    const promise = assert.rejects(client.sendCommand(['PING']), CommandTimeoutError),
-      start = process.hrtime.bigint();
+    const promise = assert.rejects(client.sendCommand(['PING']), AbortError);
+    const start = process.hrtime.bigint();
 
     while (process.hrtime.bigint() - start < 50_000_000) {
-      // block the event loop for 1ms, to make sure the connection will timeout
+      // block the event loop for 50ms, to make sure the connection will timeout
     }
 
     await promise;

--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -263,6 +263,23 @@ describe('Client', () => {
           AbortError
         );
       }, GLOBAL.SERVERS.OPEN);
+
+      testUtils.testWithClient('AbortError with timeout', client => {
+        const controller = new AbortController();
+        controller.abort();
+
+        return assert.rejects(
+          client.sendCommand(['PING'], {
+            abortSignal: controller.signal
+          }),
+          AbortError
+        );
+      }, {
+        ...GLOBAL.SERVERS.OPEN,
+        clientOptions: {
+          commandTimeout: 50,
+        }
+      });
     });
 
   testUtils.testWithClient('CommandTimeoutError', async client => {

--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'node:assert';
 import testUtils, { GLOBAL, waitTillBeenCalled } from '../test-utils';
 import RedisClient, { RedisClientOptions, RedisClientType } from '.';
-import { AbortError, ClientClosedError, ClientOfflineError, ConnectionTimeoutError, CommandTimeoutError, DisconnectsClientError, ErrorReply, MultiErrorReply, SocketClosedUnexpectedlyError, WatchError } from '../errors';
+import { AbortError, ClientClosedError, ClientOfflineError, ConnectionTimeoutError, DisconnectsClientError, ErrorReply, MultiErrorReply, WatchError } from '../errors';
 import { defineScript } from '../lua-script';
 import { spy } from 'sinon';
 import { once } from 'node:events';
@@ -264,16 +264,21 @@ describe('Client', () => {
         );
       }, GLOBAL.SERVERS.OPEN);
 
-      testUtils.testWithClient('AbortError with timeout', client => {
-        const controller = new AbortController();
-        controller.abort();
+      testUtils.testWithClient('rejects with AbortError - respects given abortSignal', client => {
 
-        return assert.rejects(
-          client.sendCommand(['PING'], {
-            abortSignal: controller.signal
-          }),
+        const promise = client.sendCommand(['PING'], {
+          abortSignal: AbortSignal.abort("my reason")
+        })
+
+        assert.rejects(
+          promise,
           AbortError
         );
+
+        promise.catch((error: unknown) => {
+          assert.ok((error as string).includes("my reason"));
+        });
+
       }, {
         ...GLOBAL.SERVERS.OPEN,
         clientOptions: {
@@ -282,19 +287,20 @@ describe('Client', () => {
       });
     });
 
-  testUtils.testWithClient('CommandTimeoutError', async client => {
-    const promise = assert.rejects(client.sendCommand(['PING']), AbortError);
+
+  testUtils.testWithClient('rejects with AbortError on commandTimeout timer', async client => {
     const start = process.hrtime.bigint();
+    const promise = client.ping();
 
-    while (process.hrtime.bigint() - start < 50_000_000) {
-      // block the event loop for 50ms, to make sure the connection will timeout
-    }
+    while (process.hrtime.bigint() - start < 10_000_000) {
+      // block the event loop for 10ms, to make sure the connection will timeout
+    };
 
-    await promise;
+    assert.rejects(promise, AbortError);
   }, {
     ...GLOBAL.SERVERS.OPEN,
     clientOptions: {
-      commandTimeout: 50,
+      commandTimeout: 10,
     }
   });
 

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -4,7 +4,7 @@ import { BasicAuth, CredentialsError, CredentialsProvider, StreamingCredentialsP
 import RedisCommandsQueue, { CommandOptions } from './commands-queue';
 import { EventEmitter } from 'node:events';
 import { attachConfig, functionArgumentsPrefix, getTransformReply, scriptArgumentsPrefix } from '../commander';
-import { ClientClosedError, ClientOfflineError, CommandTimeoutError, DisconnectsClientError, WatchError } from '../errors';
+import { ClientClosedError, ClientOfflineError, AbortError, DisconnectsClientError, WatchError } from '../errors';
 import { URL } from 'node:url';
 import { TcpSocketConnectOpts } from 'node:net';
 import { PUBSUB_TYPE, PubSubType, PubSubListener, PubSubTypeListeners, ChannelListeners } from './pub-sub';
@@ -918,7 +918,7 @@ export default class RedisClient<
     return new Promise<T>((resolve, reject) => {
       const timeoutId = setTimeout(() => {
         controller.abort();
-        reject(new CommandTimeoutError());
+        reject(new AbortError());
       }, this._self.#options?.commandTimeout)
       promise.then(result => {
         clearInterval(timeoutId);

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -4,7 +4,7 @@ import { BasicAuth, CredentialsError, CredentialsProvider, StreamingCredentialsP
 import RedisCommandsQueue, { CommandOptions } from './commands-queue';
 import { EventEmitter } from 'node:events';
 import { attachConfig, functionArgumentsPrefix, getTransformReply, scriptArgumentsPrefix } from '../commander';
-import { ClientClosedError, ClientOfflineError, AbortError, DisconnectsClientError, WatchError } from '../errors';
+import { ClientClosedError, ClientOfflineError, DisconnectsClientError, WatchError } from '../errors';
 import { URL } from 'node:url';
 import { TcpSocketConnectOpts } from 'node:net';
 import { PUBSUB_TYPE, PubSubType, PubSubListener, PubSubTypeListeners, ChannelListeners } from './pub-sub';
@@ -530,7 +530,7 @@ export default class RedisClient<
   async #handshake(chainId: symbol, asap: boolean) {
     const promises = [];
     const commandsWithErrorHandlers = await this.#getHandshakeCommands();
-    
+
     if (asap) commandsWithErrorHandlers.reverse()
 
     for (const { cmd, errorHandler } of commandsWithErrorHandlers) {
@@ -636,7 +636,7 @@ export default class RedisClient<
           // since they could be connected to an older version that doesn't support them.
         }
       });
-      
+
       commands.push({
         cmd: [
           'CLIENT',
@@ -893,15 +893,13 @@ export default class RedisClient<
       return Promise.reject(new ClientOfflineError());
     }
 
-    let controller: AbortController;
     if (this._self.#options?.commandTimeout) {
-      controller = new AbortController()
-      let abortSignal = controller.signal;
+      let abortSignal = AbortSignal.timeout(this._self.#options?.commandTimeout);
       if (options?.abortSignal) {
         abortSignal = AbortSignal.any([
           abortSignal,
-	  options.abortSignal
-	]);
+       	  options.abortSignal
+       	]);
       }
       options = {
         ...options,
@@ -911,23 +909,7 @@ export default class RedisClient<
     const promise = this._self.#queue.addCommand<T>(args, options);
 
     this._self.#scheduleWrite();
-    if (!this._self.#options?.commandTimeout) {
-      return promise;
-    }
-
-    return new Promise<T>((resolve, reject) => {
-      const timeoutId = setTimeout(() => {
-        controller.abort();
-        reject(new AbortError());
-      }, this._self.#options?.commandTimeout)
-      promise.then(result => {
-        clearInterval(timeoutId);
-        resolve(result)
-      }).catch(error => {
-        clearInterval(timeoutId);
-        reject(error)
-      });
-    })
+    return promise;
   }
 
   async SELECT(db: number): Promise<void> {

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -896,9 +896,16 @@ export default class RedisClient<
     let controller: AbortController;
     if (this._self.#options?.commandTimeout) {
       controller = new AbortController()
+      let abortSignal = controller.signal;
+      if (options?.abortSignal) {
+        abortSignal = AbortSignal.any([
+          abortSignal,
+	  options.abortSignal
+	]);
+      }
       options = {
         ...options,
-        abortSignal: controller.signal
+        abortSignal
       }
     }
     const promise = this._self.#queue.addCommand<T>(args, options);

--- a/packages/client/lib/errors.ts
+++ b/packages/client/lib/errors.ts
@@ -1,6 +1,6 @@
 export class AbortError extends Error {
-  constructor() {
-    super('The command was aborted');
+  constructor(message = '') {
+    super(`The command was aborted: ${message}`);
   }
 }
 

--- a/packages/client/lib/errors.ts
+++ b/packages/client/lib/errors.ts
@@ -22,6 +22,12 @@ export class SocketTimeoutError extends Error {
   }
 }
 
+export class CommandTimeoutError extends Error {
+  constructor() {
+    super('Command timeout');
+  }
+}
+
 export class ClientClosedError extends Error {
   constructor() {
     super('The client is closed');

--- a/packages/client/lib/errors.ts
+++ b/packages/client/lib/errors.ts
@@ -22,12 +22,6 @@ export class SocketTimeoutError extends Error {
   }
 }
 
-export class CommandTimeoutError extends Error {
-  constructor() {
-    super('Command timeout');
-  }
-}
-
 export class ClientClosedError extends Error {
   constructor() {
     super('The client is closed');


### PR DESCRIPTION
### Description

This PR introduces a timeout for commands sent to redis.
Our use-case is that we are using node-rate-limiter-flexible with node-redis, but sometimes the connection to redis is slow. In these cases we want to fall back the the insurance limiter of node-rate-limiter-flexible.

This feature was also requested in https://github.com/redis/node-redis/issues/2175

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
