### PR TITLE
add jsdoc comments to command parsers

### DIFF
--- a/packages/bloom/lib/commands/bloom/ADD.ts
+++ b/packages/bloom/lib/commands/bloom/ADD.ts
@@ -4,6 +4,12 @@ import { transformBooleanReply } from '@redis/client/dist/lib/commands/generic-t
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Adds an item to a Bloom Filter
+   * @param parser - The command parser
+   * @param key - The name of the Bloom filter
+   * @param item - The item to add to the filter
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, item: RedisArgument) {
     parser.push('BF.ADD');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/bloom/CARD.ts
+++ b/packages/bloom/lib/commands/bloom/CARD.ts
@@ -3,6 +3,11 @@ import { RedisArgument, NumberReply, Command } from '@redis/client/dist/lib/RESP
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the cardinality (number of items) in a Bloom Filter
+   * @param parser - The command parser
+   * @param key - The name of the Bloom filter to query
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('BF.CARD');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/bloom/EXISTS.ts
+++ b/packages/bloom/lib/commands/bloom/EXISTS.ts
@@ -4,6 +4,12 @@ import { transformBooleanReply } from '@redis/client/dist/lib/commands/generic-t
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Checks if an item exists in a Bloom Filter
+   * @param parser - The command parser
+   * @param key - The name of the Bloom filter
+   * @param item - The item to check for existence
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, item: RedisArgument) {
     parser.push('BF.EXISTS');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/bloom/INFO.ts
+++ b/packages/bloom/lib/commands/bloom/INFO.ts
@@ -12,6 +12,11 @@ export type BfInfoReplyMap = TuplesToMapReply<[
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns information about a Bloom Filter, including capacity, size, number of filters, items inserted, and expansion rate
+   * @param parser - The command parser
+   * @param key - The name of the Bloom filter to get information about
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('BF.INFO');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/bloom/INSERT.ts
+++ b/packages/bloom/lib/commands/bloom/INSERT.ts
@@ -13,6 +13,18 @@ export interface BfInsertOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Adds one or more items to a Bloom Filter, creating it if it does not exist
+   * @param parser - The command parser
+   * @param key - The name of the Bloom filter
+   * @param items - One or more items to add to the filter
+   * @param options - Optional parameters for filter creation
+   * @param options.CAPACITY - Desired capacity for a new filter
+   * @param options.ERROR - Desired error rate for a new filter
+   * @param options.EXPANSION - Expansion rate for a new filter
+   * @param options.NOCREATE - If true, prevents automatic filter creation
+   * @param options.NONSCALING - Prevents the filter from creating additional sub-filters
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/bloom/lib/commands/bloom/LOADCHUNK.ts
+++ b/packages/bloom/lib/commands/bloom/LOADCHUNK.ts
@@ -3,6 +3,13 @@ import { RedisArgument, SimpleStringReply, Command } from '@redis/client/dist/li
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Restores a Bloom Filter chunk previously saved using SCANDUMP
+   * @param parser - The command parser
+   * @param key - The name of the Bloom filter to restore
+   * @param iterator - Iterator value from the SCANDUMP command
+   * @param chunk - Data chunk from the SCANDUMP command
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, iterator: number, chunk: RedisArgument) {
     parser.push('BF.LOADCHUNK');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/bloom/MADD.ts
+++ b/packages/bloom/lib/commands/bloom/MADD.ts
@@ -5,6 +5,12 @@ import { transformBooleanArrayReply } from '@redis/client/dist/lib/commands/gene
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Adds multiple items to a Bloom Filter in a single call
+   * @param parser - The command parser
+   * @param key - The name of the Bloom filter
+   * @param items - One or more items to add to the filter
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, items: RedisVariadicArgument) {
     parser.push('BF.MADD');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/bloom/MEXISTS.ts
+++ b/packages/bloom/lib/commands/bloom/MEXISTS.ts
@@ -5,6 +5,12 @@ import { transformBooleanArrayReply } from '@redis/client/dist/lib/commands/gene
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Checks if multiple items exist in a Bloom Filter in a single call
+   * @param parser - The command parser
+   * @param key - The name of the Bloom filter
+   * @param items - One or more items to check for existence
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, items: RedisVariadicArgument) {
     parser.push('BF.MEXISTS');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/bloom/RESERVE.ts
+++ b/packages/bloom/lib/commands/bloom/RESERVE.ts
@@ -8,6 +8,16 @@ export interface BfReserveOptions {
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Creates an empty Bloom Filter with a given desired error ratio and initial capacity
+   * @param parser - The command parser
+   * @param key - The name of the Bloom filter to create
+   * @param errorRate - The desired probability for false positives (between 0 and 1)
+   * @param capacity - The number of entries intended to be added to the filter
+   * @param options - Optional parameters to tune the filter
+   * @param options.EXPANSION - Expansion rate for the filter
+   * @param options.NONSCALING - Prevents the filter from creating additional sub-filters
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/bloom/lib/commands/bloom/SCANDUMP.ts
+++ b/packages/bloom/lib/commands/bloom/SCANDUMP.ts
@@ -3,6 +3,12 @@ import { RedisArgument, TuplesReply, NumberReply, BlobStringReply, UnwrapReply, 
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Begins an incremental save of a Bloom Filter. This is useful for large filters that can't be saved at once
+   * @param parser - The command parser
+   * @param key - The name of the Bloom filter to save
+   * @param iterator - Iterator value; Start at 0, and use the iterator from the response for the next chunk
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, iterator: number) {
     parser.push('BF.SCANDUMP');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/count-min-sketch/INCRBY.ts
+++ b/packages/bloom/lib/commands/count-min-sketch/INCRBY.ts
@@ -8,6 +8,12 @@ export interface BfIncrByItem {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Increases the count of one or more items in a Count-Min Sketch
+   * @param parser - The command parser
+   * @param key - The name of the sketch
+   * @param items - A single item or array of items to increment, each with an item and increment value
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/bloom/lib/commands/count-min-sketch/INFO.ts
+++ b/packages/bloom/lib/commands/count-min-sketch/INFO.ts
@@ -16,6 +16,11 @@ export interface CmsInfoReply {
  
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns width, depth, and total count of items in a Count-Min Sketch
+   * @param parser - The command parser
+   * @param key - The name of the sketch to get information about
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('CMS.INFO');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/count-min-sketch/INITBYDIM.ts
+++ b/packages/bloom/lib/commands/count-min-sketch/INITBYDIM.ts
@@ -3,6 +3,13 @@ import { RedisArgument, SimpleStringReply, Command } from '@redis/client/dist/li
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Initialize a Count-Min Sketch using width and depth parameters
+   * @param parser - The command parser
+   * @param key - The name of the sketch
+   * @param width - Number of counters in each array (must be a multiple of 2)
+   * @param depth - Number of counter arrays (determines accuracy of estimates)
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, width: number, depth: number) {
     parser.push('CMS.INITBYDIM');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/count-min-sketch/INITBYPROB.ts
+++ b/packages/bloom/lib/commands/count-min-sketch/INITBYPROB.ts
@@ -3,6 +3,13 @@ import { RedisArgument, SimpleStringReply, Command } from '@redis/client/dist/li
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Initialize a Count-Min Sketch using error rate and probability parameters
+   * @param parser - The command parser
+   * @param key - The name of the sketch
+   * @param error - Estimate error, as a decimal between 0 and 1
+   * @param probability - The desired probability for inflated count, as a decimal between 0 and 1
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, error: number, probability: number) {
     parser.push('CMS.INITBYPROB');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/count-min-sketch/MERGE.ts
+++ b/packages/bloom/lib/commands/count-min-sketch/MERGE.ts
@@ -10,6 +10,12 @@ export type BfMergeSketches = Array<RedisArgument> | Array<BfMergeSketch>;
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Merges multiple Count-Min Sketches into a single sketch, with optional weights
+   * @param parser - The command parser
+   * @param destination - The name of the destination sketch
+   * @param source - Array of sketch names or array of sketches with weights
+   */
   parseCommand(
     parser: CommandParser,
     destination: RedisArgument,

--- a/packages/bloom/lib/commands/count-min-sketch/QUERY.ts
+++ b/packages/bloom/lib/commands/count-min-sketch/QUERY.ts
@@ -4,6 +4,12 @@ import { RedisVariadicArgument } from '@redis/client/dist/lib/commands/generic-t
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the count for one or more items in a Count-Min Sketch
+   * @param parser - The command parser
+   * @param key - The name of the sketch
+   * @param items - One or more items to get counts for
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, items: RedisVariadicArgument) {
     parser.push('CMS.QUERY');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/cuckoo/ADD.ts
+++ b/packages/bloom/lib/commands/cuckoo/ADD.ts
@@ -4,6 +4,12 @@ import { transformBooleanReply } from '@redis/client/dist/lib/commands/generic-t
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Adds an item to a Cuckoo Filter, creating the filter if it does not exist
+   * @param parser - The command parser
+   * @param key - The name of the Cuckoo filter
+   * @param item - The item to add to the filter
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, item: RedisArgument) {
     parser.push('CF.ADD');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/cuckoo/ADDNX.ts
+++ b/packages/bloom/lib/commands/cuckoo/ADDNX.ts
@@ -4,6 +4,12 @@ import { transformBooleanReply } from '@redis/client/dist/lib/commands/generic-t
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Adds an item to a Cuckoo Filter only if it does not exist
+   * @param parser - The command parser
+   * @param key - The name of the Cuckoo filter
+   * @param item - The item to add to the filter if it doesn't exist
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, item: RedisArgument) {
     parser.push('CF.ADDNX');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/cuckoo/COUNT.ts
+++ b/packages/bloom/lib/commands/cuckoo/COUNT.ts
@@ -3,6 +3,12 @@ import { RedisArgument, NumberReply, Command } from '@redis/client/dist/lib/RESP
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the number of times an item appears in a Cuckoo Filter
+   * @param parser - The command parser
+   * @param key - The name of the Cuckoo filter
+   * @param item - The item to count occurrences of
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, item: RedisArgument) {
     parser.push('CF.COUNT');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/cuckoo/DEL.ts
+++ b/packages/bloom/lib/commands/cuckoo/DEL.ts
@@ -4,6 +4,12 @@ import { transformBooleanReply } from '@redis/client/dist/lib/commands/generic-t
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Removes an item from a Cuckoo Filter if it exists
+   * @param parser - The command parser
+   * @param key - The name of the Cuckoo filter
+   * @param item - The item to remove from the filter
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, item: RedisArgument) {
     parser.push('CF.DEL');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/cuckoo/EXISTS.ts
+++ b/packages/bloom/lib/commands/cuckoo/EXISTS.ts
@@ -4,6 +4,12 @@ import { transformBooleanReply } from '@redis/client/dist/lib/commands/generic-t
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Checks if an item exists in a Cuckoo Filter
+   * @param parser - The command parser
+   * @param key - The name of the Cuckoo filter
+   * @param item - The item to check for existence
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, item: RedisArgument) {
     parser.push('CF.EXISTS');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/cuckoo/INFO.ts
+++ b/packages/bloom/lib/commands/cuckoo/INFO.ts
@@ -15,6 +15,11 @@ export type CfInfoReplyMap = TuplesToMapReply<[
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns detailed information about a Cuckoo Filter including size, buckets, filters count, items statistics and configuration
+   * @param parser - The command parser
+   * @param key - The name of the Cuckoo filter to get information about
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('CF.INFO');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/cuckoo/INSERT.ts
+++ b/packages/bloom/lib/commands/cuckoo/INSERT.ts
@@ -29,6 +29,15 @@ export function parseCfInsertArguments(
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Adds one or more items to a Cuckoo Filter, creating it if it does not exist
+   * @param parser - The command parser
+   * @param key - The name of the Cuckoo filter
+   * @param items - One or more items to add to the filter
+   * @param options - Optional parameters for filter creation
+   * @param options.CAPACITY - The number of entries intended to be added to the filter
+   * @param options.NOCREATE - If true, prevents automatic filter creation
+   */
   parseCommand(...args: Parameters<typeof parseCfInsertArguments>) {
     args[0].push('CF.INSERT');
     parseCfInsertArguments(...args);

--- a/packages/bloom/lib/commands/cuckoo/INSERTNX.ts
+++ b/packages/bloom/lib/commands/cuckoo/INSERTNX.ts
@@ -1,6 +1,15 @@
 import { Command } from '@redis/client/dist/lib/RESP/types';
 import INSERT, { parseCfInsertArguments } from './INSERT';
 
+/**
+ * Adds one or more items to a Cuckoo Filter only if they do not exist yet, creating the filter if needed
+ * @param parser - The command parser
+ * @param key - The name of the Cuckoo filter
+ * @param items - One or more items to add to the filter
+ * @param options - Optional parameters for filter creation
+ * @param options.CAPACITY - The number of entries intended to be added to the filter
+ * @param options.NOCREATE - If true, prevents automatic filter creation
+ */
 export default {
   IS_READ_ONLY: INSERT.IS_READ_ONLY,
   parseCommand(...args: Parameters<typeof parseCfInsertArguments>) {

--- a/packages/bloom/lib/commands/cuckoo/LOADCHUNK.ts
+++ b/packages/bloom/lib/commands/cuckoo/LOADCHUNK.ts
@@ -3,6 +3,13 @@ import { SimpleStringReply, Command, RedisArgument } from '@redis/client/dist/li
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Restores a Cuckoo Filter chunk previously saved using SCANDUMP
+   * @param parser - The command parser
+   * @param key - The name of the Cuckoo filter to restore
+   * @param iterator - Iterator value from the SCANDUMP command
+   * @param chunk - Data chunk from the SCANDUMP command
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, iterator: number, chunk: RedisArgument) {
     parser.push('CF.LOADCHUNK');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/cuckoo/RESERVE.ts
+++ b/packages/bloom/lib/commands/cuckoo/RESERVE.ts
@@ -9,6 +9,16 @@ export interface CfReserveOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Creates an empty Cuckoo Filter with specified capacity and parameters
+   * @param parser - The command parser
+   * @param key - The name of the Cuckoo filter to create
+   * @param capacity - The number of entries intended to be added to the filter
+   * @param options - Optional parameters to tune the filter
+   * @param options.BUCKETSIZE - Number of items in each bucket
+   * @param options.MAXITERATIONS - Maximum number of iterations before declaring filter full
+   * @param options.EXPANSION - Number of additional buckets per expansion
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/bloom/lib/commands/cuckoo/SCANDUMP.ts
+++ b/packages/bloom/lib/commands/cuckoo/SCANDUMP.ts
@@ -3,6 +3,12 @@ import { RedisArgument, TuplesReply, NumberReply, BlobStringReply, NullReply, Un
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Begins an incremental save of a Cuckoo Filter. This is useful for large filters that can't be saved at once
+   * @param parser - The command parser
+   * @param key - The name of the Cuckoo filter to save
+   * @param iterator - Iterator value; Start at 0, and use the iterator from the response for the next chunk
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, iterator: number) {
     parser.push('CF.SCANDUMP');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/t-digest/ADD.ts
+++ b/packages/bloom/lib/commands/t-digest/ADD.ts
@@ -3,6 +3,12 @@ import { SimpleStringReply, Command, RedisArgument } from '@redis/client/dist/li
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Adds one or more observations to a t-digest sketch
+   * @param parser - The command parser
+   * @param key - The name of the t-digest sketch
+   * @param values - Array of numeric values to add to the sketch
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, values: Array<number>) {
     parser.push('TDIGEST.ADD');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/t-digest/BYRANK.ts
+++ b/packages/bloom/lib/commands/t-digest/BYRANK.ts
@@ -16,6 +16,12 @@ export function transformByRankArguments(
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns value estimates for one or more ranks in a t-digest sketch
+   * @param parser - The command parser
+   * @param key - The name of the t-digest sketch
+   * @param ranks - Array of ranks to get value estimates for (ascending order)
+   */
   parseCommand(...args: Parameters<typeof transformByRankArguments>) {
     args[0].push('TDIGEST.BYRANK');
     transformByRankArguments(...args);

--- a/packages/bloom/lib/commands/t-digest/BYREVRANK.ts
+++ b/packages/bloom/lib/commands/t-digest/BYREVRANK.ts
@@ -1,6 +1,12 @@
 import { Command } from '@redis/client/dist/lib/RESP/types';
 import BYRANK, { transformByRankArguments } from './BYRANK';
 
+/**
+ * Returns value estimates for one or more ranks in a t-digest sketch, starting from highest rank
+ * @param parser - The command parser
+ * @param key - The name of the t-digest sketch
+ * @param ranks - Array of ranks to get value estimates for (descending order)
+ */
 export default {
   IS_READ_ONLY: BYRANK.IS_READ_ONLY,
   parseCommand(...args: Parameters<typeof transformByRankArguments>) {

--- a/packages/bloom/lib/commands/t-digest/CDF.ts
+++ b/packages/bloom/lib/commands/t-digest/CDF.ts
@@ -4,6 +4,12 @@ import { transformDoubleArrayReply } from '@redis/client/dist/lib/commands/gener
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Estimates the cumulative distribution function for values in a t-digest sketch
+   * @param parser - The command parser
+   * @param key - The name of the t-digest sketch
+   * @param values - Array of values to get CDF estimates for
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, values: Array<number>) {
     parser.push('TDIGEST.CDF');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/t-digest/CREATE.ts
+++ b/packages/bloom/lib/commands/t-digest/CREATE.ts
@@ -7,6 +7,13 @@ export interface TDigestCreateOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Creates a new t-digest sketch for storing distributions
+   * @param parser - The command parser
+   * @param key - The name of the t-digest sketch
+   * @param options - Optional parameters for sketch creation
+   * @param options.COMPRESSION - Compression parameter that affects performance and accuracy
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, options?: TDigestCreateOptions) {
     parser.push('TDIGEST.CREATE');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/t-digest/INFO.ts
+++ b/packages/bloom/lib/commands/t-digest/INFO.ts
@@ -16,6 +16,11 @@ export type TdInfoReplyMap = TuplesToMapReply<[
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns information about a t-digest sketch including compression, capacity, nodes, weights, observations and memory usage
+   * @param parser - The command parser
+   * @param key - The name of the t-digest sketch to get information about
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('TDIGEST.INFO');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/t-digest/MAX.ts
+++ b/packages/bloom/lib/commands/t-digest/MAX.ts
@@ -4,6 +4,11 @@ import { transformDoubleReply } from '@redis/client/dist/lib/commands/generic-tr
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the maximum value from a t-digest sketch
+   * @param parser - The command parser
+   * @param key - The name of the t-digest sketch
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('TDIGEST.MAX');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/t-digest/MERGE.ts
+++ b/packages/bloom/lib/commands/t-digest/MERGE.ts
@@ -9,6 +9,15 @@ export interface TDigestMergeOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Merges multiple t-digest sketches into one, with optional compression and override settings
+   * @param parser - The command parser
+   * @param destination - The name of the destination t-digest sketch
+   * @param source - One or more source sketch names to merge from
+   * @param options - Optional parameters for merge operation
+   * @param options.COMPRESSION - New compression value for merged sketch
+   * @param options.OVERRIDE - If true, override destination sketch if it exists
+   */
   parseCommand(
     parser: CommandParser,
     destination: RedisArgument,

--- a/packages/bloom/lib/commands/t-digest/MIN.ts
+++ b/packages/bloom/lib/commands/t-digest/MIN.ts
@@ -4,6 +4,11 @@ import { transformDoubleReply } from '@redis/client/dist/lib/commands/generic-tr
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the minimum value from a t-digest sketch
+   * @param parser - The command parser
+   * @param key - The name of the t-digest sketch
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('TDIGEST.MIN');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/t-digest/QUANTILE.ts
+++ b/packages/bloom/lib/commands/t-digest/QUANTILE.ts
@@ -4,6 +4,12 @@ import { transformDoubleArrayReply } from '@redis/client/dist/lib/commands/gener
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns value estimates at requested quantiles from a t-digest sketch
+   * @param parser - The command parser
+   * @param key - The name of the t-digest sketch
+   * @param quantiles - Array of quantiles (between 0 and 1) to get value estimates for
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, quantiles: Array<number>) {
     parser.push('TDIGEST.QUANTILE');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/t-digest/RANK.ts
+++ b/packages/bloom/lib/commands/t-digest/RANK.ts
@@ -15,6 +15,12 @@ export function transformRankArguments(
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the rank of one or more values in a t-digest sketch (number of values that are lower than each value)
+   * @param parser - The command parser
+   * @param key - The name of the t-digest sketch
+   * @param values - Array of values to get ranks for
+   */
   parseCommand(...args: Parameters<typeof transformRankArguments>) {
     args[0].push('TDIGEST.RANK');
     transformRankArguments(...args);

--- a/packages/bloom/lib/commands/t-digest/RESET.ts
+++ b/packages/bloom/lib/commands/t-digest/RESET.ts
@@ -3,6 +3,11 @@ import { RedisArgument, SimpleStringReply, Command } from '@redis/client/dist/li
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Resets a t-digest sketch, clearing all previously added observations
+   * @param parser - The command parser
+   * @param key - The name of the t-digest sketch to reset
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('TDIGEST.RESET');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/t-digest/REVRANK.ts
+++ b/packages/bloom/lib/commands/t-digest/REVRANK.ts
@@ -1,6 +1,12 @@
 import { Command } from '@redis/client/dist/lib/RESP/types';
 import RANK, { transformRankArguments } from './RANK';
 
+/**
+ * Returns the reverse rank of one or more values in a t-digest sketch (number of values that are higher than each value)
+ * @param parser - The command parser
+ * @param key - The name of the t-digest sketch
+ * @param values - Array of values to get reverse ranks for
+ */
 export default {
   IS_READ_ONLY: RANK.IS_READ_ONLY,
   parseCommand(...args: Parameters<typeof transformRankArguments>) {

--- a/packages/bloom/lib/commands/t-digest/TRIMMED_MEAN.ts
+++ b/packages/bloom/lib/commands/t-digest/TRIMMED_MEAN.ts
@@ -4,6 +4,13 @@ import { transformDoubleReply } from '@redis/client/dist/lib/commands/generic-tr
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the mean value from a t-digest sketch after trimming values at specified percentiles
+   * @param parser - The command parser
+   * @param key - The name of the t-digest sketch
+   * @param lowCutPercentile - Lower percentile cutoff (between 0 and 100)
+   * @param highCutPercentile - Higher percentile cutoff (between 0 and 100)
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/bloom/lib/commands/top-k/ADD.ts
+++ b/packages/bloom/lib/commands/top-k/ADD.ts
@@ -4,6 +4,12 @@ import { RedisVariadicArgument } from '@redis/client/dist/lib/commands/generic-t
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Adds one or more items to a Top-K filter and returns items dropped from the top-K list
+   * @param parser - The command parser
+   * @param key - The name of the Top-K filter
+   * @param items - One or more items to add to the filter
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, items: RedisVariadicArgument) {
     parser.push('TOPK.ADD');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/top-k/COUNT.ts
+++ b/packages/bloom/lib/commands/top-k/COUNT.ts
@@ -4,6 +4,12 @@ import { RedisVariadicArgument } from '@redis/client/dist/lib/commands/generic-t
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the count of occurrences for one or more items in a Top-K filter
+   * @param parser - The command parser
+   * @param key - The name of the Top-K filter
+   * @param items - One or more items to get counts for
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, items: RedisVariadicArgument) {
     parser.push('TOPK.COUNT');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/top-k/INCRBY.ts
+++ b/packages/bloom/lib/commands/top-k/INCRBY.ts
@@ -12,6 +12,12 @@ function pushIncrByItem(parser: CommandParser, { item, incrementBy }: TopKIncrBy
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Increases the score of one or more items in a Top-K filter by specified increments
+   * @param parser - The command parser
+   * @param key - The name of the Top-K filter
+   * @param items - A single item or array of items to increment, each with an item name and increment value
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/bloom/lib/commands/top-k/INFO.ts
+++ b/packages/bloom/lib/commands/top-k/INFO.ts
@@ -12,6 +12,11 @@ export type TopKInfoReplyMap = TuplesToMapReply<[
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns configuration and statistics of a Top-K filter, including k, width, depth, and decay parameters
+   * @param parser - The command parser
+   * @param key - The name of the Top-K filter to get information about
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('TOPK.INFO');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/top-k/LIST.ts
+++ b/packages/bloom/lib/commands/top-k/LIST.ts
@@ -3,6 +3,11 @@ import { RedisArgument, ArrayReply, BlobStringReply, Command } from '@redis/clie
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns all items in a Top-K filter
+   * @param parser - The command parser
+   * @param key - The name of the Top-K filter
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('TOPK.LIST');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/top-k/LIST_WITHCOUNT.ts
+++ b/packages/bloom/lib/commands/top-k/LIST_WITHCOUNT.ts
@@ -3,6 +3,11 @@ import { RedisArgument, ArrayReply, BlobStringReply, NumberReply, UnwrapReply, C
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns all items in a Top-K filter with their respective counts
+   * @param parser - The command parser
+   * @param key - The name of the Top-K filter
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('TOPK.LIST');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/top-k/QUERY.ts
+++ b/packages/bloom/lib/commands/top-k/QUERY.ts
@@ -4,6 +4,12 @@ import { RedisVariadicArgument, transformBooleanArrayReply } from '@redis/client
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Checks if one or more items are in the Top-K list
+   * @param parser - The command parser
+   * @param key - The name of the Top-K filter
+   * @param items - One or more items to check in the filter
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, items: RedisVariadicArgument) {
     parser.push('TOPK.QUERY');
     parser.pushKey(key);

--- a/packages/bloom/lib/commands/top-k/RESERVE.ts
+++ b/packages/bloom/lib/commands/top-k/RESERVE.ts
@@ -9,6 +9,16 @@ export interface TopKReserveOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Creates a new Top-K filter with specified parameters
+   * @param parser - The command parser
+   * @param key - The name of the Top-K filter
+   * @param topK - Number of top occurring items to keep
+   * @param options - Optional parameters for filter configuration
+   * @param options.width - Number of counters in each array
+   * @param options.depth - Number of counter-arrays
+   * @param options.decay - Counter decay factor
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, topK: number, options?: TopKReserveOptions) {
     parser.push('TOPK.RESERVE');
     parser.pushKey(key);

--- a/packages/client/lib/commands/ACL_CAT.ts
+++ b/packages/client/lib/commands/ACL_CAT.ts
@@ -4,6 +4,11 @@ import { RedisArgument, ArrayReply, BlobStringReply, Command } from '../RESP/typ
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Lists ACL categories or commands in a category
+   * @param parser - The Redis command parser
+   * @param categoryName - Optional category name to filter commands
+   */
   parseCommand(parser: CommandParser, categoryName?: RedisArgument) {
     parser.push('ACL', 'CAT');
     if (categoryName) {

--- a/packages/client/lib/commands/ACL_DELUSER.ts
+++ b/packages/client/lib/commands/ACL_DELUSER.ts
@@ -5,6 +5,11 @@ import { RedisVariadicArgument } from './generic-transformers';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Deletes one or more users from the ACL
+   * @param parser - The Redis command parser
+   * @param username - Username(s) to delete
+   */
   parseCommand(parser: CommandParser, username: RedisVariadicArgument) {
     parser.push('ACL', 'DELUSER');
     parser.pushVariadic(username);

--- a/packages/client/lib/commands/ACL_DRYRUN.ts
+++ b/packages/client/lib/commands/ACL_DRYRUN.ts
@@ -4,6 +4,12 @@ import { RedisArgument, SimpleStringReply, BlobStringReply, Command } from '../R
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Simulates ACL operations without executing them
+   * @param parser - The Redis command parser
+   * @param username - Username to simulate ACL operations for
+   * @param command - Command arguments to simulate
+   */
   parseCommand(parser: CommandParser, username: RedisArgument, command: Array<RedisArgument>) {
     parser.push('ACL', 'DRYRUN', username, ...command);
   },

--- a/packages/client/lib/commands/ACL_GENPASS.ts
+++ b/packages/client/lib/commands/ACL_GENPASS.ts
@@ -4,6 +4,11 @@ import { BlobStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Generates a secure password for ACL users
+   * @param parser - The Redis command parser
+   * @param bits - Optional number of bits for password entropy
+   */
   parseCommand(parser: CommandParser, bits?: number) {
     parser.push('ACL', 'GENPASS');
     if (bits) {

--- a/packages/client/lib/commands/ACL_GETUSER.ts
+++ b/packages/client/lib/commands/ACL_GETUSER.ts
@@ -20,6 +20,11 @@ type AclUser = TuplesToMapReply<[
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns ACL information about a specific user
+   * @param parser - The Redis command parser
+   * @param username - Username to get information for
+   */
   parseCommand(parser: CommandParser, username: RedisArgument) {
     parser.push('ACL', 'GETUSER', username);
   },

--- a/packages/client/lib/commands/ACL_LIST.ts
+++ b/packages/client/lib/commands/ACL_LIST.ts
@@ -4,6 +4,10 @@ import { ArrayReply, BlobStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns all configured ACL users and their permissions
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('ACL', 'LIST');
   },

--- a/packages/client/lib/commands/ACL_LOAD.ts
+++ b/packages/client/lib/commands/ACL_LOAD.ts
@@ -4,6 +4,10 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Reloads ACL configuration from the ACL file
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('ACL', 'LOAD');
   },

--- a/packages/client/lib/commands/ACL_LOG.ts
+++ b/packages/client/lib/commands/ACL_LOG.ts
@@ -21,6 +21,11 @@ export type AclLogReply = ArrayReply<TuplesToMapReply<[
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns ACL security events log entries
+   * @param parser - The Redis command parser
+   * @param count - Optional maximum number of entries to return
+   */
   parseCommand(parser: CommandParser, count?: number) {
     parser.push('ACL', 'LOG');
     if (count != undefined) {

--- a/packages/client/lib/commands/ACL_LOG_RESET.ts
+++ b/packages/client/lib/commands/ACL_LOG_RESET.ts
@@ -5,6 +5,10 @@ import ACL_LOG from './ACL_LOG';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: ACL_LOG.IS_READ_ONLY,
+  /**
+   * Clears the ACL security events log
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('ACL', 'LOG', 'RESET');
   },

--- a/packages/client/lib/commands/ACL_SAVE.ts
+++ b/packages/client/lib/commands/ACL_SAVE.ts
@@ -4,6 +4,10 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Saves the current ACL configuration to the ACL file
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('ACL', 'SAVE');
   },

--- a/packages/client/lib/commands/ACL_SETUSER.ts
+++ b/packages/client/lib/commands/ACL_SETUSER.ts
@@ -5,6 +5,12 @@ import { RedisVariadicArgument } from './generic-transformers';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Creates or modifies ACL user with specified rules
+   * @param parser - The Redis command parser
+   * @param username - Username to create or modify
+   * @param rule - ACL rule(s) to apply to the user
+   */
   parseCommand(parser: CommandParser, username: RedisArgument, rule: RedisVariadicArgument) {
     parser.push('ACL', 'SETUSER', username);
     parser.pushVariadic(rule);

--- a/packages/client/lib/commands/ACL_USERS.ts
+++ b/packages/client/lib/commands/ACL_USERS.ts
@@ -4,6 +4,10 @@ import { ArrayReply, BlobStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns a list of all configured ACL usernames
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('ACL', 'USERS');
   },

--- a/packages/client/lib/commands/ACL_WHOAMI.ts
+++ b/packages/client/lib/commands/ACL_WHOAMI.ts
@@ -4,6 +4,10 @@ import { BlobStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the username of the current connection
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('ACL', 'WHOAMI');
   },

--- a/packages/client/lib/commands/APPEND.ts
+++ b/packages/client/lib/commands/APPEND.ts
@@ -3,6 +3,12 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Appends a value to a string key
+   * @param parser - The Redis command parser
+   * @param key - The key to append to
+   * @param value - The value to append
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, value: RedisArgument) {
     parser.push('APPEND', key, value);
   },

--- a/packages/client/lib/commands/ASKING.ts
+++ b/packages/client/lib/commands/ASKING.ts
@@ -6,6 +6,10 @@ export const ASKING_CMD = 'ASKING';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Tells a Redis cluster node that the client is ok receiving such redirects
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push(ASKING_CMD);
   },

--- a/packages/client/lib/commands/AUTH.ts
+++ b/packages/client/lib/commands/AUTH.ts
@@ -9,6 +9,13 @@ export interface AuthOptions {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Authenticates the connection using a password or username and password
+   * @param parser - The Redis command parser
+   * @param options - Authentication options containing username and/or password
+   * @param options.username - Optional username for authentication
+   * @param options.password - Password for authentication
+   */
   parseCommand(parser: CommandParser, { username, password }: AuthOptions) {
     parser.push('AUTH');
     if (username !== undefined) {

--- a/packages/client/lib/commands/BGREWRITEAOF.ts
+++ b/packages/client/lib/commands/BGREWRITEAOF.ts
@@ -4,6 +4,10 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Asynchronously rewrites the append-only file
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('BGREWRITEAOF');
   },

--- a/packages/client/lib/commands/BGSAVE.ts
+++ b/packages/client/lib/commands/BGSAVE.ts
@@ -8,6 +8,12 @@ export interface BgSaveOptions {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Asynchronously saves the dataset to disk
+   * @param parser - The Redis command parser
+   * @param options - Optional configuration
+   * @param options.SCHEDULE - Schedule a BGSAVE operation when no BGSAVE is already in progress
+   */
   parseCommand(parser: CommandParser, options?: BgSaveOptions) {
     parser.push('BGSAVE');
     if (options?.SCHEDULE) {

--- a/packages/client/lib/commands/BITCOUNT.ts
+++ b/packages/client/lib/commands/BITCOUNT.ts
@@ -10,6 +10,15 @@ export interface BitCountRange {
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the count of set bits in a string key
+   * @param parser - The Redis command parser
+   * @param key - The key to count bits in
+   * @param range - Optional range specification
+   * @param range.start - Start offset in bytes/bits
+   * @param range.end - End offset in bytes/bits
+   * @param range.mode - Optional counting mode: BYTE or BIT
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, range?: BitCountRange) {
     parser.push('BITCOUNT');
     parser.pushKey(key);

--- a/packages/client/lib/commands/BITFIELD.ts
+++ b/packages/client/lib/commands/BITFIELD.ts
@@ -41,6 +41,12 @@ export type BitFieldRoOperations = Array<
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Performs arbitrary bitfield integer operations on strings
+   * @param parser - The Redis command parser
+   * @param key - The key holding the string
+   * @param operations - Array of bitfield operations to perform: GET, SET, INCRBY or OVERFLOW
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, operations: BitFieldOperations) {
     parser.push('BITFIELD');
     parser.pushKey(key);

--- a/packages/client/lib/commands/BITFIELD_RO.ts
+++ b/packages/client/lib/commands/BITFIELD_RO.ts
@@ -9,6 +9,12 @@ export type BitFieldRoOperations = Array<
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Performs read-only bitfield integer operations on strings
+   * @param parser - The Redis command parser
+   * @param key - The key holding the string
+   * @param operations - Array of GET operations to perform on the bitfield
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, operations: BitFieldRoOperations) {
     parser.push('BITFIELD_RO');
     parser.pushKey(key);

--- a/packages/client/lib/commands/BITOP.ts
+++ b/packages/client/lib/commands/BITOP.ts
@@ -6,6 +6,13 @@ export type BitOperations = 'AND' | 'OR' | 'XOR' | 'NOT';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Performs bitwise operations between strings
+   * @param parser - The Redis command parser
+   * @param operation - Bitwise operation to perform: AND, OR, XOR, NOT
+   * @param destKey - Destination key to store the result
+   * @param key - Source key(s) to perform operation on
+   */
   parseCommand(
     parser: CommandParser,
     operation: BitOperations,

--- a/packages/client/lib/commands/BITPOS.ts
+++ b/packages/client/lib/commands/BITPOS.ts
@@ -5,6 +5,15 @@ import { BitValue } from './generic-transformers';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the position of first bit set to 0 or 1 in a string
+   * @param parser - The Redis command parser
+   * @param key - The key holding the string
+   * @param bit - The bit value to look for (0 or 1)
+   * @param start - Optional starting position in bytes/bits
+   * @param end - Optional ending position in bytes/bits
+   * @param mode - Optional counting mode: BYTE or BIT
+   */
   parseCommand(parser: CommandParser,
     key: RedisArgument,
     bit: BitValue,

--- a/packages/client/lib/commands/BLMOVE.ts
+++ b/packages/client/lib/commands/BLMOVE.ts
@@ -4,6 +4,15 @@ import { ListSide } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Pop an element from a list, push it to another list and return it; or block until one is available
+   * @param parser - The Redis command parser
+   * @param source - Key of the source list
+   * @param destination - Key of the destination list
+   * @param sourceSide - Side of source list to pop from (LEFT or RIGHT)
+   * @param destinationSide - Side of destination list to push to (LEFT or RIGHT)
+   * @param timeout - Timeout in seconds, 0 to block indefinitely
+   */
   parseCommand(
     parser: CommandParser,
     source: RedisArgument,

--- a/packages/client/lib/commands/BLMPOP.ts
+++ b/packages/client/lib/commands/BLMPOP.ts
@@ -4,6 +4,12 @@ import LMPOP, { LMPopArguments, parseLMPopArguments } from './LMPOP';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Pops elements from multiple lists; blocks until elements are available
+   * @param parser - The Redis command parser
+   * @param timeout - Timeout in seconds, 0 to block indefinitely
+   * @param args - Additional arguments for LMPOP command
+   */
   parseCommand(parser: CommandParser, timeout: number, ...args: LMPopArguments) {
     parser.push('BLMPOP', timeout.toString());
     parseLMPopArguments(parser, ...args);

--- a/packages/client/lib/commands/BLPOP.ts
+++ b/packages/client/lib/commands/BLPOP.ts
@@ -4,6 +4,12 @@ import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Removes and returns the first element in a list, or blocks until one is available
+   * @param parser - The Redis command parser
+   * @param key - Key of the list to pop from, or array of keys to try sequentially
+   * @param timeout - Maximum seconds to block, 0 to block indefinitely
+   */
   parseCommand(parser: CommandParser, key: RedisVariadicArgument, timeout: number) {
     parser.push('BLPOP');
     parser.pushKeys(key);

--- a/packages/client/lib/commands/BRPOP.ts
+++ b/packages/client/lib/commands/BRPOP.ts
@@ -5,6 +5,12 @@ import BLPOP from './BLPOP';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Removes and returns the last element in a list, or blocks until one is available
+   * @param parser - The Redis command parser
+   * @param key - Key of the list to pop from, or array of keys to try sequentially
+   * @param timeout - Maximum seconds to block, 0 to block indefinitely
+   */
   parseCommand(parser: CommandParser, key: RedisVariadicArgument, timeout: number) {
     parser.push('BRPOP');
     parser.pushKeys(key);

--- a/packages/client/lib/commands/BRPOPLPUSH.ts
+++ b/packages/client/lib/commands/BRPOPLPUSH.ts
@@ -3,6 +3,13 @@ import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/type
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Pops an element from a list, pushes it to another list and returns it; blocks until element is available
+   * @param parser - The Redis command parser
+   * @param source - Key of the source list to pop from
+   * @param destination - Key of the destination list to push to
+   * @param timeout - Maximum seconds to block, 0 to block indefinitely
+   */
   parseCommand(parser: CommandParser, source: RedisArgument, destination: RedisArgument, timeout: number) {
     parser.push('BRPOPLPUSH');
     parser.pushKeys([source, destination]);

--- a/packages/client/lib/commands/BZMPOP.ts
+++ b/packages/client/lib/commands/BZMPOP.ts
@@ -4,6 +4,12 @@ import ZMPOP, { parseZMPopArguments, ZMPopArguments } from './ZMPOP';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Removes and returns members from one or more sorted sets in the specified order; blocks until elements are available
+   * @param parser - The Redis command parser
+   * @param timeout - Maximum seconds to block, 0 to block indefinitely
+   * @param args - Additional arguments specifying the keys, min/max count, and order (MIN/MAX)
+   */
   parseCommand(parser: CommandParser, timeout: number, ...args: ZMPopArguments) {
     parser.push('BZMPOP', timeout.toString());
     parseZMPopArguments(parser, ...args);

--- a/packages/client/lib/commands/BZPOPMAX.ts
+++ b/packages/client/lib/commands/BZPOPMAX.ts
@@ -4,6 +4,12 @@ import { RedisVariadicArgument, transformDoubleReply } from './generic-transform
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Removes and returns the member with the highest score in a sorted set, or blocks until one is available
+   * @param parser - The Redis command parser
+   * @param keys - Key of the sorted set, or array of keys to try sequentially
+   * @param timeout - Maximum seconds to block, 0 to block indefinitely
+   */
   parseCommand(parser: CommandParser, keys: RedisVariadicArgument, timeout: number) {
     parser.push('BZPOPMAX');
     parser.pushKeys(keys);

--- a/packages/client/lib/commands/BZPOPMIN.ts
+++ b/packages/client/lib/commands/BZPOPMIN.ts
@@ -5,6 +5,12 @@ import BZPOPMAX from './BZPOPMAX';
 
 export default {
   IS_READ_ONLY: BZPOPMAX.IS_READ_ONLY,
+  /**
+   * Removes and returns the member with the lowest score in a sorted set, or blocks until one is available
+   * @param parser - The Redis command parser
+   * @param keys - Key of the sorted set, or array of keys to try sequentially
+   * @param timeout - Maximum seconds to block, 0 to block indefinitely
+   */
   parseCommand(parser: CommandParser, keys: RedisVariadicArgument, timeout: number) {
     parser.push('BZPOPMIN');
     parser.pushKeys(keys);

--- a/packages/client/lib/commands/CLIENT_CACHING.ts
+++ b/packages/client/lib/commands/CLIENT_CACHING.ts
@@ -4,6 +4,11 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Instructs the server about tracking or not keys in the next request
+   * @param parser - The Redis command parser
+   * @param value - Whether to enable (true) or disable (false) tracking
+   */
   parseCommand(parser: CommandParser, value: boolean) {
     parser.push(
       'CLIENT',

--- a/packages/client/lib/commands/CLIENT_GETNAME.ts
+++ b/packages/client/lib/commands/CLIENT_GETNAME.ts
@@ -4,6 +4,10 @@ import { BlobStringReply, NullReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the name of the current connection
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('CLIENT', 'GETNAME');
   },

--- a/packages/client/lib/commands/CLIENT_GETREDIR.ts
+++ b/packages/client/lib/commands/CLIENT_GETREDIR.ts
@@ -4,6 +4,10 @@ import { NumberReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the ID of the client to which the current client is redirecting tracking notifications
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('CLIENT', 'GETREDIR');
   },

--- a/packages/client/lib/commands/CLIENT_ID.ts
+++ b/packages/client/lib/commands/CLIENT_ID.ts
@@ -4,6 +4,10 @@ import { NumberReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the client ID for the current connection
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('CLIENT', 'ID');
   },

--- a/packages/client/lib/commands/CLIENT_INFO.ts
+++ b/packages/client/lib/commands/CLIENT_INFO.ts
@@ -67,6 +67,10 @@ const CLIENT_INFO_REGEX = /([^\s=]+)=([^\s]*)/g;
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns information and statistics about the current client connection
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('CLIENT', 'INFO');
   },

--- a/packages/client/lib/commands/CLIENT_KILL.ts
+++ b/packages/client/lib/commands/CLIENT_KILL.ts
@@ -50,6 +50,11 @@ export type ClientKillFilter = ClientKillAddress | ClientKillLocalAddress | Clie
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Closes client connections matching the specified filters
+   * @param parser - The Redis command parser
+   * @param filters - One or more filters to match client connections to kill
+   */
   parseCommand(parser: CommandParser, filters: ClientKillFilter | Array<ClientKillFilter>) {
     parser.push('CLIENT', 'KILL');
 

--- a/packages/client/lib/commands/CLIENT_LIST.ts
+++ b/packages/client/lib/commands/CLIENT_LIST.ts
@@ -17,6 +17,11 @@ export type ListFilter = ListFilterType | ListFilterId;
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns information about all client connections. Can be filtered by type or ID
+   * @param parser - The Redis command parser
+   * @param filter - Optional filter to return only specific client types or IDs
+   */
   parseCommand(parser: CommandParser, filter?: ListFilter) {
     parser.push('CLIENT', 'LIST');
     if (filter) {

--- a/packages/client/lib/commands/CLIENT_NO-EVICT.ts
+++ b/packages/client/lib/commands/CLIENT_NO-EVICT.ts
@@ -4,6 +4,11 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Controls whether to prevent the client's connections from being evicted
+   * @param parser - The Redis command parser
+   * @param value - Whether to enable (true) or disable (false) the no-evict mode
+   */
   parseCommand(parser: CommandParser, value: boolean) {
     parser.push(
       'CLIENT',

--- a/packages/client/lib/commands/CLIENT_NO-TOUCH.ts
+++ b/packages/client/lib/commands/CLIENT_NO-TOUCH.ts
@@ -4,6 +4,11 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Controls whether to prevent the client from touching the LRU/LFU of keys
+   * @param parser - The Redis command parser
+   * @param value - Whether to enable (true) or disable (false) the no-touch mode
+   */
   parseCommand(parser: CommandParser, value: boolean) {
     parser.push(
       'CLIENT',

--- a/packages/client/lib/commands/CLIENT_PAUSE.ts
+++ b/packages/client/lib/commands/CLIENT_PAUSE.ts
@@ -4,6 +4,12 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Stops the server from processing client commands for the specified duration
+   * @param parser - The Redis command parser
+   * @param timeout - Time in milliseconds to pause command processing
+   * @param mode - Optional mode: 'WRITE' to pause only write commands, 'ALL' to pause all commands
+   */
   parseCommand(parser: CommandParser, timeout: number, mode?: 'WRITE' | 'ALL') {
     parser.push('CLIENT', 'PAUSE', timeout.toString());
     if (mode) {

--- a/packages/client/lib/commands/CLIENT_SETNAME.ts
+++ b/packages/client/lib/commands/CLIENT_SETNAME.ts
@@ -4,6 +4,11 @@ import { RedisArgument, SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Assigns a name to the current connection
+   * @param parser - The Redis command parser
+   * @param name - The name to assign to the connection
+   */
   parseCommand(parser: CommandParser, name: RedisArgument) {
     parser.push('CLIENT', 'SETNAME', name);
   },

--- a/packages/client/lib/commands/CLIENT_TRACKING.ts
+++ b/packages/client/lib/commands/CLIENT_TRACKING.ts
@@ -29,6 +29,12 @@ export type ClientTrackingOptions = CommonOptions & (
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Controls server-assisted client side caching for the current connection
+   * @param parser - The Redis command parser
+   * @param mode - Whether to enable (true) or disable (false) tracking
+   * @param options - Optional configuration including REDIRECT, BCAST, PREFIX, OPTIN, OPTOUT, and NOLOOP options
+   */
   parseCommand<M extends boolean>(
     parser: CommandParser,
     mode: M,

--- a/packages/client/lib/commands/CLIENT_TRACKINGINFO.ts
+++ b/packages/client/lib/commands/CLIENT_TRACKINGINFO.ts
@@ -10,6 +10,10 @@ type TrackingInfo = TuplesToMapReply<[
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns information about the current connection's key tracking state
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('CLIENT', 'TRACKINGINFO');
   },

--- a/packages/client/lib/commands/CLIENT_UNPAUSE.ts
+++ b/packages/client/lib/commands/CLIENT_UNPAUSE.ts
@@ -4,6 +4,10 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Resumes processing of client commands after a CLIENT PAUSE
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('CLIENT', 'UNPAUSE');
   },

--- a/packages/client/lib/commands/CLUSTER_ADDSLOTS.ts
+++ b/packages/client/lib/commands/CLUSTER_ADDSLOTS.ts
@@ -4,6 +4,11 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Assigns hash slots to the current node in a Redis Cluster
+   * @param parser - The Redis command parser
+   * @param slots - One or more hash slots to be assigned
+   */
   parseCommand(parser: CommandParser, slots: number | Array<number>) {
     parser.push('CLUSTER', 'ADDSLOTS');
     parser.pushVariadicNumber(slots);

--- a/packages/client/lib/commands/CLUSTER_ADDSLOTSRANGE.ts
+++ b/packages/client/lib/commands/CLUSTER_ADDSLOTSRANGE.ts
@@ -5,6 +5,11 @@ import { parseSlotRangesArguments, SlotRange } from './generic-transformers';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Assigns hash slot ranges to the current node in a Redis Cluster
+   * @param parser - The Redis command parser
+   * @param ranges - One or more slot ranges to be assigned, each specified as [start, end]
+   */
   parseCommand(parser: CommandParser, ranges: SlotRange | Array<SlotRange>) {
     parser.push('CLUSTER', 'ADDSLOTSRANGE');
     parseSlotRangesArguments(parser, ranges);

--- a/packages/client/lib/commands/CLUSTER_BUMPEPOCH.ts
+++ b/packages/client/lib/commands/CLUSTER_BUMPEPOCH.ts
@@ -4,6 +4,10 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Advances the cluster config epoch
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('CLUSTER', 'BUMPEPOCH');
   },

--- a/packages/client/lib/commands/CLUSTER_COUNT-FAILURE-REPORTS.ts
+++ b/packages/client/lib/commands/CLUSTER_COUNT-FAILURE-REPORTS.ts
@@ -4,6 +4,11 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the number of failure reports for a given node
+   * @param parser - The Redis command parser
+   * @param nodeId - The ID of the node to check
+   */
   parseCommand(parser: CommandParser, nodeId: RedisArgument) {
     parser.push('CLUSTER', 'COUNT-FAILURE-REPORTS', nodeId);
   },

--- a/packages/client/lib/commands/CLUSTER_COUNTKEYSINSLOT.ts
+++ b/packages/client/lib/commands/CLUSTER_COUNTKEYSINSLOT.ts
@@ -4,6 +4,11 @@ import { NumberReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the number of keys in the specified hash slot
+   * @param parser - The Redis command parser
+   * @param slot - The hash slot to check
+   */
   parseCommand(parser: CommandParser, slot: number) {
     parser.push('CLUSTER', 'COUNTKEYSINSLOT', slot.toString());
   },

--- a/packages/client/lib/commands/CLUSTER_DELSLOTS.ts
+++ b/packages/client/lib/commands/CLUSTER_DELSLOTS.ts
@@ -4,6 +4,11 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Removes hash slots from the current node in a Redis Cluster
+   * @param parser - The Redis command parser
+   * @param slots - One or more hash slots to be removed
+   */
   parseCommand(parser: CommandParser, slots: number | Array<number>) {
     parser.push('CLUSTER', 'DELSLOTS');
     parser.pushVariadicNumber(slots);

--- a/packages/client/lib/commands/CLUSTER_DELSLOTSRANGE.ts
+++ b/packages/client/lib/commands/CLUSTER_DELSLOTSRANGE.ts
@@ -5,6 +5,11 @@ import { parseSlotRangesArguments, SlotRange } from './generic-transformers';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Removes hash slot ranges from the current node in a Redis Cluster
+   * @param parser - The Redis command parser
+   * @param ranges - One or more slot ranges to be removed, each specified as [start, end]
+   */
   parseCommand(parser:CommandParser, ranges: SlotRange | Array<SlotRange>) {
     parser.push('CLUSTER', 'DELSLOTSRANGE');
     parseSlotRangesArguments(parser, ranges);

--- a/packages/client/lib/commands/CLUSTER_FAILOVER.ts
+++ b/packages/client/lib/commands/CLUSTER_FAILOVER.ts
@@ -15,6 +15,11 @@ export interface ClusterFailoverOptions {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Forces a replica to perform a manual failover of its master
+   * @param parser - The Redis command parser
+   * @param options - Optional configuration with FORCE or TAKEOVER mode
+   */
   parseCommand(parser:CommandParser, options?: ClusterFailoverOptions) {
     parser.push('CLUSTER', 'FAILOVER');
 

--- a/packages/client/lib/commands/CLUSTER_FLUSHSLOTS.ts
+++ b/packages/client/lib/commands/CLUSTER_FLUSHSLOTS.ts
@@ -4,6 +4,10 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Deletes all hash slots from the current node in a Redis Cluster
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('CLUSTER', 'FLUSHSLOTS');
   },

--- a/packages/client/lib/commands/CLUSTER_FORGET.ts
+++ b/packages/client/lib/commands/CLUSTER_FORGET.ts
@@ -4,6 +4,11 @@ import { RedisArgument, SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Removes a node from the cluster
+   * @param parser - The Redis command parser
+   * @param nodeId - The ID of the node to remove
+   */
   parseCommand(parser: CommandParser, nodeId: RedisArgument) {
     parser.push('CLUSTER', 'FORGET', nodeId);
   },

--- a/packages/client/lib/commands/CLUSTER_GETKEYSINSLOT.ts
+++ b/packages/client/lib/commands/CLUSTER_GETKEYSINSLOT.ts
@@ -4,6 +4,12 @@ import { ArrayReply, BlobStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns a number of keys from the specified hash slot
+   * @param parser - The Redis command parser
+   * @param slot - The hash slot to get keys from
+   * @param count - Maximum number of keys to return
+   */
   parseCommand(parser: CommandParser, slot: number, count: number) {
     parser.push('CLUSTER', 'GETKEYSINSLOT', slot.toString(), count.toString());
   },

--- a/packages/client/lib/commands/CLUSTER_INFO.ts
+++ b/packages/client/lib/commands/CLUSTER_INFO.ts
@@ -4,6 +4,10 @@ import { VerbatimStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns information about the state of a Redis Cluster
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('CLUSTER', 'INFO');
   },

--- a/packages/client/lib/commands/CLUSTER_KEYSLOT.ts
+++ b/packages/client/lib/commands/CLUSTER_KEYSLOT.ts
@@ -4,6 +4,11 @@ import { Command, NumberReply, RedisArgument } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the hash slot number for a given key
+   * @param parser - The Redis command parser
+   * @param key - The key to get the hash slot for
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('CLUSTER', 'KEYSLOT', key);
   },

--- a/packages/client/lib/commands/CLUSTER_LINKS.ts
+++ b/packages/client/lib/commands/CLUSTER_LINKS.ts
@@ -13,6 +13,10 @@ type ClusterLinksReply = ArrayReply<TuplesToMapReply<[
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns information about all cluster links (lower level connections to other nodes)
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('CLUSTER', 'LINKS');
   },

--- a/packages/client/lib/commands/CLUSTER_MEET.ts
+++ b/packages/client/lib/commands/CLUSTER_MEET.ts
@@ -4,6 +4,12 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Initiates a handshake with another node in the cluster
+   * @param parser - The Redis command parser
+   * @param host - Host name or IP address of the node
+   * @param port - TCP port of the node
+   */
   parseCommand(parser: CommandParser, host: string, port: number) {
     parser.push('CLUSTER', 'MEET', host, port.toString());
   },

--- a/packages/client/lib/commands/CLUSTER_MYID.ts
+++ b/packages/client/lib/commands/CLUSTER_MYID.ts
@@ -4,6 +4,10 @@ import { BlobStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the node ID of the current Redis Cluster node
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('CLUSTER', 'MYID');
   },

--- a/packages/client/lib/commands/CLUSTER_MYSHARDID.ts
+++ b/packages/client/lib/commands/CLUSTER_MYSHARDID.ts
@@ -4,6 +4,10 @@ import { BlobStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the shard ID of the current Redis Cluster node
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('CLUSTER', 'MYSHARDID');
   },

--- a/packages/client/lib/commands/CLUSTER_NODES.ts
+++ b/packages/client/lib/commands/CLUSTER_NODES.ts
@@ -4,6 +4,10 @@ import { VerbatimStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns serialized information about the nodes in a Redis Cluster
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('CLUSTER', 'NODES');
   },

--- a/packages/client/lib/commands/CLUSTER_REPLICAS.ts
+++ b/packages/client/lib/commands/CLUSTER_REPLICAS.ts
@@ -4,6 +4,11 @@ import { RedisArgument, ArrayReply, BlobStringReply, Command } from '../RESP/typ
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the replica nodes replicating from the specified primary node
+   * @param parser - The Redis command parser
+   * @param nodeId - Node ID of the primary node
+   */
   parseCommand(parser: CommandParser, nodeId: RedisArgument) {
     parser.push('CLUSTER', 'REPLICAS', nodeId);
   },

--- a/packages/client/lib/commands/CLUSTER_REPLICATE.ts
+++ b/packages/client/lib/commands/CLUSTER_REPLICATE.ts
@@ -4,6 +4,11 @@ import { RedisArgument, SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Reconfigures a node as a replica of the specified primary node
+   * @param parser - The Redis command parser
+   * @param nodeId - Node ID of the primary node to replicate
+   */
   parseCommand(parser: CommandParser, nodeId: RedisArgument) {
     parser.push('CLUSTER', 'REPLICATE', nodeId);
   },

--- a/packages/client/lib/commands/CLUSTER_RESET.ts
+++ b/packages/client/lib/commands/CLUSTER_RESET.ts
@@ -8,6 +8,11 @@ export interface ClusterResetOptions {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Resets a Redis Cluster node, clearing all information and returning it to a brand new state
+   * @param parser - The Redis command parser
+   * @param options - Options for the reset operation
+   */
   parseCommand(parser: CommandParser, options?: ClusterResetOptions) {
     parser.push('CLUSTER', 'RESET');
 

--- a/packages/client/lib/commands/CLUSTER_SAVECONFIG.ts
+++ b/packages/client/lib/commands/CLUSTER_SAVECONFIG.ts
@@ -4,6 +4,10 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Forces a Redis Cluster node to save the cluster configuration to disk
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('CLUSTER', 'SAVECONFIG');
   },

--- a/packages/client/lib/commands/CLUSTER_SET-CONFIG-EPOCH.ts
+++ b/packages/client/lib/commands/CLUSTER_SET-CONFIG-EPOCH.ts
@@ -4,6 +4,11 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Sets the configuration epoch for a Redis Cluster node
+   * @param parser - The Redis command parser
+   * @param configEpoch - The configuration epoch to set
+   */
   parseCommand(parser: CommandParser, configEpoch: number) {
     parser.push('CLUSTER', 'SET-CONFIG-EPOCH', configEpoch.toString());
   },

--- a/packages/client/lib/commands/CLUSTER_SETSLOT.ts
+++ b/packages/client/lib/commands/CLUSTER_SETSLOT.ts
@@ -13,6 +13,13 @@ export type ClusterSlotState = typeof CLUSTER_SLOT_STATES[keyof typeof CLUSTER_S
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Assigns a hash slot to a specific Redis Cluster node
+   * @param parser - The Redis command parser
+   * @param slot - The slot number to assign
+   * @param state - The state to set for the slot (IMPORTING, MIGRATING, STABLE, NODE)
+   * @param nodeId - Node ID (required for IMPORTING, MIGRATING, and NODE states)
+   */
   parseCommand(parser: CommandParser, slot: number, state: ClusterSlotState, nodeId?: RedisArgument) {
     parser.push('CLUSTER', 'SETSLOT', slot.toString(), state);
 

--- a/packages/client/lib/commands/CLUSTER_SLOTS.ts
+++ b/packages/client/lib/commands/CLUSTER_SLOTS.ts
@@ -19,6 +19,10 @@ export type ClusterSlotsNode = ReturnType<typeof transformNode>;
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns information about which Redis Cluster node handles which hash slots
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('CLUSTER', 'SLOTS');
   },

--- a/packages/client/lib/commands/COMMAND.ts
+++ b/packages/client/lib/commands/COMMAND.ts
@@ -5,6 +5,10 @@ import { CommandRawReply, CommandReply, transformCommandReply } from './generic-
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns an array with details about all Redis commands
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('COMMAND');
   },

--- a/packages/client/lib/commands/COMMAND_COUNT.ts
+++ b/packages/client/lib/commands/COMMAND_COUNT.ts
@@ -4,6 +4,10 @@ import { NumberReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the total number of commands available in the Redis server
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('COMMAND', 'COUNT');
   },

--- a/packages/client/lib/commands/COMMAND_GETKEYS.ts
+++ b/packages/client/lib/commands/COMMAND_GETKEYS.ts
@@ -4,6 +4,11 @@ import { RedisArgument, ArrayReply, BlobStringReply, Command } from '../RESP/typ
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Extracts the key names from a Redis command
+   * @param parser - The Redis command parser
+   * @param args - Command arguments to analyze
+   */
   parseCommand(parser: CommandParser, args: Array<RedisArgument>) {
     parser.push('COMMAND', 'GETKEYS');
     parser.push(...args);

--- a/packages/client/lib/commands/COMMAND_GETKEYSANDFLAGS.ts
+++ b/packages/client/lib/commands/COMMAND_GETKEYSANDFLAGS.ts
@@ -9,6 +9,11 @@ export type CommandGetKeysAndFlagsRawReply = ArrayReply<TuplesReply<[
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Extracts the key names and access flags from a Redis command
+   * @param parser - The Redis command parser
+   * @param args - Command arguments to analyze
+   */
   parseCommand(parser: CommandParser, args: Array<RedisArgument>) {
     parser.push('COMMAND', 'GETKEYSANDFLAGS');
     parser.push(...args);

--- a/packages/client/lib/commands/COMMAND_INFO.ts
+++ b/packages/client/lib/commands/COMMAND_INFO.ts
@@ -5,6 +5,11 @@ import { CommandRawReply, CommandReply, transformCommandReply } from './generic-
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns details about specific Redis commands
+   * @param parser - The Redis command parser
+   * @param commands - Array of command names to get information about
+   */
   parseCommand(parser: CommandParser, commands: Array<string>) {
     parser.push('COMMAND', 'INFO', ...commands);
   },

--- a/packages/client/lib/commands/COMMAND_LIST.ts
+++ b/packages/client/lib/commands/COMMAND_LIST.ts
@@ -19,6 +19,11 @@ export interface CommandListOptions {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns a list of all commands supported by the Redis server
+   * @param parser - The Redis command parser
+   * @param options - Options for filtering the command list
+   */
   parseCommand(parser: CommandParser, options?: CommandListOptions) {
     parser.push('COMMAND', 'LIST');
 

--- a/packages/client/lib/commands/CONFIG_GET.ts
+++ b/packages/client/lib/commands/CONFIG_GET.ts
@@ -5,6 +5,11 @@ import { RedisVariadicArgument, transformTuplesReply } from './generic-transform
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Gets the values of configuration parameters
+   * @param parser - The Redis command parser
+   * @param parameters - Pattern or specific configuration parameter names
+   */
   parseCommand(parser: CommandParser, parameters: RedisVariadicArgument) {
     parser.push('CONFIG', 'GET');
     parser.pushVariadic(parameters);

--- a/packages/client/lib/commands/CONFIG_RESETSTAT.ts
+++ b/packages/client/lib/commands/CONFIG_RESETSTAT.ts
@@ -4,6 +4,10 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Resets the statistics reported by Redis using the INFO command
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('CONFIG', 'RESETSTAT');
   },

--- a/packages/client/lib/commands/CONFIG_REWRITE.ts
+++ b/packages/client/lib/commands/CONFIG_REWRITE.ts
@@ -4,6 +4,10 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Rewrites the Redis configuration file with the current configuration
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('CONFIG', 'REWRITE');
   },

--- a/packages/client/lib/commands/CONFIG_SET.ts
+++ b/packages/client/lib/commands/CONFIG_SET.ts
@@ -8,6 +8,12 @@ type MultipleParameters = [config: Record<string, RedisArgument>];
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Sets configuration parameters to the specified values
+   * @param parser - The Redis command parser
+   * @param parameterOrConfig - Either a single parameter name or a configuration object
+   * @param value - Value for the parameter (when using single parameter format)
+   */
   parseCommand(
     parser: CommandParser,
     ...[parameterOrConfig, value]: SingleParameter | MultipleParameters

--- a/packages/client/lib/commands/COPY.ts
+++ b/packages/client/lib/commands/COPY.ts
@@ -8,6 +8,13 @@ export interface CopyCommandOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Copies the value stored at the source key to the destination key
+   * @param parser - The Redis command parser
+   * @param source - Source key
+   * @param destination - Destination key
+   * @param options - Options for the copy operation
+   */
   parseCommand(parser: CommandParser, source: RedisArgument, destination: RedisArgument, options?: CopyCommandOptions) {
     parser.push('COPY');
     parser.pushKeys([source, destination]);

--- a/packages/client/lib/commands/DBSIZE.ts
+++ b/packages/client/lib/commands/DBSIZE.ts
@@ -4,6 +4,10 @@ import { NumberReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the number of keys in the current database
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('DBSIZE');
   },

--- a/packages/client/lib/commands/DECR.ts
+++ b/packages/client/lib/commands/DECR.ts
@@ -2,6 +2,11 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Decrements the integer value of a key by one
+   * @param parser - The Redis command parser
+   * @param key - Key to decrement
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('DECR');
     parser.pushKey(key);

--- a/packages/client/lib/commands/DECRBY.ts
+++ b/packages/client/lib/commands/DECRBY.ts
@@ -2,6 +2,12 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Decrements the integer value of a key by the given number
+   * @param parser - The Redis command parser
+   * @param key - Key to decrement
+   * @param decrement - Decrement amount
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, decrement: number) {
     parser.push('DECRBY');
     parser.pushKey(key);

--- a/packages/client/lib/commands/DEL.ts
+++ b/packages/client/lib/commands/DEL.ts
@@ -4,6 +4,11 @@ import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Removes the specified keys. A key is ignored if it does not exist
+   * @param parser - The Redis command parser
+   * @param keys - One or more keys to delete
+   */
   parseCommand(parser: CommandParser, keys: RedisVariadicArgument) {
     parser.push('DEL');
     parser.pushKeys(keys);

--- a/packages/client/lib/commands/DISCARD.ts
+++ b/packages/client/lib/commands/DISCARD.ts
@@ -2,6 +2,10 @@ import { CommandParser } from '../client/parser';
 import { SimpleStringReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Discards a transaction, forgetting all queued commands
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('DISCARD');
   },

--- a/packages/client/lib/commands/DUMP.ts
+++ b/packages/client/lib/commands/DUMP.ts
@@ -3,6 +3,11 @@ import { RedisArgument, BlobStringReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns a serialized version of the value stored at the key
+   * @param parser - The Redis command parser
+   * @param key - Key to dump
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('DUMP');
     parser.pushKey(key);

--- a/packages/client/lib/commands/ECHO.ts
+++ b/packages/client/lib/commands/ECHO.ts
@@ -4,6 +4,11 @@ import { RedisArgument, BlobStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the given string
+   * @param parser - The Redis command parser
+   * @param message - Message to echo back
+   */
   parseCommand(parser: CommandParser, message: RedisArgument) {
     parser.push('ECHO', message);
   },

--- a/packages/client/lib/commands/EVAL.ts
+++ b/packages/client/lib/commands/EVAL.ts
@@ -25,6 +25,12 @@ export function parseEvalArguments(
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Executes a Lua script server side
+   * @param parser - The Redis command parser
+   * @param script - Lua script to execute
+   * @param options - Script execution options including keys and arguments
+   */
   parseCommand(...args: Parameters<typeof parseEvalArguments>) {
     args[0].push('EVAL');
     parseEvalArguments(...args);

--- a/packages/client/lib/commands/EVALSHA.ts
+++ b/packages/client/lib/commands/EVALSHA.ts
@@ -3,6 +3,12 @@ import EVAL, { parseEvalArguments } from './EVAL';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Executes a Lua script server side using the script's SHA1 digest
+   * @param parser - The Redis command parser
+   * @param sha1 - SHA1 digest of the script
+   * @param options - Script execution options including keys and arguments
+   */
   parseCommand(...args: Parameters<typeof parseEvalArguments>) {
     args[0].push('EVALSHA');
     parseEvalArguments(...args);

--- a/packages/client/lib/commands/EVALSHA_RO.ts
+++ b/packages/client/lib/commands/EVALSHA_RO.ts
@@ -3,6 +3,12 @@ import EVAL, { parseEvalArguments } from './EVAL';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Executes a read-only Lua script server side using the script's SHA1 digest
+   * @param parser - The Redis command parser
+   * @param sha1 - SHA1 digest of the script
+   * @param options - Script execution options including keys and arguments
+   */
   parseCommand(...args: Parameters<typeof parseEvalArguments>) {
     args[0].push('EVALSHA_RO');
     parseEvalArguments(...args);

--- a/packages/client/lib/commands/EVAL_RO.ts
+++ b/packages/client/lib/commands/EVAL_RO.ts
@@ -3,6 +3,12 @@ import EVAL, { parseEvalArguments } from './EVAL';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Executes a read-only Lua script server side
+   * @param parser - The Redis command parser
+   * @param script - Lua script to execute
+   * @param options - Script execution options including keys and arguments
+   */
   parseCommand(...args: Parameters<typeof parseEvalArguments>) {
     args[0].push('EVAL_RO');
     parseEvalArguments(...args);

--- a/packages/client/lib/commands/EXISTS.ts
+++ b/packages/client/lib/commands/EXISTS.ts
@@ -5,6 +5,11 @@ import { RedisVariadicArgument } from './generic-transformers';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Determines if the specified keys exist
+   * @param parser - The Redis command parser
+   * @param keys - One or more keys to check
+   */
   parseCommand(parser: CommandParser, keys: RedisVariadicArgument) {
     parser.push('EXISTS');
     parser.pushKeys(keys);

--- a/packages/client/lib/commands/EXPIRE.ts
+++ b/packages/client/lib/commands/EXPIRE.ts
@@ -3,6 +3,13 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Sets a timeout on key. After the timeout has expired, the key will be automatically deleted
+   * @param parser - The Redis command parser
+   * @param key - Key to set expiration on
+   * @param seconds - Number of seconds until key expiration
+   * @param mode - Expiration mode: NX (only if key has no expiry), XX (only if key has existing expiry), GT (only if new expiry is greater than current), LT (only if new expiry is less than current)
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/EXPIREAT.ts
+++ b/packages/client/lib/commands/EXPIREAT.ts
@@ -4,6 +4,13 @@ import { transformEXAT } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Sets the expiration for a key at a specific Unix timestamp
+   * @param parser - The Redis command parser
+   * @param key - Key to set expiration on
+   * @param timestamp - Unix timestamp (seconds since January 1, 1970) or Date object
+   * @param mode - Expiration mode: NX (only if key has no expiry), XX (only if key has existing expiry), GT (only if new expiry is greater than current), LT (only if new expiry is less than current)
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/EXPIRETIME.ts
+++ b/packages/client/lib/commands/EXPIRETIME.ts
@@ -3,6 +3,11 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the absolute Unix timestamp (since January 1, 1970) at which the given key will expire
+   * @param parser - The Redis command parser
+   * @param key - Key to check expiration time
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('EXPIRETIME');
     parser.pushKey(key);

--- a/packages/client/lib/commands/FAILOVER.ts
+++ b/packages/client/lib/commands/FAILOVER.ts
@@ -12,6 +12,11 @@ interface FailoverOptions {
 }
 
 export default {
+  /**
+   * Starts a coordinated failover between the primary and a replica
+   * @param parser - The Redis command parser
+   * @param options - Failover options including target host, abort flag, and timeout
+   */
   parseCommand(parser: CommandParser, options?: FailoverOptions) {
     parser.push('FAILOVER');
 

--- a/packages/client/lib/commands/FCALL.ts
+++ b/packages/client/lib/commands/FCALL.ts
@@ -3,6 +3,12 @@ import EVAL, { parseEvalArguments } from './EVAL';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Invokes a Redis function
+   * @param parser - The Redis command parser
+   * @param functionName - Name of the function to call
+   * @param options - Function execution options including keys and arguments
+   */
   parseCommand(...args: Parameters<typeof parseEvalArguments>) {
     args[0].push('FCALL');
     parseEvalArguments(...args);

--- a/packages/client/lib/commands/FCALL_RO.ts
+++ b/packages/client/lib/commands/FCALL_RO.ts
@@ -3,6 +3,12 @@ import EVAL, { parseEvalArguments } from './EVAL';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Invokes a read-only Redis function
+   * @param parser - The Redis command parser
+   * @param functionName - Name of the function to call
+   * @param options - Function execution options including keys and arguments
+   */
   parseCommand(...args: Parameters<typeof parseEvalArguments>) {
     args[0].push('FCALL_RO');
     parseEvalArguments(...args);

--- a/packages/client/lib/commands/FLUSHALL.ts
+++ b/packages/client/lib/commands/FLUSHALL.ts
@@ -11,6 +11,11 @@ export type RedisFlushMode = typeof REDIS_FLUSH_MODES[keyof typeof REDIS_FLUSH_M
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: false,
+  /**
+   * Removes all keys from all databases
+   * @param parser - The Redis command parser
+   * @param mode - Optional flush mode (ASYNC or SYNC)
+   */
   parseCommand(parser: CommandParser, mode?: RedisFlushMode) {
     parser.push('FLUSHALL');
     if (mode) {

--- a/packages/client/lib/commands/FLUSHDB.ts
+++ b/packages/client/lib/commands/FLUSHDB.ts
@@ -5,6 +5,11 @@ import { RedisFlushMode } from './FLUSHALL';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: false,
+  /**
+   * Removes all keys from the current database
+   * @param parser - The Redis command parser
+   * @param mode - Optional flush mode (ASYNC or SYNC)
+   */
   parseCommand(parser: CommandParser, mode?: RedisFlushMode) {
     parser.push('FLUSHDB');
     if (mode) {

--- a/packages/client/lib/commands/FUNCTION_DELETE.ts
+++ b/packages/client/lib/commands/FUNCTION_DELETE.ts
@@ -4,6 +4,11 @@ import { RedisArgument, SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: false,
+  /**
+   * Deletes a library and all its functions
+   * @param parser - The Redis command parser
+   * @param library - Name of the library to delete
+   */
   parseCommand(parser: CommandParser, library: RedisArgument) {
     parser.push('FUNCTION', 'DELETE', library);
   },

--- a/packages/client/lib/commands/FUNCTION_DUMP.ts
+++ b/packages/client/lib/commands/FUNCTION_DUMP.ts
@@ -4,6 +4,10 @@ import { BlobStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns a serialized payload representing the current functions loaded in the server
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('FUNCTION', 'DUMP')
   },

--- a/packages/client/lib/commands/FUNCTION_FLUSH.ts
+++ b/packages/client/lib/commands/FUNCTION_FLUSH.ts
@@ -5,6 +5,11 @@ import { RedisFlushMode } from './FLUSHALL';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: false,
+  /**
+   * Deletes all the libraries and functions from a Redis server
+   * @param parser - The Redis command parser
+   * @param mode - Optional flush mode (ASYNC or SYNC)
+   */
   parseCommand(parser: CommandParser, mode?: RedisFlushMode) {
     parser.push('FUNCTION', 'FLUSH');
 

--- a/packages/client/lib/commands/FUNCTION_KILL.ts
+++ b/packages/client/lib/commands/FUNCTION_KILL.ts
@@ -4,6 +4,10 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Kills a function that is currently executing
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('FUNCTION', 'KILL');
   },

--- a/packages/client/lib/commands/FUNCTION_LIST.ts
+++ b/packages/client/lib/commands/FUNCTION_LIST.ts
@@ -20,6 +20,11 @@ export type FunctionListReply = ArrayReply<TuplesToMapReply<FunctionListReplyIte
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: false,
+  /**
+   * Returns all libraries and functions
+   * @param parser - The Redis command parser
+   * @param options - Options for listing functions
+   */
   parseCommand(parser: CommandParser, options?: FunctionListOptions) {
     parser.push('FUNCTION', 'LIST');
 

--- a/packages/client/lib/commands/FUNCTION_LIST_WITHCODE.ts
+++ b/packages/client/lib/commands/FUNCTION_LIST_WITHCODE.ts
@@ -9,6 +9,11 @@ export type FunctionListWithCodeReply = ArrayReply<TuplesToMapReply<[
 export default {
   NOT_KEYED_COMMAND: FUNCTION_LIST.NOT_KEYED_COMMAND,
   IS_READ_ONLY: FUNCTION_LIST.IS_READ_ONLY,
+  /**
+   * Returns all libraries and functions including their source code
+   * @param parser - The Redis command parser
+   * @param options - Options for listing functions
+   */
   parseCommand(...args: Parameters<typeof FUNCTION_LIST.parseCommand>) {
     FUNCTION_LIST.parseCommand(...args);
     args[0].push('WITHCODE');

--- a/packages/client/lib/commands/FUNCTION_LOAD.ts
+++ b/packages/client/lib/commands/FUNCTION_LOAD.ts
@@ -8,6 +8,12 @@ export interface FunctionLoadOptions {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: false,
+  /**
+   * Loads a library to Redis
+   * @param parser - The Redis command parser
+   * @param code - Library code to load
+   * @param options - Function load options
+   */
   parseCommand(parser: CommandParser, code: RedisArgument, options?: FunctionLoadOptions) {
     parser.push('FUNCTION', 'LOAD');
 

--- a/packages/client/lib/commands/FUNCTION_RESTORE.ts
+++ b/packages/client/lib/commands/FUNCTION_RESTORE.ts
@@ -8,6 +8,12 @@ export interface FunctionRestoreOptions {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: false,
+  /**
+   * Restores libraries from the dump payload
+   * @param parser - The Redis command parser
+   * @param dump - Serialized payload of functions to restore
+   * @param options - Options for the restore operation
+   */
   parseCommand(parser: CommandParser, dump: RedisArgument, options?: FunctionRestoreOptions) {
     parser.push('FUNCTION', 'RESTORE', dump);
 

--- a/packages/client/lib/commands/FUNCTION_STATS.ts
+++ b/packages/client/lib/commands/FUNCTION_STATS.ts
@@ -23,6 +23,10 @@ type FunctionStatsReply = TuplesToMapReply<[
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns information about the function that is currently running and information about the available execution engines
+   * @param parser - The Redis command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('FUNCTION', 'STATS');
   },

--- a/packages/client/lib/commands/GEOADD.ts
+++ b/packages/client/lib/commands/GEOADD.ts
@@ -21,6 +21,13 @@ export interface GeoAddOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Adds geospatial items to the specified key
+   * @param parser - The Redis command parser
+   * @param key - Key to add the geospatial items to
+   * @param toAdd - Geospatial member(s) to add
+   * @param options - Options for the GEOADD command
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/GEODIST.ts
+++ b/packages/client/lib/commands/GEODIST.ts
@@ -5,6 +5,14 @@ import { GeoUnits } from './GEOSEARCH';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the distance between two members in a geospatial index
+   * @param parser - The Redis command parser
+   * @param key - Key of the geospatial index
+   * @param member1 - First member in the geospatial index
+   * @param member2 - Second member in the geospatial index
+   * @param unit - Unit of distance (m, km, ft, mi)
+   */
   parseCommand(parser: CommandParser,
     key: RedisArgument,
     member1: RedisArgument,

--- a/packages/client/lib/commands/GEOHASH.ts
+++ b/packages/client/lib/commands/GEOHASH.ts
@@ -5,6 +5,12 @@ import { RedisVariadicArgument } from './generic-transformers';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the Geohash string representation of one or more position members
+   * @param parser - The Redis command parser
+   * @param key - Key of the geospatial index
+   * @param member - One or more members in the geospatial index
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, member: RedisVariadicArgument) {
     parser.push('GEOHASH');
     parser.pushKey(key);

--- a/packages/client/lib/commands/GEOPOS.ts
+++ b/packages/client/lib/commands/GEOPOS.ts
@@ -5,6 +5,12 @@ import { RedisVariadicArgument } from './generic-transformers';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the longitude and latitude of one or more members in a geospatial index
+   * @param parser - The Redis command parser
+   * @param key - Key of the geospatial index
+   * @param member - One or more members in the geospatial index
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, member: RedisVariadicArgument) {
     parser.push('GEOPOS');
     parser.pushKey(key);

--- a/packages/client/lib/commands/GEORADIUS.ts
+++ b/packages/client/lib/commands/GEORADIUS.ts
@@ -18,6 +18,15 @@ export function parseGeoRadiusArguments(
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Queries members in a geospatial index based on a radius from a center point
+   * @param parser - The Redis command parser
+   * @param key - Key of the geospatial index
+   * @param from - Center coordinates for the search
+   * @param radius - Radius of the search area
+   * @param unit - Unit of distance (m, km, ft, mi)
+   * @param options - Additional search options
+   */
   parseCommand(...args: Parameters<typeof parseGeoRadiusArguments>) {
     args[0].push('GEORADIUS');
     return parseGeoRadiusArguments(...args);

--- a/packages/client/lib/commands/GEORADIUSBYMEMBER.ts
+++ b/packages/client/lib/commands/GEORADIUSBYMEMBER.ts
@@ -18,6 +18,15 @@ export function parseGeoRadiusByMemberArguments(
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Queries members in a geospatial index based on a radius from a member
+   * @param parser - The Redis command parser
+   * @param key - Key of the geospatial index
+   * @param from - Member name to use as center point
+   * @param radius - Radius of the search area
+   * @param unit - Unit of distance (m, km, ft, mi)
+   * @param options - Additional search options
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/GEORADIUSBYMEMBER_RO.ts
+++ b/packages/client/lib/commands/GEORADIUSBYMEMBER_RO.ts
@@ -4,6 +4,15 @@ import GEORADIUSBYMEMBER, { parseGeoRadiusByMemberArguments } from './GEORADIUSB
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Read-only variant that queries members in a geospatial index based on a radius from a member
+   * @param parser - The Redis command parser
+   * @param key - Key of the geospatial index
+   * @param from - Member name to use as center point
+   * @param radius - Radius of the search area
+   * @param unit - Unit of distance (m, km, ft, mi)
+   * @param options - Additional search options
+   */
   parseCommand(...args: Parameters<typeof parseGeoRadiusByMemberArguments>) {
     const parser = args[0];
     parser.push('GEORADIUSBYMEMBER_RO');

--- a/packages/client/lib/commands/GEORADIUSBYMEMBER_RO_WITH.ts
+++ b/packages/client/lib/commands/GEORADIUSBYMEMBER_RO_WITH.ts
@@ -4,6 +4,15 @@ import GEORADIUSBYMEMBER_WITH, { parseGeoRadiusByMemberWithArguments } from './G
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Read-only variant that queries members in a geospatial index based on a radius from a member with additional information
+   * @param parser - The Redis command parser
+   * @param key - Key of the geospatial index
+   * @param from - Member name to use as center point
+   * @param radius - Radius of the search area
+   * @param unit - Unit of distance (m, km, ft, mi)
+   * @param withValues - Information to include with each returned member
+   */
   parseCommand(...args: Parameters<typeof parseGeoRadiusByMemberWithArguments>) {
     const parser = args[0];
     parser.push('GEORADIUSBYMEMBER_RO');

--- a/packages/client/lib/commands/GEORADIUSBYMEMBER_STORE.ts
+++ b/packages/client/lib/commands/GEORADIUSBYMEMBER_STORE.ts
@@ -9,6 +9,16 @@ export interface GeoRadiusStoreOptions extends GeoSearchOptions {
 
 export default {
   IS_READ_ONLY: GEORADIUSBYMEMBER.IS_READ_ONLY,
+  /**
+   * Queries members in a geospatial index based on a radius from a member and stores the results
+   * @param parser - The Redis command parser
+   * @param key - Key of the geospatial index
+   * @param from - Member name to use as center point
+   * @param radius - Radius of the search area
+   * @param unit - Unit of distance (m, km, ft, mi)
+   * @param destination - Key to store the results
+   * @param options - Additional search and storage options
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/GEORADIUSBYMEMBER_WITH.ts
+++ b/packages/client/lib/commands/GEORADIUSBYMEMBER_WITH.ts
@@ -23,6 +23,16 @@ export function parseGeoRadiusByMemberWithArguments(
 
 export default {
   IS_READ_ONLY: GEORADIUSBYMEMBER.IS_READ_ONLY,
+  /**
+   * Queries members in a geospatial index based on a radius from a member with additional information
+   * @param parser - The Redis command parser
+   * @param key - Key of the geospatial index
+   * @param from - Member name to use as center point
+   * @param radius - Radius of the search area
+   * @param unit - Unit of distance (m, km, ft, mi)
+   * @param replyWith - Information to include with each returned member
+   * @param options - Additional search options
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/GEORADIUS_RO.ts
+++ b/packages/client/lib/commands/GEORADIUS_RO.ts
@@ -4,6 +4,15 @@ import GEORADIUS, { parseGeoRadiusArguments } from './GEORADIUS';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Read-only variant that queries members in a geospatial index based on a radius from a center point
+   * @param parser - The Redis command parser
+   * @param key - Key of the geospatial index
+   * @param from - Center coordinates for the search
+   * @param radius - Radius of the search area
+   * @param unit - Unit of distance (m, km, ft, mi)
+   * @param options - Additional search options
+   */
   parseCommand(...args: Parameters<typeof parseGeoRadiusArguments>) {
     args[0].push('GEORADIUS_RO');
     parseGeoRadiusArguments(...args);

--- a/packages/client/lib/commands/GEORADIUS_RO_WITH.ts
+++ b/packages/client/lib/commands/GEORADIUS_RO_WITH.ts
@@ -5,6 +5,16 @@ import GEORADIUS_WITH from './GEORADIUS_WITH';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Read-only variant that queries members in a geospatial index based on a radius from a center point with additional information
+   * @param parser - The Redis command parser
+   * @param key - Key of the geospatial index
+   * @param from - Center coordinates for the search
+   * @param radius - Radius of the search area
+   * @param unit - Unit of distance (m, km, ft, mi)
+   * @param replyWith - Information to include with each returned member
+   * @param options - Additional search options
+   */
   parseCommand(...args: Parameters<typeof parseGeoRadiusWithArguments>) {
     args[0].push('GEORADIUS_RO');
     parseGeoRadiusWithArguments(...args);

--- a/packages/client/lib/commands/GEORADIUS_STORE.ts
+++ b/packages/client/lib/commands/GEORADIUS_STORE.ts
@@ -9,6 +9,16 @@ export interface GeoRadiusStoreOptions extends GeoSearchOptions {
 
 export default {
   IS_READ_ONLY: GEORADIUS.IS_READ_ONLY,
+  /**
+   * Queries members in a geospatial index based on a radius from a center point and stores the results
+   * @param parser - The Redis command parser
+   * @param key - Key of the geospatial index
+   * @param from - Center coordinates for the search
+   * @param radius - Radius of the search area
+   * @param unit - Unit of distance (m, km, ft, mi)
+   * @param destination - Key to store the results
+   * @param options - Additional search and storage options
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/GEORADIUS_WITH.ts
+++ b/packages/client/lib/commands/GEORADIUS_WITH.ts
@@ -20,6 +20,16 @@ export function parseGeoRadiusWithArguments(
 
 export default {
   IS_READ_ONLY: GEORADIUS.IS_READ_ONLY,
+  /**
+   * Queries members in a geospatial index based on a radius from a center point with additional information
+   * @param parser - The Redis command parser
+   * @param key - Key of the geospatial index
+   * @param from - Center coordinates for the search
+   * @param radius - Radius of the search area
+   * @param unit - Unit of distance (m, km, ft, mi)
+   * @param replyWith - Information to include with each returned member
+   * @param options - Additional search options
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/GEOSEARCH.ts
+++ b/packages/client/lib/commands/GEOSEARCH.ts
@@ -80,6 +80,14 @@ export function parseGeoSearchOptions(
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Queries members inside an area of a geospatial index
+   * @param parser - The Redis command parser
+   * @param key - Key of the geospatial index
+   * @param from - Center point of the search (member name or coordinates)
+   * @param by - Search area specification (radius or box dimensions)
+   * @param options - Additional search options
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/GEOSEARCHSTORE.ts
+++ b/packages/client/lib/commands/GEOSEARCHSTORE.ts
@@ -8,6 +8,15 @@ export interface GeoSearchStoreOptions extends GeoSearchOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Searches a geospatial index and stores the results in a new sorted set
+   * @param parser - The Redis command parser
+   * @param destination - Key to store the results
+   * @param source - Key of the geospatial index to search
+   * @param from - Center point of the search (member name or coordinates)
+   * @param by - Search area specification (radius or box dimensions)
+   * @param options - Additional search and storage options
+   */
   parseCommand(
     parser: CommandParser,
     destination: RedisArgument,

--- a/packages/client/lib/commands/GEOSEARCH_WITH.ts
+++ b/packages/client/lib/commands/GEOSEARCH_WITH.ts
@@ -22,6 +22,15 @@ export interface GeoReplyWithMember {
 
 export default {
   IS_READ_ONLY: GEOSEARCH.IS_READ_ONLY,
+  /**
+   * Queries members inside an area of a geospatial index with additional information
+   * @param parser - The Redis command parser
+   * @param key - Key of the geospatial index
+   * @param from - Center point of the search (member name or coordinates)
+   * @param by - Search area specification (radius or box dimensions)
+   * @param replyWith - Information to include with each returned member
+   * @param options - Additional search options
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/GET.ts
+++ b/packages/client/lib/commands/GET.ts
@@ -4,6 +4,11 @@ import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/type
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Gets the value of a key
+   * @param parser - The Redis command parser
+   * @param key - Key to get the value of
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('GET');
     parser.pushKey(key);

--- a/packages/client/lib/commands/GETBIT.ts
+++ b/packages/client/lib/commands/GETBIT.ts
@@ -5,6 +5,12 @@ import { BitValue } from './generic-transformers';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the bit value at a given offset in a string value
+   * @param parser - The Redis command parser
+   * @param key - Key to retrieve the bit from
+   * @param offset - Bit offset
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, offset: number) {
     parser.push('GETBIT');
     parser.pushKey(key);

--- a/packages/client/lib/commands/GETDEL.ts
+++ b/packages/client/lib/commands/GETDEL.ts
@@ -3,6 +3,11 @@ import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/type
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Gets the value of a key and deletes the key
+   * @param parser - The Redis command parser
+   * @param key - Key to get and delete
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('GETDEL');
     parser.pushKey(key);

--- a/packages/client/lib/commands/GETEX.ts
+++ b/packages/client/lib/commands/GETEX.ts
@@ -39,6 +39,12 @@ export type GetExOptions = {
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Gets the value of a key and optionally sets its expiration
+   * @param parser - The Redis command parser
+   * @param key - Key to get value from
+   * @param options - Options for setting expiration
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, options: GetExOptions) {
     parser.push('GETEX');
     parser.pushKey(key);

--- a/packages/client/lib/commands/GETRANGE.ts
+++ b/packages/client/lib/commands/GETRANGE.ts
@@ -4,6 +4,13 @@ import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/type
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns a substring of the string stored at a key
+   * @param parser - The Redis command parser
+   * @param key - Key to get substring from
+   * @param start - Start position of the substring
+   * @param end - End position of the substring
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, start: number, end: number) {
     parser.push('GETRANGE');
     parser.pushKey(key);

--- a/packages/client/lib/commands/GETSET.ts
+++ b/packages/client/lib/commands/GETSET.ts
@@ -3,6 +3,12 @@ import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/type
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Sets a key to a new value and returns its old value
+   * @param parser - The Redis command parser
+   * @param key - Key to set
+   * @param value - Value to set
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, value: RedisArgument) {
     parser.push('GETSET');
     parser.pushKey(key);

--- a/packages/client/lib/commands/HDEL.ts
+++ b/packages/client/lib/commands/HDEL.ts
@@ -3,6 +3,12 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
+  /**
+   * Removes one or more fields from a hash
+   * @param parser - The Redis command parser
+   * @param key - Key of the hash
+   * @param field - Field(s) to remove
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, field: RedisVariadicArgument) {
     parser.push('HDEL');
     parser.pushKey(key);

--- a/packages/client/lib/commands/HELLO.ts
+++ b/packages/client/lib/commands/HELLO.ts
@@ -21,6 +21,12 @@ export type HelloReply = TuplesToMapReply<[
 ]>;
 
 export default {
+  /**
+   * Handshakes with the Redis server and switches to the specified protocol version
+   * @param parser - The Redis command parser
+   * @param protover - Protocol version to use
+   * @param options - Additional options for authentication and connection naming
+   */
   parseCommand(parser: CommandParser, protover?: RespVersions, options?: HelloOptions) {
     parser.push('HELLO');
 

--- a/packages/client/lib/commands/HEXISTS.ts
+++ b/packages/client/lib/commands/HEXISTS.ts
@@ -4,6 +4,12 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Determines whether a field exists in a hash
+   * @param parser - The Redis command parser
+   * @param key - Key of the hash
+   * @param field - Field to check
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, field: RedisArgument) {
     parser.push('HEXISTS');
     parser.pushKey(key);

--- a/packages/client/lib/commands/HEXPIRE.ts
+++ b/packages/client/lib/commands/HEXPIRE.ts
@@ -16,6 +16,14 @@ export const HASH_EXPIRATION = {
 export type HashExpiration = typeof HASH_EXPIRATION[keyof typeof HASH_EXPIRATION];
 
 export default {
+  /**
+   * Sets a timeout on hash fields. After the timeout has expired, the fields will be automatically deleted
+   * @param parser - The Redis command parser
+   * @param key - Key of the hash
+   * @param fields - Fields to set expiration on
+   * @param seconds - Number of seconds until field expiration
+   * @param mode - Expiration mode: NX (only if field has no expiry), XX (only if field has existing expiry), GT (only if new expiry is greater than current), LT (only if new expiry is less than current)
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/HEXPIREAT.ts
+++ b/packages/client/lib/commands/HEXPIREAT.ts
@@ -3,6 +3,14 @@ import { RedisVariadicArgument, transformEXAT } from './generic-transformers';
 import { ArrayReply, Command, NumberReply, RedisArgument } from '../RESP/types';
 
 export default {
+  /**
+   * Sets the expiration for hash fields at a specific Unix timestamp
+   * @param parser - The Redis command parser
+   * @param key - Key of the hash
+   * @param fields - Fields to set expiration on
+   * @param timestamp - Unix timestamp (seconds since January 1, 1970) or Date object
+   * @param mode - Expiration mode: NX (only if field has no expiry), XX (only if field has existing expiry), GT (only if new expiry is greater than current), LT (only if new expiry is less than current)
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/HEXPIRETIME.ts
+++ b/packages/client/lib/commands/HEXPIRETIME.ts
@@ -11,6 +11,12 @@ export const HASH_EXPIRATION_TIME = {
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the absolute Unix timestamp (since January 1, 1970) at which the given hash fields will expire
+   * @param parser - The Redis command parser
+   * @param key - Key of the hash
+   * @param fields - Fields to check expiration time
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/HGET.ts
+++ b/packages/client/lib/commands/HGET.ts
@@ -4,6 +4,12 @@ import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/type
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Gets the value of a field in a hash
+   * @param parser - The Redis command parser
+   * @param key - Key of the hash
+   * @param field - Field to get the value of
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, field: RedisArgument) {
     parser.push('HGET');
     parser.pushKey(key);

--- a/packages/client/lib/commands/HGETALL.ts
+++ b/packages/client/lib/commands/HGETALL.ts
@@ -5,6 +5,11 @@ import { transformTuplesReply } from './generic-transformers';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Gets all fields and values in a hash
+   * @param parser - The Redis command parser
+   * @param key - Key of the hash
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('HGETALL');
     parser.pushKey(key);

--- a/packages/client/lib/commands/HGETDEL.ts
+++ b/packages/client/lib/commands/HGETDEL.ts
@@ -3,6 +3,12 @@ import { RedisVariadicArgument } from './generic-transformers';
 import { RedisArgument, ArrayReply, BlobStringReply, NullReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Gets and deletes the specified fields from a hash
+   * @param parser - The Redis command parser
+   * @param key - Key of the hash
+   * @param fields - Fields to get and delete
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, fields: RedisVariadicArgument) {
     parser.push('HGETDEL');
     parser.pushKey(key);

--- a/packages/client/lib/commands/HGETEX.ts
+++ b/packages/client/lib/commands/HGETEX.ts
@@ -12,6 +12,13 @@ export interface HGetExOptions {
 }
 
 export default {
+  /**
+   * Gets the values of the specified fields in a hash and optionally sets their expiration
+   * @param parser - The Redis command parser
+   * @param key - Key of the hash
+   * @param fields - Fields to get values from
+   * @param options - Options for setting expiration
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/HINCRBY.ts
+++ b/packages/client/lib/commands/HINCRBY.ts
@@ -2,6 +2,13 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Increments the integer value of a field in a hash by the given number
+   * @param parser - The Redis command parser
+   * @param key - Key of the hash
+   * @param field - Field to increment
+   * @param increment - Increment amount
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/HINCRBYFLOAT.ts
+++ b/packages/client/lib/commands/HINCRBYFLOAT.ts
@@ -2,6 +2,13 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, BlobStringReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Increments the float value of a field in a hash by the given amount
+   * @param parser - The Redis command parser
+   * @param key - Key of the hash
+   * @param field - Field to increment
+   * @param increment - Increment amount (float)
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/HKEYS.ts
+++ b/packages/client/lib/commands/HKEYS.ts
@@ -4,6 +4,11 @@ import { RedisArgument, ArrayReply, BlobStringReply, Command } from '../RESP/typ
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Gets all field names in a hash
+   * @param parser - The Redis command parser
+   * @param key - Key of the hash
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('HKEYS')
     parser.pushKey(key);

--- a/packages/client/lib/commands/HLEN.ts
+++ b/packages/client/lib/commands/HLEN.ts
@@ -4,6 +4,11 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Gets the number of fields in a hash.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the hash.
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('HLEN');
     parser.pushKey(key);

--- a/packages/client/lib/commands/HMGET.ts
+++ b/packages/client/lib/commands/HMGET.ts
@@ -5,6 +5,12 @@ import { RedisVariadicArgument } from './generic-transformers';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Gets the values of all the specified fields in a hash.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the hash.
+   * @param fields - Fields to get from the hash.
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, fields: RedisVariadicArgument) {
     parser.push('HMGET');
     parser.pushKey(key);

--- a/packages/client/lib/commands/HPERSIST.ts
+++ b/packages/client/lib/commands/HPERSIST.ts
@@ -3,6 +3,12 @@ import { ArrayReply, Command, NullReply, NumberReply, RedisArgument } from '../R
 import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
+  /**
+   * Removes the expiration from the specified fields in a hash.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the hash.
+   * @param fields - Fields to remove expiration from.
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/HPEXPIRE.ts
+++ b/packages/client/lib/commands/HPEXPIRE.ts
@@ -4,6 +4,15 @@ import { RedisVariadicArgument } from './generic-transformers';
 import { HashExpiration } from './HEXPIRE';
 
 export default {
+  /**
+   * Parses the arguments for the `HPEXPIRE` command.
+   *
+   * @param parser - The command parser instance.
+   * @param key - The key of the hash.
+   * @param fields - The fields to set the expiration for.
+   * @param ms - The expiration time in milliseconds.
+   * @param mode - Optional mode for the command ('NX', 'XX', 'GT', 'LT').
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument, 

--- a/packages/client/lib/commands/HPEXPIREAT.ts
+++ b/packages/client/lib/commands/HPEXPIREAT.ts
@@ -5,6 +5,15 @@ import { HashExpiration } from './HEXPIRE';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Parses the arguments for the `HPEXPIREAT` command.
+   *
+   * @param parser - The command parser instance.
+   * @param key - The key of the hash.
+   * @param fields - The fields to set the expiration for.
+   * @param timestamp - The expiration timestamp (Unix timestamp or Date object).
+   * @param mode - Optional mode for the command ('NX', 'XX', 'GT', 'LT').
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/HPEXPIRETIME.ts
+++ b/packages/client/lib/commands/HPEXPIRETIME.ts
@@ -4,6 +4,14 @@ import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the HPEXPIRETIME command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to retrieve expiration time for
+   * @param fields - The fields to retrieve expiration time for
+   * @see https://redis.io/commands/hpexpiretime/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/HPTTL.ts
+++ b/packages/client/lib/commands/HPTTL.ts
@@ -4,6 +4,14 @@ import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the HPTTL command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to check time-to-live for
+   * @param fields - The fields to check time-to-live for
+   * @see https://redis.io/commands/hpttl/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/HRANDFIELD.ts
+++ b/packages/client/lib/commands/HRANDFIELD.ts
@@ -3,6 +3,13 @@ import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/type
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the HRANDFIELD command
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the hash to get a random field from
+   * @see https://redis.io/commands/hrandfield/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('HRANDFIELD');
     parser.pushKey(key);

--- a/packages/client/lib/commands/HRANDFIELD_COUNT.ts
+++ b/packages/client/lib/commands/HRANDFIELD_COUNT.ts
@@ -3,6 +3,14 @@ import { RedisArgument, ArrayReply, BlobStringReply, Command } from '../RESP/typ
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the HRANDFIELD command with count parameter
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the hash to get random fields from
+   * @param count - The number of fields to return (positive: unique fields, negative: may repeat fields)
+   * @see https://redis.io/commands/hrandfield/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, count: number) {
     parser.push('HRANDFIELD');
     parser.pushKey(key);

--- a/packages/client/lib/commands/HRANDFIELD_COUNT_WITHVALUES.ts
+++ b/packages/client/lib/commands/HRANDFIELD_COUNT_WITHVALUES.ts
@@ -8,6 +8,14 @@ export type HRandFieldCountWithValuesReply = Array<{
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the HRANDFIELD command with count parameter and WITHVALUES option
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the hash to get random fields from
+   * @param count - The number of fields to return (positive: unique fields, negative: may repeat fields)
+   * @see https://redis.io/commands/hrandfield/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, count: number) {
     parser.push('HRANDFIELD');
     parser.pushKey(key);

--- a/packages/client/lib/commands/HSCAN.ts
+++ b/packages/client/lib/commands/HSCAN.ts
@@ -9,6 +9,15 @@ export interface HScanEntry {
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the HSCAN command
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the hash to scan
+   * @param cursor - The cursor position to start scanning from
+   * @param options - Options for the scan (COUNT, MATCH, TYPE)
+   * @see https://redis.io/commands/hscan/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/HSCAN_NOVALUES.ts
+++ b/packages/client/lib/commands/HSCAN_NOVALUES.ts
@@ -3,6 +3,12 @@ import HSCAN from './HSCAN';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the HSCAN command with NOVALUES option
+   * 
+   * @param args - The same parameters as HSCAN command
+   * @see https://redis.io/commands/hscan/
+   */
   parseCommand(...args: Parameters<typeof HSCAN.parseCommand>) {
     const parser = args[0];
 

--- a/packages/client/lib/commands/HSET.ts
+++ b/packages/client/lib/commands/HSET.ts
@@ -18,6 +18,15 @@ type MultipleFieldsArguments = [...generic: GenericArguments, value: HSETObject 
 export type HSETArguments = SingleFieldArguments | MultipleFieldsArguments;
 
 export default {
+  /**
+   * Constructs the HSET command
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the hash
+   * @param value - Either the field name (when using single field) or an object/map/array of field-value pairs
+   * @param fieldValue - The value to set (only used with single field variant)
+   * @see https://redis.io/commands/hset/
+   */
   parseCommand(parser: CommandParser, ...[key, value, fieldValue]: SingleFieldArguments | MultipleFieldsArguments) {
     parser.push('HSET');
     parser.pushKey(key);

--- a/packages/client/lib/commands/HSETEX.ts
+++ b/packages/client/lib/commands/HSETEX.ts
@@ -20,6 +20,15 @@ type HSETEXMap = Map<HashTypes, HashTypes>;
 type HSETEXTuples = Array<[HashTypes, HashTypes]> | Array<HashTypes>;
 
 export default {
+  /**
+   * Constructs the HSETEX command
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the hash
+   * @param fields - Object, Map, or Array of field-value pairs to set
+   * @param options - Optional configuration for expiration and mode settings
+   * @see https://redis.io/commands/hsetex/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/HSETNX.ts
+++ b/packages/client/lib/commands/HSETNX.ts
@@ -3,6 +3,15 @@ import { RedisArgument, Command, NumberReply } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the HSETNX command
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the hash
+   * @param field - The field to set if it does not exist
+   * @param value - The value to set
+   * @see https://redis.io/commands/hsetnx/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/HSTRLEN.ts
+++ b/packages/client/lib/commands/HSTRLEN.ts
@@ -4,6 +4,14 @@ import { RedisArgument, ArrayReply, BlobStringReply, Command } from '../RESP/typ
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the HSTRLEN command
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the hash
+   * @param field - The field to get the string length of
+   * @see https://redis.io/commands/hstrlen/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, field: RedisArgument) {
     parser.push('HSTRLEN');
     parser.pushKey(key);

--- a/packages/client/lib/commands/HTTL.ts
+++ b/packages/client/lib/commands/HTTL.ts
@@ -4,6 +4,12 @@ import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the remaining time to live of field(s) in a hash.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the hash.
+   * @param fields - Fields to check time to live.
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/HVALS.ts
+++ b/packages/client/lib/commands/HVALS.ts
@@ -4,6 +4,11 @@ import { RedisArgument, ArrayReply, BlobStringReply, Command } from '../RESP/typ
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Gets all values in a hash.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the hash.
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('HVALS');
     parser.pushKey(key);

--- a/packages/client/lib/commands/INCR.ts
+++ b/packages/client/lib/commands/INCR.ts
@@ -2,6 +2,13 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Constructs the INCR command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to increment
+   * @see https://redis.io/commands/incr/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('INCR');
     parser.pushKey(key);

--- a/packages/client/lib/commands/INCRBY.ts
+++ b/packages/client/lib/commands/INCRBY.ts
@@ -2,6 +2,14 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Constructs the INCRBY command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to increment
+   * @param increment - The amount to increment by
+   * @see https://redis.io/commands/incrby/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, increment: number) {
     parser.push('INCRBY');
     parser.pushKey(key);

--- a/packages/client/lib/commands/INCRBYFLOAT.ts
+++ b/packages/client/lib/commands/INCRBYFLOAT.ts
@@ -2,6 +2,14 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, BlobStringReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Constructs the INCRBYFLOAT command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to increment
+   * @param increment - The floating-point value to increment by
+   * @see https://redis.io/commands/incrbyfloat/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, increment: number) {
     parser.push('INCRBYFLOAT');
     parser.pushKey(key);

--- a/packages/client/lib/commands/INFO.ts
+++ b/packages/client/lib/commands/INFO.ts
@@ -4,6 +4,13 @@ import { RedisArgument, VerbatimStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the INFO command
+   * 
+   * @param parser - The command parser
+   * @param section - Optional specific section of information to retrieve
+   * @see https://redis.io/commands/info/
+   */
   parseCommand(parser: CommandParser, section?: RedisArgument) {
     parser.push('INFO');
 

--- a/packages/client/lib/commands/KEYS.ts
+++ b/packages/client/lib/commands/KEYS.ts
@@ -4,6 +4,13 @@ import { RedisArgument, ArrayReply, BlobStringReply, Command } from '../RESP/typ
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the KEYS command
+   * 
+   * @param parser - The command parser
+   * @param pattern - The pattern to match keys against
+   * @see https://redis.io/commands/keys/
+   */
   parseCommand(parser: CommandParser, pattern: RedisArgument) {
     parser.push('KEYS', pattern);
   },

--- a/packages/client/lib/commands/LASTSAVE.ts
+++ b/packages/client/lib/commands/LASTSAVE.ts
@@ -4,6 +4,12 @@ import { NumberReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the LASTSAVE command
+   * 
+   * @param parser - The command parser
+   * @see https://redis.io/commands/lastsave/
+   */
   parseCommand(parser: CommandParser) {
     parser.push('LASTSAVE');
   },

--- a/packages/client/lib/commands/LATENCY_DOCTOR.ts
+++ b/packages/client/lib/commands/LATENCY_DOCTOR.ts
@@ -4,6 +4,12 @@ import { BlobStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the LATENCY DOCTOR command
+   * 
+   * @param parser - The command parser
+   * @see https://redis.io/commands/latency-doctor/
+   */
   parseCommand(parser: CommandParser) {
     parser.push('LATENCY', 'DOCTOR');
   },

--- a/packages/client/lib/commands/LATENCY_GRAPH.ts
+++ b/packages/client/lib/commands/LATENCY_GRAPH.ts
@@ -25,6 +25,13 @@ export type LatencyEvent = typeof LATENCY_EVENTS[keyof typeof LATENCY_EVENTS];
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the LATENCY GRAPH command
+   * 
+   * @param parser - The command parser
+   * @param event - The latency event to get the graph for
+   * @see https://redis.io/commands/latency-graph/
+   */
   parseCommand(parser: CommandParser, event: LatencyEvent) {
     parser.push('LATENCY', 'GRAPH', event);
   },

--- a/packages/client/lib/commands/LATENCY_HISTORY.ts
+++ b/packages/client/lib/commands/LATENCY_HISTORY.ts
@@ -23,6 +23,13 @@ export type LatencyEventType = (
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the LATENCY HISTORY command
+   * 
+   * @param parser - The command parser
+   * @param event - The latency event to get the history for
+   * @see https://redis.io/commands/latency-history/
+   */
   parseCommand(parser: CommandParser, event: LatencyEventType) {
     parser.push('LATENCY', 'HISTORY', event);
   },

--- a/packages/client/lib/commands/LATENCY_LATEST.ts
+++ b/packages/client/lib/commands/LATENCY_LATEST.ts
@@ -4,6 +4,12 @@ import { ArrayReply, BlobStringReply, NumberReply, Command } from '../RESP/types
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the LATENCY LATEST command
+   * 
+   * @param parser - The command parser
+   * @see https://redis.io/commands/latency-latest/
+   */
   parseCommand(parser: CommandParser) {
     parser.push('LATENCY', 'LATEST');
   },

--- a/packages/client/lib/commands/LCS.ts
+++ b/packages/client/lib/commands/LCS.ts
@@ -3,6 +3,14 @@ import { RedisArgument, BlobStringReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the LCS command (Longest Common Substring)
+   * 
+   * @param parser - The command parser
+   * @param key1 - First key containing the first string
+   * @param key2 - Second key containing the second string
+   * @see https://redis.io/commands/lcs/
+   */
   parseCommand(
     parser: CommandParser,
     key1: RedisArgument,

--- a/packages/client/lib/commands/LCS_IDX.ts
+++ b/packages/client/lib/commands/LCS_IDX.ts
@@ -25,6 +25,15 @@ export type LcsIdxReply = TuplesToMapReply<[
 
 export default {
   IS_READ_ONLY: LCS.IS_READ_ONLY,
+  /**
+   * Constructs the LCS command with IDX option
+   * 
+   * @param parser - The command parser
+   * @param key1 - First key containing the first string
+   * @param key2 - Second key containing the second string
+   * @param options - Additional options for the LCS IDX command
+   * @see https://redis.io/commands/lcs/
+   */
   parseCommand(
     parser: CommandParser,
     key1: RedisArgument,

--- a/packages/client/lib/commands/LCS_IDX_WITHMATCHLEN.ts
+++ b/packages/client/lib/commands/LCS_IDX_WITHMATCHLEN.ts
@@ -16,6 +16,12 @@ export type LcsIdxWithMatchLenReply = TuplesToMapReply<[
 
 export default {
   IS_READ_ONLY: LCS_IDX.IS_READ_ONLY,
+  /**
+   * Constructs the LCS command with IDX and WITHMATCHLEN options
+   * 
+   * @param args - The same parameters as LCS_IDX command
+   * @see https://redis.io/commands/lcs/
+   */
   parseCommand(...args: Parameters<typeof LCS_IDX.parseCommand>) {
     const parser = args[0];
     LCS_IDX.parseCommand(...args);

--- a/packages/client/lib/commands/LCS_LEN.ts
+++ b/packages/client/lib/commands/LCS_LEN.ts
@@ -3,6 +3,12 @@ import LCS from './LCS';
 
 export default {
   IS_READ_ONLY: LCS.IS_READ_ONLY,
+  /**
+   * Constructs the LCS command with LEN option
+   * 
+   * @param args - The same parameters as LCS command
+   * @see https://redis.io/commands/lcs/
+   */
   parseCommand(...args: Parameters<typeof LCS.parseCommand>) {
     const parser = args[0];
 

--- a/packages/client/lib/commands/LINDEX.ts
+++ b/packages/client/lib/commands/LINDEX.ts
@@ -4,6 +4,14 @@ import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/type
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the LINDEX command
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the list
+   * @param index - The index of the element to retrieve
+   * @see https://redis.io/commands/lindex/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, index: number) {
     parser.push('LINDEX');
     parser.pushKey(key);

--- a/packages/client/lib/commands/LINSERT.ts
+++ b/packages/client/lib/commands/LINSERT.ts
@@ -5,6 +5,16 @@ type LInsertPosition = 'BEFORE' | 'AFTER';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the LINSERT command
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the list
+   * @param position - The position where to insert (BEFORE or AFTER)
+   * @param pivot - The element to find in the list
+   * @param element - The element to insert
+   * @see https://redis.io/commands/linsert/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/LLEN.ts
+++ b/packages/client/lib/commands/LLEN.ts
@@ -4,6 +4,13 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the LLEN command
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the list to get the length of
+   * @see https://redis.io/commands/llen/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('LLEN');
     parser.pushKey(key);

--- a/packages/client/lib/commands/LMOVE.ts
+++ b/packages/client/lib/commands/LMOVE.ts
@@ -4,6 +4,16 @@ import { ListSide } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the LMOVE command
+   * 
+   * @param parser - The command parser
+   * @param source - The source list key
+   * @param destination - The destination list key
+   * @param sourceSide - The side to pop from (LEFT or RIGHT)
+   * @param destinationSide - The side to push to (LEFT or RIGHT)
+   * @see https://redis.io/commands/lmove/
+   */
   parseCommand(
     parser: CommandParser,
     source: RedisArgument,

--- a/packages/client/lib/commands/LMPOP.ts
+++ b/packages/client/lib/commands/LMPOP.ts
@@ -24,6 +24,13 @@ export type LMPopArguments = Tail<Parameters<typeof parseLMPopArguments>>;
 
 export default {
   IS_READ_ONLY: false,  
+  /**
+   * Constructs the LMPOP command
+   * 
+   * @param parser - The command parser
+   * @param args - Arguments including keys, side (LEFT or RIGHT), and options
+   * @see https://redis.io/commands/lmpop/
+   */
   parseCommand(parser: CommandParser, ...args: LMPopArguments) {
     parser.push('LMPOP');
     parseLMPopArguments(parser, ...args);

--- a/packages/client/lib/commands/LOLWUT.ts
+++ b/packages/client/lib/commands/LOLWUT.ts
@@ -4,6 +4,14 @@ import { BlobStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the LOLWUT command
+   * 
+   * @param parser - The command parser
+   * @param version - Optional version parameter
+   * @param optionalArguments - Additional optional numeric arguments
+   * @see https://redis.io/commands/lolwut/
+   */
   parseCommand(parser: CommandParser, version?: number, ...optionalArguments: Array<number>) {
     parser.push('LOLWUT');
     if (version) {

--- a/packages/client/lib/commands/LPOP.ts
+++ b/packages/client/lib/commands/LPOP.ts
@@ -2,6 +2,13 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Constructs the LPOP command
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the list to pop from
+   * @see https://redis.io/commands/lpop/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('LPOP');
     parser.pushKey(key);

--- a/packages/client/lib/commands/LPOP_COUNT.ts
+++ b/packages/client/lib/commands/LPOP_COUNT.ts
@@ -4,6 +4,14 @@ import LPOP from './LPOP';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the LPOP command with count parameter
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the list to pop from
+   * @param count - The number of elements to pop
+   * @see https://redis.io/commands/lpop/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, count: number) {
     LPOP.parseCommand(parser, key);
     parser.push(count.toString())

--- a/packages/client/lib/commands/LPOS.ts
+++ b/packages/client/lib/commands/LPOS.ts
@@ -9,6 +9,15 @@ export interface LPosOptions {
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the LPOS command
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the list
+   * @param element - The element to search for
+   * @param options - Optional parameters for RANK and MAXLEN
+   * @see https://redis.io/commands/lpos/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/LPOS_COUNT.ts
+++ b/packages/client/lib/commands/LPOS_COUNT.ts
@@ -5,6 +5,16 @@ import LPOS, { LPosOptions } from './LPOS';
 export default {
   CACHEABLE: LPOS.CACHEABLE,
   IS_READ_ONLY: LPOS.IS_READ_ONLY,
+  /**
+   * Constructs the LPOS command with COUNT option
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the list
+   * @param element - The element to search for
+   * @param count - The number of positions to return
+   * @param options - Optional parameters for RANK and MAXLEN
+   * @see https://redis.io/commands/lpos/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/LPUSH.ts
+++ b/packages/client/lib/commands/LPUSH.ts
@@ -3,6 +3,14 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
+  /**
+   * Constructs the LPUSH command
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the list
+   * @param elements - One or more elements to push to the list
+   * @see https://redis.io/commands/lpush/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, elements: RedisVariadicArgument) {
     parser.push('LPUSH');
     parser.pushKey(key);

--- a/packages/client/lib/commands/LPUSHX.ts
+++ b/packages/client/lib/commands/LPUSHX.ts
@@ -3,6 +3,14 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
+  /**
+   * Constructs the LPUSHX command
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the list
+   * @param elements - One or more elements to push to the list if it exists
+   * @see https://redis.io/commands/lpushx/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, elements: RedisVariadicArgument) {
     parser.push('LPUSHX');
     parser.pushKey(key);

--- a/packages/client/lib/commands/LRANGE.ts
+++ b/packages/client/lib/commands/LRANGE.ts
@@ -4,6 +4,15 @@ import { RedisArgument, ArrayReply, BlobStringReply, Command } from '../RESP/typ
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the LRANGE command
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the list
+   * @param start - The starting index
+   * @param stop - The ending index
+   * @see https://redis.io/commands/lrange/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, start: number, stop: number) {
     parser.push('LRANGE');
     parser.pushKey(key);

--- a/packages/client/lib/commands/LREM.ts
+++ b/packages/client/lib/commands/LREM.ts
@@ -3,6 +3,15 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the LREM command
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the list
+   * @param count - The count of elements to remove (negative: from tail to head, 0: all occurrences, positive: from head to tail)
+   * @param element - The element to remove
+   * @see https://redis.io/commands/lrem/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, count: number, element: RedisArgument) {
     parser.push('LREM');
     parser.pushKey(key);

--- a/packages/client/lib/commands/LSET.ts
+++ b/packages/client/lib/commands/LSET.ts
@@ -3,6 +3,15 @@ import { RedisArgument, SimpleStringReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the LSET command
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the list
+   * @param index - The index of the element to replace
+   * @param element - The new value to set
+   * @see https://redis.io/commands/lset/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, index: number, element: RedisArgument) {
     parser.push('LSET');
     parser.pushKey(key);

--- a/packages/client/lib/commands/LTRIM.ts
+++ b/packages/client/lib/commands/LTRIM.ts
@@ -2,6 +2,15 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, SimpleStringReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Constructs the LTRIM command
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the list
+   * @param start - The starting index
+   * @param stop - The ending index
+   * @see https://redis.io/commands/ltrim/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, start: number, stop: number) {
     parser.push('LTRIM');
     parser.pushKey(key);

--- a/packages/client/lib/commands/MEMORY_DOCTOR.ts
+++ b/packages/client/lib/commands/MEMORY_DOCTOR.ts
@@ -4,6 +4,12 @@ import { BlobStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the MEMORY DOCTOR command
+   * 
+   * @param parser - The command parser
+   * @see https://redis.io/commands/memory-doctor/
+   */
   parseCommand(parser: CommandParser) {
     parser.push('MEMORY', 'DOCTOR');
   },

--- a/packages/client/lib/commands/MEMORY_MALLOC-STATS.ts
+++ b/packages/client/lib/commands/MEMORY_MALLOC-STATS.ts
@@ -4,6 +4,12 @@ import { BlobStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the MEMORY MALLOC-STATS command
+   * 
+   * @param parser - The command parser
+   * @see https://redis.io/commands/memory-malloc-stats/
+   */
   parseCommand(parser: CommandParser) {
     parser.push('MEMORY', 'MALLOC-STATS');
   },

--- a/packages/client/lib/commands/MEMORY_PURGE.ts
+++ b/packages/client/lib/commands/MEMORY_PURGE.ts
@@ -4,6 +4,12 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: false,
+  /**
+   * Constructs the MEMORY PURGE command
+   * 
+   * @param parser - The command parser
+   * @see https://redis.io/commands/memory-purge/
+   */
   parseCommand(parser: CommandParser) {
     parser.push('MEMORY', 'PURGE');
   },

--- a/packages/client/lib/commands/MEMORY_STATS.ts
+++ b/packages/client/lib/commands/MEMORY_STATS.ts
@@ -38,6 +38,12 @@ export type MemoryStatsReply = TuplesToMapReply<[
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the MEMORY STATS command
+   * 
+   * @param parser - The command parser
+   * @see https://redis.io/commands/memory-stats/
+   */
   parseCommand(parser: CommandParser) {
     parser.push('MEMORY', 'STATS');
   },

--- a/packages/client/lib/commands/MEMORY_USAGE.ts
+++ b/packages/client/lib/commands/MEMORY_USAGE.ts
@@ -7,6 +7,14 @@ export interface MemoryUsageOptions {
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the MEMORY USAGE command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to get memory usage for
+   * @param options - Optional parameters including SAMPLES
+   * @see https://redis.io/commands/memory-usage/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, options?: MemoryUsageOptions) {
     parser.push('MEMORY', 'USAGE');
     parser.pushKey(key);

--- a/packages/client/lib/commands/MGET.ts
+++ b/packages/client/lib/commands/MGET.ts
@@ -4,6 +4,13 @@ import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/type
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the MGET command
+   * 
+   * @param parser - The command parser
+   * @param keys - Array of keys to get
+   * @see https://redis.io/commands/mget/
+   */
   parseCommand(parser: CommandParser, keys: Array<RedisArgument>) {
     parser.push('MGET');
     parser.pushKeys(keys);

--- a/packages/client/lib/commands/MIGRATE.ts
+++ b/packages/client/lib/commands/MIGRATE.ts
@@ -10,6 +10,18 @@ export interface MigrateOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the MIGRATE command
+   * 
+   * @param parser - The command parser
+   * @param host - Target Redis instance host
+   * @param port - Target Redis instance port
+   * @param key - Key or keys to migrate
+   * @param destinationDb - Target database index
+   * @param timeout - Timeout in milliseconds
+   * @param options - Optional parameters including COPY, REPLACE, and AUTH
+   * @see https://redis.io/commands/migrate/
+   */
   parseCommand(
     parser: CommandParser,
     host: RedisArgument,

--- a/packages/client/lib/commands/MODULE_LIST.ts
+++ b/packages/client/lib/commands/MODULE_LIST.ts
@@ -9,6 +9,12 @@ export type ModuleListReply = ArrayReply<TuplesToMapReply<[
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the MODULE LIST command
+   * 
+   * @param parser - The command parser
+   * @see https://redis.io/commands/module-list/
+   */
   parseCommand(parser: CommandParser) {
     parser.push('MODULE', 'LIST');
   },

--- a/packages/client/lib/commands/MODULE_LOAD.ts
+++ b/packages/client/lib/commands/MODULE_LOAD.ts
@@ -4,6 +4,14 @@ import { RedisArgument, SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the MODULE LOAD command
+   * 
+   * @param parser - The command parser
+   * @param path - Path to the module file
+   * @param moduleArguments - Optional arguments to pass to the module
+   * @see https://redis.io/commands/module-load/
+   */
   parseCommand(parser: CommandParser, path: RedisArgument, moduleArguments?: Array<RedisArgument>) {
     parser.push('MODULE', 'LOAD', path);
 

--- a/packages/client/lib/commands/MODULE_UNLOAD.ts
+++ b/packages/client/lib/commands/MODULE_UNLOAD.ts
@@ -4,6 +4,13 @@ import { RedisArgument, SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the MODULE UNLOAD command
+   * 
+   * @param parser - The command parser
+   * @param name - The name of the module to unload
+   * @see https://redis.io/commands/module-unload/
+   */
   parseCommand(parser: CommandParser, name: RedisArgument) {
     parser.push('MODULE', 'UNLOAD', name);
   },

--- a/packages/client/lib/commands/MOVE.ts
+++ b/packages/client/lib/commands/MOVE.ts
@@ -2,6 +2,14 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Constructs the MOVE command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to move
+   * @param db - The destination database index
+   * @see https://redis.io/commands/move/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, db: number) {
     parser.push('MOVE');
     parser.pushKey(key);

--- a/packages/client/lib/commands/MSET.ts
+++ b/packages/client/lib/commands/MSET.ts
@@ -33,6 +33,13 @@ export function parseMSetArguments(parser: CommandParser, toSet: MSetArguments) 
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the MSET command
+   * 
+   * @param parser - The command parser
+   * @param toSet - Key-value pairs to set (array of tuples, flat array, or object)
+   * @see https://redis.io/commands/mset/
+   */
   parseCommand(parser: CommandParser, toSet: MSetArguments) {
     parser.push('MSET');
     return parseMSetArguments(parser, toSet);

--- a/packages/client/lib/commands/MSETNX.ts
+++ b/packages/client/lib/commands/MSETNX.ts
@@ -4,6 +4,13 @@ import { MSetArguments, parseMSetArguments } from './MSET';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the MSETNX command
+   * 
+   * @param parser - The command parser
+   * @param toSet - Key-value pairs to set if none of the keys exist (array of tuples, flat array, or object)
+   * @see https://redis.io/commands/msetnx/
+   */
   parseCommand(parser: CommandParser, toSet: MSetArguments) {
     parser.push('MSETNX');
     return parseMSetArguments(parser, toSet);

--- a/packages/client/lib/commands/OBJECT_ENCODING.ts
+++ b/packages/client/lib/commands/OBJECT_ENCODING.ts
@@ -3,6 +3,13 @@ import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/type
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the OBJECT ENCODING command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to get the internal encoding for
+   * @see https://redis.io/commands/object-encoding/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('OBJECT', 'ENCODING');
     parser.pushKey(key);

--- a/packages/client/lib/commands/OBJECT_FREQ.ts
+++ b/packages/client/lib/commands/OBJECT_FREQ.ts
@@ -3,6 +3,13 @@ import { RedisArgument, NumberReply, NullReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the OBJECT FREQ command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to get the access frequency for
+   * @see https://redis.io/commands/object-freq/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('OBJECT', 'FREQ');
     parser.pushKey(key);

--- a/packages/client/lib/commands/OBJECT_IDLETIME.ts
+++ b/packages/client/lib/commands/OBJECT_IDLETIME.ts
@@ -3,6 +3,13 @@ import { RedisArgument, NumberReply, NullReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the OBJECT IDLETIME command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to get the idle time for
+   * @see https://redis.io/commands/object-idletime/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('OBJECT', 'IDLETIME');
     parser.pushKey(key);

--- a/packages/client/lib/commands/OBJECT_REFCOUNT.ts
+++ b/packages/client/lib/commands/OBJECT_REFCOUNT.ts
@@ -3,6 +3,13 @@ import { RedisArgument, NumberReply, NullReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the OBJECT REFCOUNT command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to get the reference count for
+   * @see https://redis.io/commands/object-refcount/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('OBJECT', 'REFCOUNT');
     parser.pushKey(key);

--- a/packages/client/lib/commands/PERSIST.ts
+++ b/packages/client/lib/commands/PERSIST.ts
@@ -2,6 +2,13 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Constructs the PERSIST command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to remove the expiration from
+   * @see https://redis.io/commands/persist/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('PERSIST');
     parser.pushKey(key);

--- a/packages/client/lib/commands/PEXPIRE.ts
+++ b/packages/client/lib/commands/PEXPIRE.ts
@@ -3,6 +3,15 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the PEXPIRE command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to set the expiration for
+   * @param ms - The expiration time in milliseconds
+   * @param mode - Optional mode for the command ('NX', 'XX', 'GT', 'LT')
+   * @see https://redis.io/commands/pexpire/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/PEXPIREAT.ts
+++ b/packages/client/lib/commands/PEXPIREAT.ts
@@ -4,6 +4,15 @@ import { transformPXAT } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the PEXPIREAT command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to set the expiration for
+   * @param msTimestamp - The expiration timestamp in milliseconds (Unix timestamp or Date object)
+   * @param mode - Optional mode for the command ('NX', 'XX', 'GT', 'LT')
+   * @see https://redis.io/commands/pexpireat/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/PEXPIRETIME.ts
+++ b/packages/client/lib/commands/PEXPIRETIME.ts
@@ -3,6 +3,13 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the PEXPIRETIME command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to get the expiration time for in milliseconds
+   * @see https://redis.io/commands/pexpiretime/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('PEXPIRETIME');
     parser.pushKey(key);

--- a/packages/client/lib/commands/PFADD.ts
+++ b/packages/client/lib/commands/PFADD.ts
@@ -4,6 +4,14 @@ import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the PFADD command
+   * 
+   * @param parser - The command parser
+   * @param key - The key of the HyperLogLog
+   * @param element - Optional elements to add
+   * @see https://redis.io/commands/pfadd/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, element?: RedisVariadicArgument) {
     parser.push('PFADD')
     parser.pushKey(key);

--- a/packages/client/lib/commands/PFCOUNT.ts
+++ b/packages/client/lib/commands/PFCOUNT.ts
@@ -4,6 +4,13 @@ import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the PFCOUNT command
+   * 
+   * @param parser - The command parser
+   * @param keys - One or more keys of HyperLogLog structures to count
+   * @see https://redis.io/commands/pfcount/
+   */
   parseCommand(parser: CommandParser, keys: RedisVariadicArgument) {
     parser.push('PFCOUNT');
     parser.pushKeys(keys);

--- a/packages/client/lib/commands/PFMERGE.ts
+++ b/packages/client/lib/commands/PFMERGE.ts
@@ -3,6 +3,14 @@ import { RedisArgument, SimpleStringReply, Command } from '../RESP/types';
 import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
+  /**
+   * Constructs the PFMERGE command
+   * 
+   * @param parser - The command parser
+   * @param destination - The destination key to merge to
+   * @param sources - One or more source keys to merge from
+   * @see https://redis.io/commands/pfmerge/
+   */
   parseCommand(
     parser: CommandParser,
     destination: RedisArgument,

--- a/packages/client/lib/commands/PING.ts
+++ b/packages/client/lib/commands/PING.ts
@@ -4,6 +4,13 @@ import { RedisArgument, SimpleStringReply, BlobStringReply, Command } from '../R
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the PING command
+   * 
+   * @param parser - The command parser
+   * @param message - Optional message to be returned instead of PONG
+   * @see https://redis.io/commands/ping/
+   */
   parseCommand(parser: CommandParser, message?: RedisArgument) {
     parser.push('PING');
     if (message) {

--- a/packages/client/lib/commands/PSETEX.ts
+++ b/packages/client/lib/commands/PSETEX.ts
@@ -2,6 +2,15 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, SimpleStringReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Constructs the PSETEX command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to set
+   * @param ms - The expiration time in milliseconds
+   * @param value - The value to set
+   * @see https://redis.io/commands/psetex/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, ms: number, value: RedisArgument) {
     parser.push('PSETEX');
     parser.pushKey(key);

--- a/packages/client/lib/commands/PTTL.ts
+++ b/packages/client/lib/commands/PTTL.ts
@@ -3,6 +3,13 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the PTTL command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to get the time to live in milliseconds
+   * @see https://redis.io/commands/pttl/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('PTTL');
     parser.pushKey(key);

--- a/packages/client/lib/commands/PUBLISH.ts
+++ b/packages/client/lib/commands/PUBLISH.ts
@@ -5,6 +5,14 @@ export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
   IS_FORWARD_COMMAND: true,
+  /**
+   * Constructs the PUBLISH command
+   * 
+   * @param parser - The command parser
+   * @param channel - The channel to publish to
+   * @param message - The message to publish
+   * @see https://redis.io/commands/publish/
+   */
   parseCommand(parser: CommandParser, channel: RedisArgument, message: RedisArgument) {
     parser.push('PUBLISH', channel, message);
   },

--- a/packages/client/lib/commands/PUBSUB_CHANNELS.ts
+++ b/packages/client/lib/commands/PUBSUB_CHANNELS.ts
@@ -4,6 +4,13 @@ import { RedisArgument, ArrayReply, BlobStringReply, Command } from '../RESP/typ
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the PUBSUB CHANNELS command
+   * 
+   * @param parser - The command parser
+   * @param pattern - Optional pattern to filter channels
+   * @see https://redis.io/commands/pubsub-channels/
+   */
   parseCommand(parser: CommandParser, pattern?: RedisArgument) {
     parser.push('PUBSUB', 'CHANNELS');
 

--- a/packages/client/lib/commands/PUBSUB_NUMPAT.ts
+++ b/packages/client/lib/commands/PUBSUB_NUMPAT.ts
@@ -4,6 +4,12 @@ import { NumberReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the PUBSUB NUMPAT command
+   * 
+   * @param parser - The command parser
+   * @see https://redis.io/commands/pubsub-numpat/
+   */
   parseCommand(parser: CommandParser) {
     parser.push('PUBSUB', 'NUMPAT');
   },

--- a/packages/client/lib/commands/PUBSUB_NUMSUB.ts
+++ b/packages/client/lib/commands/PUBSUB_NUMSUB.ts
@@ -5,6 +5,13 @@ import { RedisVariadicArgument } from './generic-transformers';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the PUBSUB NUMSUB command
+   * 
+   * @param parser - The command parser
+   * @param channels - Optional channel names to get subscription count for
+   * @see https://redis.io/commands/pubsub-numsub/
+   */
   parseCommand(parser: CommandParser, channels?: RedisVariadicArgument) {
     parser.push('PUBSUB', 'NUMSUB');
 
@@ -12,6 +19,12 @@ export default {
       parser.pushVariadic(channels);
     }
   },
+  /**
+   * Transforms the PUBSUB NUMSUB reply into a record of channel name to subscriber count
+   * 
+   * @param rawReply - The raw reply from Redis
+   * @returns Record mapping channel names to their subscriber counts
+   */
   transformReply(rawReply: UnwrapReply<ArrayReply<BlobStringReply | NumberReply>>) {
     const reply = Object.create(null);
     let i = 0;

--- a/packages/client/lib/commands/PUBSUB_SHARDCHANNELS.ts
+++ b/packages/client/lib/commands/PUBSUB_SHARDCHANNELS.ts
@@ -4,6 +4,13 @@ import { RedisArgument, ArrayReply, BlobStringReply, Command } from '../RESP/typ
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the PUBSUB SHARDCHANNELS command
+   * 
+   * @param parser - The command parser
+   * @param pattern - Optional pattern to filter shard channels
+   * @see https://redis.io/commands/pubsub-shardchannels/
+   */
   parseCommand(parser: CommandParser, pattern?: RedisArgument) {
     parser.push('PUBSUB', 'SHARDCHANNELS');
 

--- a/packages/client/lib/commands/PUBSUB_SHARDNUMSUB.ts
+++ b/packages/client/lib/commands/PUBSUB_SHARDNUMSUB.ts
@@ -4,6 +4,13 @@ import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the PUBSUB SHARDNUMSUB command
+   * 
+   * @param parser - The command parser
+   * @param channels - Optional shard channel names to get subscription count for
+   * @see https://redis.io/commands/pubsub-shardnumsub/
+   */
   parseCommand(parser: CommandParser, channels?: RedisVariadicArgument) {
     parser.push('PUBSUB', 'SHARDNUMSUB');
 
@@ -11,6 +18,12 @@ export default {
       parser.pushVariadic(channels);
     }
   },
+  /**
+   * Transforms the PUBSUB SHARDNUMSUB reply into a record of shard channel name to subscriber count
+   * 
+   * @param reply - The raw reply from Redis
+   * @returns Record mapping shard channel names to their subscriber counts
+   */
   transformReply(reply: UnwrapReply<ArrayReply<BlobStringReply | NumberReply>>) {
     const transformedReply: Record<string, NumberReply> = Object.create(null);
 

--- a/packages/client/lib/commands/RANDOMKEY.ts
+++ b/packages/client/lib/commands/RANDOMKEY.ts
@@ -4,6 +4,12 @@ import { NumberReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the RANDOMKEY command
+   * 
+   * @param parser - The command parser
+   * @see https://redis.io/commands/randomkey/
+   */
   parseCommand(parser: CommandParser) {
     parser.push('RANDOMKEY');
   },

--- a/packages/client/lib/commands/READONLY.ts
+++ b/packages/client/lib/commands/READONLY.ts
@@ -4,6 +4,12 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the READONLY command
+   * 
+   * @param parser - The command parser
+   * @see https://redis.io/commands/readonly/
+   */
   parseCommand(parser: CommandParser) {
     parser.push('READONLY');
   },

--- a/packages/client/lib/commands/READWRITE.ts
+++ b/packages/client/lib/commands/READWRITE.ts
@@ -4,6 +4,12 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the READWRITE command
+   * 
+   * @param parser - The command parser
+   * @see https://redis.io/commands/readwrite/
+   */
   parseCommand(parser: CommandParser) {
     parser.push('READWRITE');
   },

--- a/packages/client/lib/commands/RENAME.ts
+++ b/packages/client/lib/commands/RENAME.ts
@@ -3,6 +3,14 @@ import { RedisArgument, SimpleStringReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the RENAME command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to rename
+   * @param newKey - The new key name
+   * @see https://redis.io/commands/rename/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, newKey: RedisArgument) {
     parser.push('RENAME');
     parser.pushKeys([key, newKey]);

--- a/packages/client/lib/commands/RENAMENX.ts
+++ b/packages/client/lib/commands/RENAMENX.ts
@@ -3,6 +3,14 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the RENAMENX command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to rename
+   * @param newKey - The new key name, if it doesn't exist
+   * @see https://redis.io/commands/renamenx/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, newKey: RedisArgument) {
     parser.push('RENAMENX');
     parser.pushKeys([key, newKey]);

--- a/packages/client/lib/commands/REPLICAOF.ts
+++ b/packages/client/lib/commands/REPLICAOF.ts
@@ -4,6 +4,14 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the REPLICAOF command
+   * 
+   * @param parser - The command parser
+   * @param host - The host of the master to replicate from
+   * @param port - The port of the master to replicate from
+   * @see https://redis.io/commands/replicaof/
+   */
   parseCommand(parser: CommandParser, host: string, port: number) {
     parser.push('REPLICAOF', host, port.toString());
   },

--- a/packages/client/lib/commands/RESTORE-ASKING.ts
+++ b/packages/client/lib/commands/RESTORE-ASKING.ts
@@ -4,6 +4,12 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the RESTORE-ASKING command
+   * 
+   * @param parser - The command parser
+   * @see https://redis.io/commands/restore-asking/
+   */
   parseCommand(parser: CommandParser) {
     parser.push('RESTORE-ASKING');
   },

--- a/packages/client/lib/commands/RESTORE.ts
+++ b/packages/client/lib/commands/RESTORE.ts
@@ -1,6 +1,14 @@
 import { CommandParser } from '../client/parser';
 import { RedisArgument, SimpleStringReply, Command } from '../RESP/types';
 
+/**
+ * Options for the RESTORE command
+ * 
+ * @property REPLACE - Replace existing key
+ * @property ABSTTL - Use the TTL value as absolute timestamp
+ * @property IDLETIME - Set the idle time (seconds) for the key
+ * @property FREQ - Set the frequency counter for LFU policy
+ */
 export interface RestoreOptions {
   REPLACE?: boolean;
   ABSTTL?: boolean;
@@ -10,6 +18,16 @@ export interface RestoreOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the RESTORE command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to restore
+   * @param ttl - Time to live in milliseconds, 0 for no expiry
+   * @param serializedValue - The serialized value from DUMP command
+   * @param options - Options for the RESTORE command
+   * @see https://redis.io/commands/restore/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/ROLE.ts
+++ b/packages/client/lib/commands/ROLE.ts
@@ -1,12 +1,18 @@
 import { CommandParser } from '../client/parser';
 import { BlobStringReply, NumberReply, ArrayReply, TuplesReply, UnwrapReply, Command } from '../RESP/types';
 
+/**
+ * Role information returned for a Redis master
+ */
 type MasterRole = [
   role: BlobStringReply<'master'>,
   replicationOffest: NumberReply,
   replicas: ArrayReply<TuplesReply<[host: BlobStringReply, port: BlobStringReply, replicationOffest: BlobStringReply]>>
 ];
 
+/**
+ * Role information returned for a Redis slave
+ */
 type SlaveRole = [
   role: BlobStringReply<'slave'>,
   masterHost: BlobStringReply,
@@ -15,19 +21,37 @@ type SlaveRole = [
   dataReceived: NumberReply
 ];
 
+/**
+ * Role information returned for a Redis sentinel
+ */
 type SentinelRole = [
   role: BlobStringReply<'sentinel'>,
   masterNames: ArrayReply<BlobStringReply>
 ];
 
+/**
+ * Combined role type for Redis instance role information
+ */
 type Role = TuplesReply<MasterRole | SlaveRole | SentinelRole>;
 
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the ROLE command
+   * 
+   * @param parser - The command parser
+   * @see https://redis.io/commands/role/
+   */
   parseCommand(parser: CommandParser) {
     parser.push('ROLE');
   },
+  /**
+   * Transforms the ROLE reply into a structured object
+   * 
+   * @param reply - The raw reply from Redis
+   * @returns Structured object representing role information
+   */
   transformReply(reply: UnwrapReply<Role>) {
     switch (reply[0] as unknown as UnwrapReply<typeof reply[0]>) {
       case 'master': {

--- a/packages/client/lib/commands/RPOP.ts
+++ b/packages/client/lib/commands/RPOP.ts
@@ -2,6 +2,13 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Constructs the RPOP command
+   * 
+   * @param parser - The command parser
+   * @param key - The list key to pop from
+   * @see https://redis.io/commands/rpop/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('RPOP');
     parser.pushKey(key);

--- a/packages/client/lib/commands/RPOPLPUSH.ts
+++ b/packages/client/lib/commands/RPOPLPUSH.ts
@@ -2,6 +2,14 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Constructs the RPOPLPUSH command
+   * 
+   * @param parser - The command parser
+   * @param source - The source list key
+   * @param destination - The destination list key
+   * @see https://redis.io/commands/rpoplpush/
+   */
   parseCommand(parser: CommandParser, source: RedisArgument, destination: RedisArgument) {
     parser.push('RPOPLPUSH');
     parser.pushKeys([source, destination]);

--- a/packages/client/lib/commands/RPOP_COUNT.ts
+++ b/packages/client/lib/commands/RPOP_COUNT.ts
@@ -2,6 +2,14 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, ArrayReply, BlobStringReply, NullReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Constructs the RPOP command with count parameter
+   * 
+   * @param parser - The command parser
+   * @param key - The list key to pop from
+   * @param count - The number of elements to pop
+   * @see https://redis.io/commands/rpop/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, count: number) {
     parser.push('RPOP');
     parser.pushKey(key);

--- a/packages/client/lib/commands/RPUSH.ts
+++ b/packages/client/lib/commands/RPUSH.ts
@@ -3,6 +3,14 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
+  /**
+   * Constructs the RPUSH command
+   * 
+   * @param parser - The command parser
+   * @param key - The list key to push to
+   * @param element - One or more elements to push
+   * @see https://redis.io/commands/rpush/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, element: RedisVariadicArgument) {
     parser.push('RPUSH');
     parser.pushKey(key);

--- a/packages/client/lib/commands/RPUSHX.ts
+++ b/packages/client/lib/commands/RPUSHX.ts
@@ -3,6 +3,14 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
+  /**
+   * Constructs the RPUSHX command
+   * 
+   * @param parser - The command parser
+   * @param key - The list key to push to (only if it exists)
+   * @param element - One or more elements to push
+   * @see https://redis.io/commands/rpushx/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, element: RedisVariadicArgument) {
     parser.push('RPUSHX');
     parser.pushKey(key);

--- a/packages/client/lib/commands/SADD.ts
+++ b/packages/client/lib/commands/SADD.ts
@@ -3,6 +3,14 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
+  /**
+   * Constructs the SADD command
+   * 
+   * @param parser - The command parser
+   * @param key - The set key to add members to
+   * @param members - One or more members to add to the set
+   * @see https://redis.io/commands/sadd/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, members: RedisVariadicArgument) {
     parser.push('SADD');
     parser.pushKey(key);

--- a/packages/client/lib/commands/SAVE.ts
+++ b/packages/client/lib/commands/SAVE.ts
@@ -4,6 +4,12 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the SAVE command
+   * 
+   * @param parser - The command parser
+   * @see https://redis.io/commands/save/
+   */
   parseCommand(parser: CommandParser) {
     parser.push('SAVE');
   },

--- a/packages/client/lib/commands/SCAN.ts
+++ b/packages/client/lib/commands/SCAN.ts
@@ -1,11 +1,24 @@
 import { CommandParser } from '../client/parser';
 import { RedisArgument, CommandArguments, BlobStringReply, ArrayReply, Command } from '../RESP/types';
 
+/**
+ * Common options for SCAN-type commands
+ * 
+ * @property MATCH - Pattern to filter returned keys
+ * @property COUNT - Hint for how many elements to return per iteration
+ */
 export interface ScanCommonOptions {
   MATCH?: string;
   COUNT?: number;
 }
 
+/**
+ * Parses scan arguments for SCAN-type commands
+ * 
+ * @param parser - The command parser
+ * @param cursor - The cursor position for iteration
+ * @param options - Scan options
+ */
 export function parseScanArguments(
   parser: CommandParser,
   cursor: RedisArgument,
@@ -21,6 +34,14 @@ export function parseScanArguments(
   }
 }
 
+/**
+ * Pushes scan arguments to the command arguments array
+ * 
+ * @param args - The command arguments array
+ * @param cursor - The cursor position for iteration
+ * @param options - Scan options
+ * @returns The updated command arguments array
+ */
 export function pushScanArguments(
   args: CommandArguments,
   cursor: RedisArgument,
@@ -39,6 +60,11 @@ export function pushScanArguments(
   return args;
 }
 
+/**
+ * Options for the SCAN command
+ * 
+ * @property TYPE - Filter by value type
+ */
 export interface ScanOptions extends ScanCommonOptions {
   TYPE?: RedisArgument;
 }
@@ -46,6 +72,14 @@ export interface ScanOptions extends ScanCommonOptions {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the SCAN command
+   * 
+   * @param parser - The command parser
+   * @param cursor - The cursor position to start scanning from
+   * @param options - Scan options
+   * @see https://redis.io/commands/scan/
+   */
   parseCommand(parser: CommandParser, cursor: RedisArgument, options?: ScanOptions) {
     parser.push('SCAN');
     parseScanArguments(parser, cursor, options);
@@ -54,6 +88,12 @@ export default {
       parser.push('TYPE', options.TYPE);
     }
   },
+  /**
+   * Transforms the SCAN reply into a structured object
+   * 
+   * @param reply - The raw reply containing cursor and keys
+   * @returns Object with cursor and keys properties
+   */
   transformReply([cursor, keys]: [BlobStringReply, ArrayReply<BlobStringReply>]) {
     return {
       cursor,

--- a/packages/client/lib/commands/SCARD.ts
+++ b/packages/client/lib/commands/SCARD.ts
@@ -4,6 +4,13 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the SCARD command
+   * 
+   * @param parser - The command parser
+   * @param key - The set key to get the cardinality of
+   * @see https://redis.io/commands/scard/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('SCARD');
     parser.pushKey(key);

--- a/packages/client/lib/commands/SCRIPT_DEBUG.ts
+++ b/packages/client/lib/commands/SCRIPT_DEBUG.ts
@@ -4,6 +4,13 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the SCRIPT DEBUG command
+   * 
+   * @param parser - The command parser
+   * @param mode - Debug mode: YES, SYNC, or NO
+   * @see https://redis.io/commands/script-debug/
+   */
   parseCommand(parser: CommandParser, mode: 'YES' | 'SYNC' | 'NO') {
     parser.push('SCRIPT', 'DEBUG', mode);
   },

--- a/packages/client/lib/commands/SCRIPT_EXISTS.ts
+++ b/packages/client/lib/commands/SCRIPT_EXISTS.ts
@@ -5,6 +5,13 @@ import { RedisVariadicArgument } from './generic-transformers';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the SCRIPT EXISTS command
+   * 
+   * @param parser - The command parser
+   * @param sha1 - One or more SHA1 digests of scripts
+   * @see https://redis.io/commands/script-exists/
+   */
   parseCommand(parser: CommandParser, sha1: RedisVariadicArgument) {
     parser.push('SCRIPT', 'EXISTS');
     parser.pushVariadic(sha1);

--- a/packages/client/lib/commands/SCRIPT_FLUSH.ts
+++ b/packages/client/lib/commands/SCRIPT_FLUSH.ts
@@ -4,6 +4,13 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the SCRIPT FLUSH command
+   * 
+   * @param parser - The command parser
+   * @param mode - Optional flush mode: ASYNC or SYNC
+   * @see https://redis.io/commands/script-flush/
+   */
   parseCommand(parser: CommandParser, mode?: 'ASYNC' | 'SYNC') {
     parser.push('SCRIPT', 'FLUSH');
 

--- a/packages/client/lib/commands/SCRIPT_KILL.ts
+++ b/packages/client/lib/commands/SCRIPT_KILL.ts
@@ -4,6 +4,12 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the SCRIPT KILL command
+   * 
+   * @param parser - The command parser
+   * @see https://redis.io/commands/script-kill/
+   */
   parseCommand(parser: CommandParser) {
     parser.push('SCRIPT', 'KILL');
   },

--- a/packages/client/lib/commands/SCRIPT_LOAD.ts
+++ b/packages/client/lib/commands/SCRIPT_LOAD.ts
@@ -4,6 +4,13 @@ import { BlobStringReply, Command, RedisArgument } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the SCRIPT LOAD command
+   * 
+   * @param parser - The command parser
+   * @param script - The Lua script to load
+   * @see https://redis.io/commands/script-load/
+   */
   parseCommand(parser: CommandParser, script: RedisArgument) {
     parser.push('SCRIPT', 'LOAD', script);
   },

--- a/packages/client/lib/commands/SDIFF.ts
+++ b/packages/client/lib/commands/SDIFF.ts
@@ -5,6 +5,13 @@ import { RedisVariadicArgument } from './generic-transformers';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the SDIFF command
+   * 
+   * @param parser - The command parser
+   * @param keys - One or more set keys to compute the difference from
+   * @see https://redis.io/commands/sdiff/
+   */
   parseCommand(parser: CommandParser, keys: RedisVariadicArgument) {
     parser.push('SDIFF');
     parser.pushKeys(keys);

--- a/packages/client/lib/commands/SDIFFSTORE.ts
+++ b/packages/client/lib/commands/SDIFFSTORE.ts
@@ -3,6 +3,14 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
+  /**
+   * Constructs the SDIFFSTORE command
+   * 
+   * @param parser - The command parser
+   * @param destination - The destination key to store the result
+   * @param keys - One or more set keys to compute the difference from
+   * @see https://redis.io/commands/sdiffstore/
+   */
   parseCommand(parser: CommandParser, destination: RedisArgument, keys: RedisVariadicArgument) {
     parser.push('SDIFFSTORE');
     parser.pushKey(destination);

--- a/packages/client/lib/commands/SET.ts
+++ b/packages/client/lib/commands/SET.ts
@@ -43,6 +43,15 @@ export interface SetOptions {
 }
 
 export default {
+  /**
+   * Constructs the SET command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to set
+   * @param value - The value to set
+   * @param options - Additional options for the SET command
+   * @see https://redis.io/commands/set/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, value: RedisArgument | number, options?: SetOptions) {
     parser.push('SET');
     parser.pushKey(key);

--- a/packages/client/lib/commands/SETBIT.ts
+++ b/packages/client/lib/commands/SETBIT.ts
@@ -4,6 +4,15 @@ import { BitValue } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the SETBIT command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to set the bit on
+   * @param offset - The bit offset (zero-based)
+   * @param value - The bit value (0 or 1)
+   * @see https://redis.io/commands/setbit/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, offset: number, value: BitValue) {
     parser.push('SETBIT');
     parser.pushKey(key);

--- a/packages/client/lib/commands/SETEX.ts
+++ b/packages/client/lib/commands/SETEX.ts
@@ -2,6 +2,15 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, SimpleStringReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Constructs the SETEX command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to set
+   * @param seconds - The expiration time in seconds
+   * @param value - The value to set
+   * @see https://redis.io/commands/setex/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, seconds: number, value: RedisArgument) {
     parser.push('SETEX');
     parser.pushKey(key);

--- a/packages/client/lib/commands/SETNX.ts
+++ b/packages/client/lib/commands/SETNX.ts
@@ -2,6 +2,14 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Constructs the SETNX command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to set if it doesn't exist
+   * @param value - The value to set
+   * @see https://redis.io/commands/setnx/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, value: RedisArgument) {
     parser.push('SETNX');
     parser.pushKey(key);

--- a/packages/client/lib/commands/SETRANGE.ts
+++ b/packages/client/lib/commands/SETRANGE.ts
@@ -2,6 +2,15 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
+  /**
+   * Constructs the SETRANGE command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to modify
+   * @param offset - The offset at which to start writing
+   * @param value - The value to write at the offset
+   * @see https://redis.io/commands/setrange/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, offset: number, value: RedisArgument) {
     parser.push('SETRANGE');
     parser.pushKey(key);

--- a/packages/client/lib/commands/SHUTDOWN.ts
+++ b/packages/client/lib/commands/SHUTDOWN.ts
@@ -1,6 +1,14 @@
 import { CommandParser } from '../client/parser';
 import { SimpleStringReply, Command } from '../RESP/types';
 
+/**
+ * Options for the SHUTDOWN command
+ * 
+ * @property mode - NOSAVE will not save DB, SAVE will force save DB
+ * @property NOW - Immediately terminate all clients
+ * @property FORCE - Force shutdown even in case of errors
+ * @property ABORT - Abort a shutdown in progress
+ */
 export interface ShutdownOptions {
   mode?: 'NOSAVE' | 'SAVE';
   NOW?: boolean;
@@ -11,6 +19,13 @@ export interface ShutdownOptions {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: false,
+  /**
+   * Constructs the SHUTDOWN command
+   * 
+   * @param parser - The command parser
+   * @param options - Options for the shutdown process
+   * @see https://redis.io/commands/shutdown/
+   */
   parseCommand(parser: CommandParser, options?: ShutdownOptions) {
     parser.push('SHUTDOWN');
 

--- a/packages/client/lib/commands/SINTER.ts
+++ b/packages/client/lib/commands/SINTER.ts
@@ -5,6 +5,13 @@ import { RedisVariadicArgument } from './generic-transformers';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the SINTER command
+   * 
+   * @param parser - The command parser
+   * @param keys - One or more set keys to compute the intersection from
+   * @see https://redis.io/commands/sinter/
+   */
   parseCommand(parser: CommandParser, keys: RedisVariadicArgument) {
     parser.push('SINTER');
     parser.pushKeys(keys);

--- a/packages/client/lib/commands/SINTERCARD.ts
+++ b/packages/client/lib/commands/SINTERCARD.ts
@@ -2,13 +2,25 @@ import { CommandParser } from '../client/parser';
 import { NumberReply, Command } from '../RESP/types';
 import { RedisVariadicArgument } from './generic-transformers';
 
+/**
+ * Options for the SINTERCARD command
+ * 
+ * @property LIMIT - Maximum number of elements to return
+ */
 export interface SInterCardOptions {
   LIMIT?: number;
 }
 
 export default {
   IS_READ_ONLY: true,
-  // option `number` for backwards compatibility
+  /**
+   * Constructs the SINTERCARD command
+   * 
+   * @param parser - The command parser
+   * @param keys - One or more set keys to compute the intersection cardinality from
+   * @param options - Options for the SINTERCARD command or a number for LIMIT (backwards compatibility)
+   * @see https://redis.io/commands/sintercard/
+   */
   parseCommand(parser: CommandParser, keys: RedisVariadicArgument, options?: SInterCardOptions | number) {
     parser.push('SINTERCARD');
     parser.pushKeysLength(keys);

--- a/packages/client/lib/commands/SINTERSTORE.ts
+++ b/packages/client/lib/commands/SINTERSTORE.ts
@@ -4,6 +4,14 @@ import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the SINTERSTORE command
+   * 
+   * @param parser - The command parser
+   * @param destination - The destination key to store the result
+   * @param keys - One or more set keys to compute the intersection from
+   * @see https://redis.io/commands/sinterstore/
+   */
   parseCommand(parser: CommandParser, destination: RedisArgument, keys: RedisVariadicArgument) {
     parser.push('SINTERSTORE');
     parser.pushKey(destination)

--- a/packages/client/lib/commands/SISMEMBER.ts
+++ b/packages/client/lib/commands/SISMEMBER.ts
@@ -4,6 +4,14 @@ import { NumberReply, Command, RedisArgument } from '../RESP/types';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the SISMEMBER command
+   * 
+   * @param parser - The command parser
+   * @param key - The set key to check membership in
+   * @param member - The member to check for existence
+   * @see https://redis.io/commands/sismember/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, member: RedisArgument) {
     parser.push('SISMEMBER');
     parser.pushKey(key);

--- a/packages/client/lib/commands/SMEMBERS.ts
+++ b/packages/client/lib/commands/SMEMBERS.ts
@@ -4,6 +4,13 @@ import { RedisArgument, ArrayReply, BlobStringReply, SetReply, Command } from '.
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the SMEMBERS command
+   * 
+   * @param parser - The command parser
+   * @param key - The set key to get all members from
+   * @see https://redis.io/commands/smembers/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('SMEMBERS');
     parser.pushKey(key);

--- a/packages/client/lib/commands/SMISMEMBER.ts
+++ b/packages/client/lib/commands/SMISMEMBER.ts
@@ -4,6 +4,14 @@ import { RedisArgument, ArrayReply, NumberReply, Command } from '../RESP/types';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the SMISMEMBER command
+   * 
+   * @param parser - The command parser
+   * @param key - The set key to check membership in
+   * @param members - The members to check for existence
+   * @see https://redis.io/commands/smismember/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, members: Array<RedisArgument>) {
     parser.push('SMISMEMBER');
     parser.pushKey(key);

--- a/packages/client/lib/commands/SMOVE.ts
+++ b/packages/client/lib/commands/SMOVE.ts
@@ -3,6 +3,15 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the SMOVE command
+   * 
+   * @param parser - The command parser
+   * @param source - The source set key
+   * @param destination - The destination set key
+   * @param member - The member to move
+   * @see https://redis.io/commands/smove/
+   */
   parseCommand(parser: CommandParser, source: RedisArgument, destination: RedisArgument, member: RedisArgument) {
     parser.push('SMOVE');
     parser.pushKeys([source, destination]);

--- a/packages/client/lib/commands/SORT.ts
+++ b/packages/client/lib/commands/SORT.ts
@@ -1,6 +1,15 @@
 import { CommandParser } from '../client/parser';
 import { RedisArgument, ArrayReply, BlobStringReply, Command } from '../RESP/types';
 
+/**
+ * Options for the SORT command
+ * 
+ * @property BY - Pattern for external key to sort by
+ * @property LIMIT - Offset and count for results pagination
+ * @property GET - Pattern(s) for retrieving external keys
+ * @property DIRECTION - Sort direction: ASC (ascending) or DESC (descending)
+ * @property ALPHA - Sort lexicographically instead of numerically
+ */
 export interface SortOptions {
   BY?: RedisArgument;
   LIMIT?: {
@@ -12,6 +21,13 @@ export interface SortOptions {
   ALPHA?: boolean;
 }
 
+/**
+ * Parses sort arguments for the SORT command
+ * 
+ * @param parser - The command parser
+ * @param key - The key to sort
+ * @param options - Sort options
+ */
 export function parseSortArguments(
   parser: CommandParser,
   key: RedisArgument,
@@ -52,6 +68,14 @@ export function parseSortArguments(
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the SORT command
+   * 
+   * @param parser - The command parser
+   * @param key - The key to sort (list, set, or sorted set)
+   * @param options - Sort options
+   * @see https://redis.io/commands/sort/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, options?: SortOptions) {
     parser.push('SORT');
     parseSortArguments(parser, key, options);

--- a/packages/client/lib/commands/SORT_RO.ts
+++ b/packages/client/lib/commands/SORT_RO.ts
@@ -3,6 +3,10 @@ import SORT, { parseSortArguments } from './SORT';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Read-only variant of SORT that sorts the elements in a list, set or sorted set.
+   * @param args - Same parameters as the SORT command.
+   */
   parseCommand(...args: Parameters<typeof parseSortArguments>) {
     const parser = args[0];
 

--- a/packages/client/lib/commands/SORT_STORE.ts
+++ b/packages/client/lib/commands/SORT_STORE.ts
@@ -4,6 +4,13 @@ import SORT, { SortOptions } from './SORT';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Sorts the elements in a list, set or sorted set and stores the result in a new list.
+   * @param parser - The Redis command parser.
+   * @param source - Key of the source list, set or sorted set.
+   * @param destination - Destination key where the result will be stored.
+   * @param options - Optional sorting parameters.
+   */
   parseCommand(parser: CommandParser, source: RedisArgument, destination: RedisArgument, options?: SortOptions) {
     SORT.parseCommand(parser, source, options);
     parser.push('STORE', destination);

--- a/packages/client/lib/commands/SPOP.ts
+++ b/packages/client/lib/commands/SPOP.ts
@@ -3,6 +3,13 @@ import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/type
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the SPOP command to remove and return a random member from a set
+   *
+   * @param parser - The command parser
+   * @param key - The key of the set to pop from
+   * @see https://redis.io/commands/spop/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('SPOP');
     parser.pushKey(key);

--- a/packages/client/lib/commands/SPOP_COUNT.ts
+++ b/packages/client/lib/commands/SPOP_COUNT.ts
@@ -3,6 +3,14 @@ import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/type
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the SPOP command to remove and return multiple random members from a set
+   *
+   * @param parser - The command parser
+   * @param key - The key of the set to pop from
+   * @param count - The number of members to pop
+   * @see https://redis.io/commands/spop/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, count: number) {
     parser.push('SPOP');
     parser.pushKey(key);

--- a/packages/client/lib/commands/SPUBLISH.ts
+++ b/packages/client/lib/commands/SPUBLISH.ts
@@ -3,6 +3,14 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the SPUBLISH command to post a message to a Sharded Pub/Sub channel
+   *
+   * @param parser - The command parser
+   * @param channel - The channel to publish to
+   * @param message - The message to publish
+   * @see https://redis.io/commands/spublish/
+   */
   parseCommand(parser: CommandParser, channel: RedisArgument, message: RedisArgument) {
     parser.push('SPUBLISH');
     parser.pushKey(channel);

--- a/packages/client/lib/commands/SRANDMEMBER.ts
+++ b/packages/client/lib/commands/SRANDMEMBER.ts
@@ -3,6 +3,13 @@ import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/type
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the SRANDMEMBER command to get a random member from a set
+   *
+   * @param parser - The command parser
+   * @param key - The key of the set to get random member from
+   * @see https://redis.io/commands/srandmember/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('SRANDMEMBER')
     parser.pushKey(key);

--- a/packages/client/lib/commands/SRANDMEMBER_COUNT.ts
+++ b/packages/client/lib/commands/SRANDMEMBER_COUNT.ts
@@ -4,6 +4,14 @@ import SRANDMEMBER from './SRANDMEMBER';
 
 export default {
   IS_READ_ONLY: SRANDMEMBER.IS_READ_ONLY,
+  /**
+   * Constructs the SRANDMEMBER command to get multiple random members from a set
+   *
+   * @param parser - The command parser
+   * @param key - The key of the set to get random members from
+   * @param count - The number of members to return. If negative, may return the same member multiple times
+   * @see https://redis.io/commands/srandmember/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, count: number) {
     SRANDMEMBER.parseCommand(parser, key);
     parser.push(count.toString());

--- a/packages/client/lib/commands/SREM.ts
+++ b/packages/client/lib/commands/SREM.ts
@@ -4,6 +4,15 @@ import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the SREM command to remove one or more members from a set
+   *
+   * @param parser - The command parser
+   * @param key - The key of the set to remove members from
+   * @param members - One or more members to remove from the set
+   * @returns The number of members that were removed from the set
+   * @see https://redis.io/commands/srem/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, members: RedisVariadicArgument) {
     parser.push('SREM');
     parser.pushKey(key);

--- a/packages/client/lib/commands/SSCAN.ts
+++ b/packages/client/lib/commands/SSCAN.ts
@@ -4,6 +4,16 @@ import { ScanCommonOptions, parseScanArguments} from './SCAN';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the SSCAN command to incrementally iterate over elements in a set
+   *
+   * @param parser - The command parser
+   * @param key - The key of the set to scan
+   * @param cursor - The cursor position to start scanning from
+   * @param options - Optional scanning parameters (COUNT and MATCH)
+   * @returns Iterator containing cursor position and matching members
+   * @see https://redis.io/commands/sscan/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,
@@ -14,6 +24,13 @@ export default {
     parser.pushKey(key);
     parseScanArguments(parser, cursor, options);
   },
+  /**
+   * Transforms the SSCAN reply into a cursor result object
+   * 
+   * @param cursor - The next cursor position
+   * @param members - Array of matching set members
+   * @returns Object containing cursor and members array
+   */
   transformReply([cursor, members]: [BlobStringReply, Array<BlobStringReply>]) {
     return {
       cursor,

--- a/packages/client/lib/commands/STRLEN.ts
+++ b/packages/client/lib/commands/STRLEN.ts
@@ -4,6 +4,14 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the STRLEN command to get the length of a string value
+   *
+   * @param parser - The command parser
+   * @param key - The key holding the string value
+   * @returns The length of the string value, or 0 when key does not exist
+   * @see https://redis.io/commands/strlen/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('STRLEN');
     parser.pushKey(key);

--- a/packages/client/lib/commands/SUNION.ts
+++ b/packages/client/lib/commands/SUNION.ts
@@ -5,6 +5,14 @@ import { RedisVariadicArgument } from './generic-transformers';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the SUNION command to return the members of the set resulting from the union of all the given sets
+   *
+   * @param parser - The command parser
+   * @param keys - One or more set keys to compute the union from
+   * @returns Array of all elements that are members of at least one of the given sets
+   * @see https://redis.io/commands/sunion/
+   */
   parseCommand(parser: CommandParser, keys: RedisVariadicArgument) {
     parser.push('SUNION');
     parser.pushKeys(keys);

--- a/packages/client/lib/commands/SUNIONSTORE.ts
+++ b/packages/client/lib/commands/SUNIONSTORE.ts
@@ -4,6 +4,15 @@ import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the SUNIONSTORE command to store the union of multiple sets into a destination set
+   *
+   * @param parser - The command parser
+   * @param destination - The destination key to store the resulting set
+   * @param keys - One or more source set keys to compute the union from
+   * @returns The number of elements in the resulting set
+   * @see https://redis.io/commands/sunionstore/
+   */
   parseCommand(parser: CommandParser, destination: RedisArgument, keys: RedisVariadicArgument) {
     parser.push('SUNIONSTORE');
     parser.pushKey(destination);

--- a/packages/client/lib/commands/SWAPDB.ts
+++ b/packages/client/lib/commands/SWAPDB.ts
@@ -4,6 +4,12 @@ import { SimpleStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: false,
+  /**
+   * Swaps the data of two Redis databases.
+   * @param parser - The Redis command parser.
+   * @param index1 - First database index.
+   * @param index2 - Second database index.
+   */
   parseCommand(parser: CommandParser, index1: number, index2: number) {
     parser.push('SWAPDB', index1.toString(), index2.toString());
   },

--- a/packages/client/lib/commands/TIME.ts
+++ b/packages/client/lib/commands/TIME.ts
@@ -4,6 +4,13 @@ import { BlobStringReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the TIME command to return the server's current time
+   *
+   * @param parser - The command parser
+   * @returns Array containing the Unix timestamp in seconds and microseconds
+   * @see https://redis.io/commands/time/
+   */
   parseCommand(parser: CommandParser) {
     parser.push('TIME');
   },

--- a/packages/client/lib/commands/TOUCH.ts
+++ b/packages/client/lib/commands/TOUCH.ts
@@ -4,6 +4,14 @@ import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the TOUCH command to alter the last access time of keys
+   *
+   * @param parser - The command parser
+   * @param key - One or more keys to touch
+   * @returns The number of keys that were touched
+   * @see https://redis.io/commands/touch/
+   */
   parseCommand(parser: CommandParser, key: RedisVariadicArgument) {
     parser.push('TOUCH');
     parser.pushKeys(key);

--- a/packages/client/lib/commands/TTL.ts
+++ b/packages/client/lib/commands/TTL.ts
@@ -3,6 +3,14 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the TTL command to get the remaining time to live of a key
+   *
+   * @param parser - The command parser
+   * @param key - Key to check
+   * @returns Time to live in seconds, -2 if key does not exist, -1 if has no timeout
+   * @see https://redis.io/commands/ttl/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('TTL');
     parser.pushKey(key);

--- a/packages/client/lib/commands/TYPE.ts
+++ b/packages/client/lib/commands/TYPE.ts
@@ -4,6 +4,14 @@ import { RedisArgument, SimpleStringReply, Command } from '../RESP/types';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the TYPE command to determine the data type stored at key
+   *
+   * @param parser - The command parser
+   * @param key - Key to check
+   * @returns String reply: "none", "string", "list", "set", "zset", "hash", "stream"
+   * @see https://redis.io/commands/type/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('TYPE');
     parser.pushKey(key);

--- a/packages/client/lib/commands/UNLINK.ts
+++ b/packages/client/lib/commands/UNLINK.ts
@@ -4,6 +4,14 @@ import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the UNLINK command to asynchronously delete one or more keys
+   *
+   * @param parser - The command parser
+   * @param keys - One or more keys to unlink
+   * @returns The number of keys that were unlinked
+   * @see https://redis.io/commands/unlink/
+   */
   parseCommand(parser: CommandParser, keys: RedisVariadicArgument) {
     parser.push('UNLINK');
     parser.pushKeys(keys);

--- a/packages/client/lib/commands/WAIT.ts
+++ b/packages/client/lib/commands/WAIT.ts
@@ -4,6 +4,15 @@ import { NumberReply, Command } from '../RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the WAIT command to synchronize with replicas
+   *
+   * @param parser - The command parser
+   * @param numberOfReplicas - Number of replicas that must acknowledge the write
+   * @param timeout - Maximum time to wait in milliseconds
+   * @returns The number of replicas that acknowledged the write
+   * @see https://redis.io/commands/wait/
+   */
   parseCommand(parser: CommandParser, numberOfReplicas: number, timeout: number) {
     parser.push('WAIT', numberOfReplicas.toString(), timeout.toString());
   },

--- a/packages/client/lib/commands/XACK.ts
+++ b/packages/client/lib/commands/XACK.ts
@@ -4,6 +4,16 @@ import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the XACK command to acknowledge the processing of stream messages in a consumer group
+   *
+   * @param parser - The command parser
+   * @param key - The stream key
+   * @param group - The consumer group name
+   * @param id - One or more message IDs to acknowledge
+   * @returns The number of messages successfully acknowledged
+   * @see https://redis.io/commands/xack/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, group: RedisArgument, id: RedisVariadicArgument) {
     parser.push('XACK');
     parser.pushKey(key);

--- a/packages/client/lib/commands/XADD.ts
+++ b/packages/client/lib/commands/XADD.ts
@@ -2,6 +2,15 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, BlobStringReply, Command } from '../RESP/types';
 import { Tail } from './generic-transformers';
 
+/**
+ * Options for the XADD command
+ * 
+ * @property TRIM - Optional trimming configuration
+ * @property TRIM.strategy - Trim strategy: MAXLEN (by length) or MINID (by ID)
+ * @property TRIM.strategyModifier - Exact ('=') or approximate ('~') trimming
+ * @property TRIM.threshold - Maximum stream length or minimum ID to retain
+ * @property TRIM.limit - Maximum number of entries to trim in one call
+ */
 export interface XAddOptions {
   TRIM?: {
     strategy?: 'MAXLEN' | 'MINID';
@@ -11,6 +20,16 @@ export interface XAddOptions {
   };
 }
 
+/**
+ * Parses arguments for the XADD command
+ *
+ * @param optional - Optional command modifier
+ * @param parser - The command parser
+ * @param key - The stream key
+ * @param id - Message ID (* for auto-generation)
+ * @param message - Key-value pairs representing the message fields
+ * @param options - Additional options for stream trimming
+ */
 export function parseXAddArguments(
   optional: RedisArgument | undefined,
   parser: CommandParser,
@@ -50,6 +69,17 @@ export function parseXAddArguments(
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the XADD command to append a new entry to a stream
+   *
+   * @param parser - The command parser
+   * @param key - The stream key
+   * @param id - Message ID (* for auto-generation)
+   * @param message - Key-value pairs representing the message fields
+   * @param options - Additional options for stream trimming
+   * @returns The ID of the added entry
+   * @see https://redis.io/commands/xadd/
+   */
   parseCommand(...args: Tail<Parameters<typeof parseXAddArguments>>) {
     return parseXAddArguments(undefined, ...args);
   },

--- a/packages/client/lib/commands/XADD_NOMKSTREAM.ts
+++ b/packages/client/lib/commands/XADD_NOMKSTREAM.ts
@@ -2,8 +2,18 @@ import { BlobStringReply, NullReply, Command } from '../RESP/types';
 import { Tail } from './generic-transformers';
 import { parseXAddArguments } from './XADD';
 
+/**
+ * Command for adding entries to an existing stream without creating it if it doesn't exist
+ */
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the XADD command with NOMKSTREAM option to append a new entry to an existing stream
+   *
+   * @param args - Arguments tuple containing parser, key, id, message, and options
+   * @returns The ID of the added entry, or null if the stream doesn't exist
+   * @see https://redis.io/commands/xadd/
+   */
   parseCommand(...args: Tail<Parameters<typeof parseXAddArguments>>) {
     return parseXAddArguments('NOMKSTREAM', ...args);
   },

--- a/packages/client/lib/commands/XAUTOCLAIM.ts
+++ b/packages/client/lib/commands/XAUTOCLAIM.ts
@@ -2,10 +2,22 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, TuplesReply, BlobStringReply, ArrayReply, NullReply, UnwrapReply, Command, TypeMapping } from '../RESP/types';
 import { StreamMessageRawReply, transformStreamMessageNullReply } from './generic-transformers';
 
+/**
+ * Options for the XAUTOCLAIM command
+ * 
+ * @property COUNT - Limit the number of messages to claim
+ */
 export interface XAutoClaimOptions {
   COUNT?: number;
 }
 
+/**
+ * Raw reply structure for XAUTOCLAIM command
+ * 
+ * @property nextId - The ID to use for the next XAUTOCLAIM call
+ * @property messages - Array of claimed messages or null entries
+ * @property deletedMessages - Array of message IDs that no longer exist
+ */
 export type XAutoClaimRawReply = TuplesReply<[
   nextId: BlobStringReply,
   messages: ArrayReply<StreamMessageRawReply | NullReply>,
@@ -14,6 +26,19 @@ export type XAutoClaimRawReply = TuplesReply<[
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the XAUTOCLAIM command to automatically claim pending messages in a consumer group
+   *
+   * @param parser - The command parser
+   * @param key - The stream key
+   * @param group - The consumer group name
+   * @param consumer - The consumer name that will claim the messages
+   * @param minIdleTime - Minimum idle time in milliseconds for a message to be claimed
+   * @param start - Message ID to start scanning from
+   * @param options - Additional options for the claim operation
+   * @returns Object containing nextId, claimed messages, and list of deleted message IDs
+   * @see https://redis.io/commands/xautoclaim/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,
@@ -31,6 +56,14 @@ export default {
       parser.push('COUNT', options.COUNT.toString());
     }
   },
+  /**
+   * Transforms the raw XAUTOCLAIM reply into a structured object
+   * 
+   * @param reply - Raw reply from Redis
+   * @param preserve - Preserve options (unused)
+   * @param typeMapping - Type mapping for message fields
+   * @returns Structured object containing nextId, messages, and deletedMessages
+   */
   transformReply(reply: UnwrapReply<XAutoClaimRawReply>, preserve?: any, typeMapping?: TypeMapping) {
     return {
       nextId: reply[0],

--- a/packages/client/lib/commands/XAUTOCLAIM_JUSTID.ts
+++ b/packages/client/lib/commands/XAUTOCLAIM_JUSTID.ts
@@ -1,6 +1,13 @@
 import { TuplesReply, BlobStringReply, ArrayReply, UnwrapReply, Command } from '../RESP/types';
 import XAUTOCLAIM from './XAUTOCLAIM';
 
+/**
+ * Raw reply structure for XAUTOCLAIM JUSTID command
+ * 
+ * @property nextId - The ID to use for the next XAUTOCLAIM call
+ * @property messages - Array of message IDs that were claimed
+ * @property deletedMessages - Array of message IDs that no longer exist
+ */
 type XAutoClaimJustIdRawReply = TuplesReply<[
   nextId: BlobStringReply,
   messages: ArrayReply<BlobStringReply>,
@@ -9,11 +16,24 @@ type XAutoClaimJustIdRawReply = TuplesReply<[
 
 export default {
   IS_READ_ONLY: XAUTOCLAIM.IS_READ_ONLY,
+  /**
+   * Constructs the XAUTOCLAIM command with JUSTID option to get only message IDs
+   *
+   * @param args - Same parameters as XAUTOCLAIM command
+   * @returns Object containing nextId and arrays of claimed and deleted message IDs
+   * @see https://redis.io/commands/xautoclaim/
+   */
   parseCommand(...args: Parameters<typeof XAUTOCLAIM.parseCommand>) {
     const parser = args[0];
     XAUTOCLAIM.parseCommand(...args);
     parser.push('JUSTID');
   },
+  /**
+   * Transforms the raw XAUTOCLAIM JUSTID reply into a structured object
+   * 
+   * @param reply - Raw reply from Redis
+   * @returns Structured object containing nextId, message IDs, and deleted message IDs
+   */
   transformReply(reply: UnwrapReply<XAutoClaimJustIdRawReply>) {
     return {
       nextId: reply[0],

--- a/packages/client/lib/commands/XCLAIM.ts
+++ b/packages/client/lib/commands/XCLAIM.ts
@@ -2,6 +2,15 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, ArrayReply, NullReply, UnwrapReply, Command, TypeMapping } from '../RESP/types';
 import { RedisVariadicArgument, StreamMessageRawReply, transformStreamMessageNullReply } from './generic-transformers';
 
+/**
+ * Options for the XCLAIM command
+ * 
+ * @property IDLE - Set the idle time (in milliseconds) for the claimed messages
+ * @property TIME - Set the last delivery time (Unix timestamp or Date)
+ * @property RETRYCOUNT - Set the retry counter for the claimed messages
+ * @property FORCE - Create the pending message entry even if the message doesn't exist
+ * @property LASTID - Update the consumer group last ID
+ */
 export interface XClaimOptions {
   IDLE?: number;
   TIME?: number | Date;
@@ -12,6 +21,19 @@ export interface XClaimOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the XCLAIM command to claim pending messages in a consumer group
+   *
+   * @param parser - The command parser
+   * @param key - The stream key
+   * @param group - The consumer group name
+   * @param consumer - The consumer name that will claim the messages
+   * @param minIdleTime - Minimum idle time in milliseconds for a message to be claimed
+   * @param id - One or more message IDs to claim
+   * @param options - Additional options for the claim operation
+   * @returns Array of claimed messages
+   * @see https://redis.io/commands/xclaim/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,
@@ -49,6 +71,14 @@ export default {
       parser.push('LASTID', options.LASTID);
     }
   },
+  /**
+   * Transforms the raw XCLAIM reply into an array of messages
+   * 
+   * @param reply - Raw reply from Redis
+   * @param preserve - Preserve options (unused)
+   * @param typeMapping - Type mapping for message fields
+   * @returns Array of claimed messages with their fields
+   */
   transformReply(
     reply: UnwrapReply<ArrayReply<StreamMessageRawReply | NullReply>>, 
     preserve?: any,

--- a/packages/client/lib/commands/XCLAIM_JUSTID.ts
+++ b/packages/client/lib/commands/XCLAIM_JUSTID.ts
@@ -1,12 +1,27 @@
 import { ArrayReply, BlobStringReply, Command } from '../RESP/types';
 import XCLAIM from './XCLAIM';
 
+/**
+ * Command variant for XCLAIM that returns only message IDs
+ */
 export default {
   IS_READ_ONLY: XCLAIM.IS_READ_ONLY,
+  /**
+   * Constructs the XCLAIM command with JUSTID option to get only message IDs
+   *
+   * @param args - Same parameters as XCLAIM command
+   * @returns Array of successfully claimed message IDs
+   * @see https://redis.io/commands/xclaim/
+   */
   parseCommand(...args: Parameters<typeof XCLAIM.parseCommand>) {
     const parser = args[0];
     XCLAIM.parseCommand(...args);
     parser.push('JUSTID');
   },
+  /**
+   * Transforms the XCLAIM JUSTID reply into an array of message IDs
+   * 
+   * @returns Array of claimed message IDs
+   */
   transformReply: undefined as unknown as () => ArrayReply<BlobStringReply>
 } as const satisfies Command;

--- a/packages/client/lib/commands/XDEL.ts
+++ b/packages/client/lib/commands/XDEL.ts
@@ -2,8 +2,20 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, NumberReply, Command } from '../RESP/types';
 import { RedisVariadicArgument } from './generic-transformers';
 
+/**
+ * Command for removing messages from a stream
+ */
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the XDEL command to remove one or more messages from a stream
+   *
+   * @param parser - The command parser
+   * @param key - The stream key
+   * @param id - One or more message IDs to delete
+   * @returns The number of messages actually deleted
+   * @see https://redis.io/commands/xdel/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, id: RedisVariadicArgument) {
     parser.push('XDEL');
     parser.pushKey(key);

--- a/packages/client/lib/commands/XGROUP_CREATE.ts
+++ b/packages/client/lib/commands/XGROUP_CREATE.ts
@@ -1,6 +1,12 @@
 import { CommandParser } from '../client/parser';
 import { RedisArgument, SimpleStringReply, Command } from '../RESP/types';
 
+/**
+ * Options for creating a consumer group
+ * 
+ * @property MKSTREAM - Create the stream if it doesn't exist
+ * @property ENTRIESREAD - Set the number of entries that were read in this consumer group (Redis 7.0+)
+ */
 export interface XGroupCreateOptions {
   MKSTREAM?: boolean;
   /**
@@ -11,6 +17,17 @@ export interface XGroupCreateOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the XGROUP CREATE command to create a consumer group for a stream
+   *
+   * @param parser - The command parser
+   * @param key - The stream key
+   * @param group - Name of the consumer group
+   * @param id - ID of the last delivered item in the stream ('$' for last item, '0' for all items)
+   * @param options - Additional options for group creation
+   * @returns 'OK' if successful
+   * @see https://redis.io/commands/xgroup-create/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/XGROUP_CREATECONSUMER.ts
+++ b/packages/client/lib/commands/XGROUP_CREATECONSUMER.ts
@@ -1,8 +1,21 @@
 import { CommandParser } from '../client/parser';
 import { RedisArgument, Command, NumberReply } from '../RESP/types';
 
+/**
+ * Command for creating a new consumer in a consumer group
+ */
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the XGROUP CREATECONSUMER command to create a new consumer in a consumer group
+   *
+   * @param parser - The command parser
+   * @param key - The stream key
+   * @param group - Name of the consumer group
+   * @param consumer - Name of the consumer to create
+   * @returns 1 if the consumer was created, 0 if it already existed
+   * @see https://redis.io/commands/xgroup-createconsumer/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/XGROUP_DELCONSUMER.ts
+++ b/packages/client/lib/commands/XGROUP_DELCONSUMER.ts
@@ -1,8 +1,21 @@
 import { CommandParser } from '../client/parser';
 import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
+/**
+ * Command for removing a consumer from a consumer group
+ */
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the XGROUP DELCONSUMER command to remove a consumer from a consumer group
+   *
+   * @param parser - The command parser
+   * @param key - The stream key
+   * @param group - Name of the consumer group
+   * @param consumer - Name of the consumer to remove 
+   * @returns The number of pending messages owned by the deleted consumer
+   * @see https://redis.io/commands/xgroup-delconsumer/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/XGROUP_DESTROY.ts
+++ b/packages/client/lib/commands/XGROUP_DESTROY.ts
@@ -1,8 +1,20 @@
 import { CommandParser } from '../client/parser';
 import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
+/**
+ * Command for removing a consumer group
+ */
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the XGROUP DESTROY command to remove a consumer group
+   *
+   * @param parser - The command parser
+   * @param key - The stream key
+   * @param group - Name of the consumer group to destroy
+   * @returns 1 if the group was destroyed, 0 if it did not exist
+   * @see https://redis.io/commands/xgroup-destroy/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, group: RedisArgument) {
     parser.push('XGROUP', 'DESTROY');
     parser.pushKey(key);

--- a/packages/client/lib/commands/XGROUP_SETID.ts
+++ b/packages/client/lib/commands/XGROUP_SETID.ts
@@ -1,6 +1,11 @@
 import { CommandParser } from '../client/parser';
 import { RedisArgument, SimpleStringReply, Command } from '../RESP/types';
 
+/**
+ * Options for setting a consumer group's ID position
+ * 
+ * @property ENTRIESREAD - Set the number of entries that were read in this consumer group (Redis 7.0+)
+ */
 export interface XGroupSetIdOptions {
   /** added in 7.0 */
   ENTRIESREAD?: number;
@@ -8,6 +13,17 @@ export interface XGroupSetIdOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the XGROUP SETID command to set the last delivered ID for a consumer group
+   *
+   * @param parser - The command parser
+   * @param key - The stream key
+   * @param group - Name of the consumer group
+   * @param id - ID to set as last delivered message ('$' for last item, '0' for all items)
+   * @param options - Additional options for setting the group ID
+   * @returns 'OK' if successful
+   * @see https://redis.io/commands/xgroup-setid/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/XINFO_CONSUMERS.ts
+++ b/packages/client/lib/commands/XINFO_CONSUMERS.ts
@@ -1,6 +1,14 @@
 import { CommandParser } from '../client/parser';
 import { RedisArgument, ArrayReply, TuplesToMapReply, BlobStringReply, NumberReply, UnwrapReply, Resp2Reply, Command } from '../RESP/types';
 
+/**
+ * Reply structure for XINFO CONSUMERS command
+ * 
+ * @property name - Name of the consumer
+ * @property pending - Number of pending messages for this consumer
+ * @property idle - Idle time in milliseconds
+ * @property inactive - Time in milliseconds since last interaction (Redis 7.2+)
+ */
 export type XInfoConsumersReply = ArrayReply<TuplesToMapReply<[
   [BlobStringReply<'name'>, BlobStringReply],
   [BlobStringReply<'pending'>, NumberReply],
@@ -11,12 +19,27 @@ export type XInfoConsumersReply = ArrayReply<TuplesToMapReply<[
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the XINFO CONSUMERS command to list the consumers in a consumer group
+   *
+   * @param parser - The command parser
+   * @param key - The stream key
+   * @param group - Name of the consumer group
+   * @returns Array of consumer information objects
+   * @see https://redis.io/commands/xinfo-consumers/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, group: RedisArgument) {
     parser.push('XINFO', 'CONSUMERS');
     parser.pushKey(key);
     parser.push(group);
   },
   transformReply: {
+    /**
+     * Transforms RESP2 reply into a structured consumer information array
+     * 
+     * @param reply - Raw RESP2 reply from Redis
+     * @returns Array of consumer information objects
+     */
     2: (reply: UnwrapReply<Resp2Reply<XInfoConsumersReply>>) => {
       return reply.map(consumer => {
         const unwrapped = consumer as unknown as UnwrapReply<typeof consumer>;

--- a/packages/client/lib/commands/XINFO_GROUPS.ts
+++ b/packages/client/lib/commands/XINFO_GROUPS.ts
@@ -1,6 +1,9 @@
 import { CommandParser } from '../client/parser';
 import { RedisArgument, ArrayReply, TuplesToMapReply, BlobStringReply, NumberReply, NullReply, UnwrapReply, Resp2Reply, Command } from '../RESP/types';
 
+/**
+ * Reply structure for XINFO GROUPS command containing information about consumer groups
+ */
 export type XInfoGroupsReply = ArrayReply<TuplesToMapReply<[
   [BlobStringReply<'name'>, BlobStringReply],
   [BlobStringReply<'consumers'>, NumberReply],
@@ -14,11 +17,31 @@ export type XInfoGroupsReply = ArrayReply<TuplesToMapReply<[
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the XINFO GROUPS command to list the consumer groups of a stream
+   *
+   * @param parser - The command parser
+   * @param key - The stream key
+   * @returns Array of consumer group information objects
+   * @see https://redis.io/commands/xinfo-groups/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('XINFO', 'GROUPS');
     parser.pushKey(key);
   },
   transformReply: {
+    /**
+     * Transforms RESP2 reply into a structured consumer group information array
+     * 
+     * @param reply - Raw RESP2 reply from Redis
+     * @returns Array of consumer group information objects containing:
+     *          name - Name of the consumer group
+     *          consumers - Number of consumers in the group
+     *          pending - Number of pending messages for the group
+     *          last-delivered-id - ID of the last delivered message
+     *          entries-read - Number of entries read in the group (Redis 7.0+)
+     *          lag - Number of entries not read by the group (Redis 7.0+)
+     */
     2: (reply: UnwrapReply<Resp2Reply<XInfoGroupsReply>>) => {
       return reply.map(group => {
         const unwrapped = group as unknown as UnwrapReply<typeof group>;

--- a/packages/client/lib/commands/XLEN.ts
+++ b/packages/client/lib/commands/XLEN.ts
@@ -1,9 +1,20 @@
 import { CommandParser } from '../client/parser';
 import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
+/**
+ * Command for getting the length of a stream
+ */
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the XLEN command to get the number of entries in a stream
+   *
+   * @param parser - The command parser
+   * @param key - The stream key
+   * @returns The number of entries inside the stream
+   * @see https://redis.io/commands/xlen/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('XLEN');
     parser.pushKey(key);

--- a/packages/client/lib/commands/XPENDING.ts
+++ b/packages/client/lib/commands/XPENDING.ts
@@ -1,6 +1,14 @@
 import { CommandParser } from '../client/parser';
 import { RedisArgument, BlobStringReply, NullReply, ArrayReply, TuplesReply, NumberReply, UnwrapReply, Command } from '../RESP/types';
 
+/**
+ * Raw reply structure for XPENDING command
+ * 
+ * @property pending - Number of pending messages in the group
+ * @property firstId - ID of the first pending message
+ * @property lastId - ID of the last pending message
+ * @property consumers - Array of consumer info with delivery counts
+ */
 type XPendingRawReply = TuplesReply<[
   pending: NumberReply,
   firstId: BlobStringReply | NullReply,
@@ -14,11 +22,26 @@ type XPendingRawReply = TuplesReply<[
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the XPENDING command to inspect pending messages of a consumer group
+   *
+   * @param parser - The command parser
+   * @param key - The stream key
+   * @param group - Name of the consumer group
+   * @returns Summary of pending messages including total count, ID range, and per-consumer stats 
+   * @see https://redis.io/commands/xpending/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, group: RedisArgument) {
     parser.push('XPENDING');
     parser.pushKey(key);
     parser.push(group);
   },
+  /**
+   * Transforms the raw XPENDING reply into a structured object
+   * 
+   * @param reply - Raw reply from Redis
+   * @returns Object containing pending count, ID range, and consumer statistics
+   */
   transformReply(reply: UnwrapReply<XPendingRawReply>) {
     const consumers = reply[3] as unknown as UnwrapReply<typeof reply[3]>;
     return {

--- a/packages/client/lib/commands/XPENDING_RANGE.ts
+++ b/packages/client/lib/commands/XPENDING_RANGE.ts
@@ -1,11 +1,25 @@
 import { CommandParser } from '../client/parser';
 import { RedisArgument, ArrayReply, TuplesReply, BlobStringReply, NumberReply, UnwrapReply, Command } from '../RESP/types';
 
+/**
+ * Options for the XPENDING RANGE command
+ * 
+ * @property IDLE - Filter by message idle time in milliseconds
+ * @property consumer - Filter by specific consumer name
+ */
 export interface XPendingRangeOptions {
   IDLE?: number;
   consumer?: RedisArgument;
 }
 
+/**
+ * Raw reply structure for XPENDING RANGE command
+ * 
+ * @property id - Message ID
+ * @property consumer - Name of the consumer that holds the message
+ * @property millisecondsSinceLastDelivery - Time since last delivery attempt
+ * @property deliveriesCounter - Number of times this message was delivered
+ */
 type XPendingRangeRawReply = ArrayReply<TuplesReply<[
   id: BlobStringReply,
   consumer: BlobStringReply,
@@ -16,6 +30,19 @@ type XPendingRangeRawReply = ArrayReply<TuplesReply<[
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the XPENDING command with range parameters to get detailed information about pending messages
+   *
+   * @param parser - The command parser
+   * @param key - The stream key
+   * @param group - Name of the consumer group
+   * @param start - Start of ID range (use '-' for minimum ID)
+   * @param end - End of ID range (use '+' for maximum ID)
+   * @param count - Maximum number of messages to return
+   * @param options - Additional filtering options
+   * @returns Array of pending message details
+   * @see https://redis.io/commands/xpending/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,
@@ -39,6 +66,12 @@ export default {
       parser.push(options.consumer);
     }
   },
+  /**
+   * Transforms the raw XPENDING RANGE reply into a structured array of message details
+   * 
+   * @param reply - Raw reply from Redis
+   * @returns Array of objects containing message ID, consumer, idle time, and delivery count
+   */
   transformReply(reply: UnwrapReply<XPendingRangeRawReply>) {
     return reply.map(pending => {
       const unwrapped = pending as unknown as UnwrapReply<typeof pending>;

--- a/packages/client/lib/commands/XRANGE.ts
+++ b/packages/client/lib/commands/XRANGE.ts
@@ -2,10 +2,23 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, ArrayReply, UnwrapReply, Command, TypeMapping } from '../RESP/types';
 import { StreamMessageRawReply, transformStreamMessageReply } from './generic-transformers';
 
+/**
+ * Options for the XRANGE command
+ * 
+ * @property COUNT - Limit the number of entries returned
+ */
 export interface XRangeOptions {
   COUNT?: number;
 }
 
+/**
+ * Helper function to build XRANGE command arguments
+ * 
+ * @param start - Start of ID range (use '-' for minimum ID)
+ * @param end - End of ID range (use '+' for maximum ID)
+ * @param options - Additional options for the range query
+ * @returns Array of arguments for the XRANGE command
+ */
 export function xRangeArguments(
   start: RedisArgument,
   end: RedisArgument,
@@ -23,11 +36,28 @@ export function xRangeArguments(
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the XRANGE command to read stream entries in a specific range
+   *
+   * @param parser - The command parser
+   * @param key - The stream key
+   * @param args - Arguments tuple containing start ID, end ID, and options
+   * @returns Array of messages in the specified range
+   * @see https://redis.io/commands/xrange/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, ...args: Parameters<typeof xRangeArguments>) {
     parser.push('XRANGE');
     parser.pushKey(key);
     parser.pushVariadic(xRangeArguments(args[0], args[1], args[2]));
   },
+  /**
+   * Transforms the raw XRANGE reply into structured message objects
+   * 
+   * @param reply - Raw reply from Redis
+   * @param preserve - Preserve options (unused)
+   * @param typeMapping - Type mapping for message fields
+   * @returns Array of structured message objects
+   */
   transformReply(
     reply: UnwrapReply<ArrayReply<StreamMessageRawReply>>,
     preserve?: any,

--- a/packages/client/lib/commands/XREAD.ts
+++ b/packages/client/lib/commands/XREAD.ts
@@ -2,6 +2,12 @@ import { CommandParser } from '../client/parser';
 import { Command, RedisArgument, ReplyUnion } from '../RESP/types';
 import { transformStreamsMessagesReplyResp2 } from './generic-transformers';
 
+/**
+ * Structure representing a stream to read from
+ * 
+ * @property key - The stream key
+ * @property id - The message ID to start reading from
+ */
 export interface XReadStream {
   key: RedisArgument;
   id: RedisArgument;
@@ -9,6 +15,12 @@ export interface XReadStream {
 
 export type XReadStreams = Array<XReadStream> | XReadStream;
 
+/**
+ * Helper function to push stream keys and IDs to the command parser
+ * 
+ * @param parser - The command parser
+ * @param streams - Single stream or array of streams to read from
+ */
 export function pushXReadStreams(parser: CommandParser, streams: XReadStreams) {
   parser.push('STREAMS');
 
@@ -25,6 +37,12 @@ export function pushXReadStreams(parser: CommandParser, streams: XReadStreams) {
   }
 }
 
+/**
+ * Options for the XREAD command
+ * 
+ * @property COUNT - Limit the number of entries returned per stream
+ * @property BLOCK - Milliseconds to block waiting for new entries (0 for indefinite)
+ */
 export interface XReadOptions {
   COUNT?: number;
   BLOCK?: number;
@@ -32,6 +50,15 @@ export interface XReadOptions {
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the XREAD command to read messages from one or more streams
+   *
+   * @param parser - The command parser
+   * @param streams - Single stream or array of streams to read from
+   * @param options - Additional options for reading streams
+   * @returns Array of stream entries, each containing the stream name and its messages
+   * @see https://redis.io/commands/xread/
+   */
   parseCommand(parser: CommandParser, streams: XReadStreams, options?: XReadOptions) {
     parser.push('XREAD');
 
@@ -45,6 +72,9 @@ export default {
 
     pushXReadStreams(parser, streams);
   },
+  /**
+   * Transform functions for different RESP versions
+   */
   transformReply: {
     2: transformStreamsMessagesReplyResp2,
     3: undefined as unknown as () => ReplyUnion

--- a/packages/client/lib/commands/XREADGROUP.ts
+++ b/packages/client/lib/commands/XREADGROUP.ts
@@ -3,6 +3,13 @@ import { Command, RedisArgument, ReplyUnion } from '../RESP/types';
 import { XReadStreams, pushXReadStreams } from './XREAD';
 import { transformStreamsMessagesReplyResp2 } from './generic-transformers';
 
+/**
+ * Options for the XREADGROUP command
+ * 
+ * @property COUNT - Limit the number of entries returned per stream
+ * @property BLOCK - Milliseconds to block waiting for new entries (0 for indefinite)
+ * @property NOACK - Skip adding the message to the PEL (Pending Entries List)
+ */
 export interface XReadGroupOptions {
   COUNT?: number;
   BLOCK?: number;
@@ -11,6 +18,17 @@ export interface XReadGroupOptions {
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Constructs the XREADGROUP command to read messages from streams as a consumer group member
+   *
+   * @param parser - The command parser
+   * @param group - Name of the consumer group
+   * @param consumer - Name of the consumer in the group
+   * @param streams - Single stream or array of streams to read from
+   * @param options - Additional options for reading streams
+   * @returns Array of stream entries, each containing the stream name and its messages
+   * @see https://redis.io/commands/xreadgroup/
+   */
   parseCommand(
     parser: CommandParser,
     group: RedisArgument,
@@ -34,6 +52,9 @@ export default {
 
     pushXReadStreams(parser, streams);
   },
+  /**
+   * Transform functions for different RESP versions
+   */
   transformReply: {
     2: transformStreamsMessagesReplyResp2,
     3: undefined as unknown as () => ReplyUnion

--- a/packages/client/lib/commands/XREVRANGE.ts
+++ b/packages/client/lib/commands/XREVRANGE.ts
@@ -2,13 +2,30 @@ import { CommandParser } from '../client/parser';
 import { Command, RedisArgument } from '../RESP/types';
 import XRANGE, { xRangeArguments } from './XRANGE';
 
+/**
+ * Options for the XREVRANGE command
+ * 
+ * @property COUNT - Limit the number of entries returned
+ */
 export interface XRevRangeOptions {
   COUNT?: number;
 }
 
+/**
+ * Command for reading stream entries in reverse order
+ */
 export default {
   CACHEABLE: XRANGE.CACHEABLE,
   IS_READ_ONLY: XRANGE.IS_READ_ONLY,
+  /**
+   * Constructs the XREVRANGE command to read stream entries in reverse order
+   *
+   * @param parser - The command parser
+   * @param key - The stream key
+   * @param args - Arguments tuple containing start ID, end ID, and options
+   * @returns Array of messages in the specified range in reverse order
+   * @see https://redis.io/commands/xrevrange/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, ...args: Parameters<typeof xRangeArguments>) {
     parser.push('XREVRANGE');
     parser.pushKey(key);

--- a/packages/client/lib/commands/XTRIM.ts
+++ b/packages/client/lib/commands/XTRIM.ts
@@ -1,14 +1,34 @@
 import { CommandParser } from '../client/parser';
 import { NumberReply, Command, RedisArgument } from '../RESP/types';
 
+/**
+ * Options for the XTRIM command
+ * 
+ * @property strategyModifier - Exact ('=') or approximate ('~') trimming
+ * @property LIMIT - Maximum number of entries to trim in one call (Redis 6.2+)
+ */
 export interface XTrimOptions {
   strategyModifier?: '=' | '~';
   /** added in 6.2 */
   LIMIT?: number;
 }
 
+/**
+ * Command for trimming a stream to a specified length or minimum ID
+ */
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Constructs the XTRIM command to trim a stream by length or minimum ID
+   *
+   * @param parser - The command parser
+   * @param key - The stream key
+   * @param strategy - Trim by maximum length (MAXLEN) or minimum ID (MINID)
+   * @param threshold - Maximum length or minimum ID threshold
+   * @param options - Additional options for trimming
+   * @returns Number of entries removed from the stream
+   * @see https://redis.io/commands/xtrim/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/ZADD.ts
+++ b/packages/client/lib/commands/ZADD.ts
@@ -2,6 +2,9 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, Command } from '../RESP/types';
 import { SortedSetMember, transformDoubleArgument, transformDoubleReply } from './generic-transformers';
 
+/**
+ * Options for the ZADD command
+ */
 export interface ZAddOptions {
   condition?: 'NX' | 'XX';
   /**
@@ -24,7 +27,20 @@ export interface ZAddOptions {
   CH?: boolean;
 }
 
+/**
+ * Command for adding members to a sorted set
+ */
 export default {
+  /**
+   * Constructs the ZADD command to add one or more members to a sorted set
+   *
+   * @param parser - The command parser
+   * @param key - The sorted set key
+   * @param members - One or more members to add with their scores
+   * @param options - Additional options for adding members
+   * @returns Number of new members added (or changed members if CH is set)
+   * @see https://redis.io/commands/zadd/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,
@@ -59,6 +75,12 @@ export default {
   transformReply: transformDoubleReply
 } as const satisfies Command;
 
+/**
+ * Helper function to push sorted set members to the command
+ * 
+ * @param parser - The command parser
+ * @param members - One or more members with their scores
+ */
 export function pushMembers(
   parser: CommandParser,
   members: SortedSetMember | Array<SortedSetMember>) {
@@ -71,6 +93,12 @@ export function pushMembers(
   }
 }
 
+/**
+ * Helper function to push a single sorted set member to the command
+ * 
+ * @param parser - The command parser
+ * @param member - Member with its score
+ */
 function pushMember(
   parser: CommandParser,
   member: SortedSetMember

--- a/packages/client/lib/commands/ZADD_INCR.ts
+++ b/packages/client/lib/commands/ZADD_INCR.ts
@@ -3,13 +3,33 @@ import { RedisArgument, Command } from '../RESP/types';
 import { pushMembers } from './ZADD';
 import { SortedSetMember, transformNullableDoubleReply } from './generic-transformers';
 
+/**
+ * Options for the ZADD INCR command
+ * 
+ * @property condition - Add condition: NX (only if not exists) or XX (only if exists)
+ * @property comparison - Score comparison: LT (less than) or GT (greater than)
+ * @property CH - Return the number of changed elements instead of added elements
+ */
 export interface ZAddOptions {
   condition?: 'NX' | 'XX';
   comparison?: 'LT' | 'GT';
   CH?: boolean;
 }
 
+/**
+ * Command for incrementing the score of a member in a sorted set
+ */
 export default {
+  /**
+   * Constructs the ZADD command with INCR option to increment the score of a member
+   *
+   * @param parser - The command parser
+   * @param key - The sorted set key
+   * @param members - Member(s) whose score to increment
+   * @param options - Additional options for the increment operation
+   * @returns The new score of the member after increment (null if member does not exist with XX option)
+   * @see https://redis.io/commands/zadd/
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/ZCARD.ts
+++ b/packages/client/lib/commands/ZCARD.ts
@@ -1,9 +1,20 @@
 import { CommandParser } from '../client/parser';
 import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
+/**
+ * Command for getting the number of members in a sorted set
+ */
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Constructs the ZCARD command to get the cardinality (number of members) of a sorted set
+   *
+   * @param parser - The command parser
+   * @param key - The sorted set key
+   * @returns Number of members in the sorted set
+   * @see https://redis.io/commands/zcard/
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('ZCARD');
     parser.pushKey(key);

--- a/packages/client/lib/commands/ZCOUNT.ts
+++ b/packages/client/lib/commands/ZCOUNT.ts
@@ -5,6 +5,13 @@ import { transformStringDoubleArgument } from './generic-transformers';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the number of elements in the sorted set with a score between min and max.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param min - Minimum score to count from (inclusive).
+   * @param max - Maximum score to count to (inclusive).
+   */
   parseCommand(
     parser: CommandParser, 
     key: RedisArgument,

--- a/packages/client/lib/commands/ZDIFF.ts
+++ b/packages/client/lib/commands/ZDIFF.ts
@@ -4,6 +4,11 @@ import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the difference between the first sorted set and all the successive sorted sets.
+   * @param parser - The Redis command parser.
+   * @param keys - Keys of the sorted sets.
+   */
   parseCommand(parser: CommandParser, keys: RedisVariadicArgument) {
     parser.push('ZDIFF');
     parser.pushKeysLength(keys);

--- a/packages/client/lib/commands/ZDIFFSTORE.ts
+++ b/packages/client/lib/commands/ZDIFFSTORE.ts
@@ -4,6 +4,12 @@ import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Computes the difference between the first and all successive sorted sets and stores it in a new key.
+   * @param parser - The Redis command parser.
+   * @param destination - Destination key where the result will be stored.
+   * @param inputKeys - Keys of the sorted sets to find the difference between.
+   */
   parseCommand(parser: CommandParser, destination: RedisArgument, inputKeys: RedisVariadicArgument) {
     parser.push('ZDIFFSTORE');
     parser.pushKey(destination);

--- a/packages/client/lib/commands/ZDIFF_WITHSCORES.ts
+++ b/packages/client/lib/commands/ZDIFF_WITHSCORES.ts
@@ -6,6 +6,11 @@ import ZDIFF from './ZDIFF';
 
 export default {
   IS_READ_ONLY: ZDIFF.IS_READ_ONLY,
+  /**
+   * Returns the difference between the first sorted set and all successive sorted sets with their scores.
+   * @param parser - The Redis command parser.
+   * @param keys - Keys of the sorted sets.
+   */
   parseCommand(parser: CommandParser, keys: RedisVariadicArgument) {
     ZDIFF.parseCommand(parser, keys);
     parser.push('WITHSCORES');

--- a/packages/client/lib/commands/ZINCRBY.ts
+++ b/packages/client/lib/commands/ZINCRBY.ts
@@ -3,6 +3,13 @@ import { RedisArgument, Command } from '../RESP/types';
 import { transformDoubleArgument, transformDoubleReply } from './generic-transformers';
 
 export default {
+  /**
+   * Increments the score of a member in a sorted set by the specified increment.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param increment - Value to increment the score by.
+   * @param member - Member whose score should be incremented.
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/ZINTER.ts
+++ b/packages/client/lib/commands/ZINTER.ts
@@ -29,6 +29,12 @@ export function parseZInterArguments(
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Intersects multiple sorted sets and returns the result as a new sorted set.
+   * @param parser - The Redis command parser.
+   * @param keys - Keys of the sorted sets to intersect.
+   * @param options - Optional parameters for the intersection operation.
+   */
   parseCommand(parser: CommandParser, keys: ZInterKeysType, options?: ZInterOptions) {
     parser.push('ZINTER');
     parseZInterArguments(parser, keys, options);

--- a/packages/client/lib/commands/ZINTERCARD.ts
+++ b/packages/client/lib/commands/ZINTERCARD.ts
@@ -8,6 +8,12 @@ export interface ZInterCardOptions {
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the cardinality of the intersection of multiple sorted sets.
+   * @param parser - The Redis command parser.
+   * @param keys - Keys of the sorted sets to intersect.
+   * @param options - Limit option or options object with limit.
+   */
   parseCommand(
     parser: CommandParser,
     keys: RedisVariadicArgument,

--- a/packages/client/lib/commands/ZINTERSTORE.ts
+++ b/packages/client/lib/commands/ZINTERSTORE.ts
@@ -6,6 +6,13 @@ import { parseZInterArguments, ZInterOptions } from './ZINTER';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Stores the result of intersection of multiple sorted sets in a new sorted set.
+   * @param parser - The Redis command parser.
+   * @param destination - Destination key where the result will be stored.
+   * @param keys - Keys of the sorted sets to intersect.
+   * @param options - Optional parameters for the intersection operation.
+   */
   parseCommand(
     parser: CommandParser,
     destination: RedisArgument,

--- a/packages/client/lib/commands/ZINTER_WITHSCORES.ts
+++ b/packages/client/lib/commands/ZINTER_WITHSCORES.ts
@@ -5,6 +5,10 @@ import ZINTER from './ZINTER';
 
 export default {
   IS_READ_ONLY: ZINTER.IS_READ_ONLY,
+  /**
+   * Intersects multiple sorted sets and returns the result with scores.
+   * @param args - Same parameters as ZINTER command.
+   */
   parseCommand(...args: Parameters<typeof ZINTER.parseCommand>) {
     ZINTER.parseCommand(...args);
     args[0].push('WITHSCORES');

--- a/packages/client/lib/commands/ZLEXCOUNT.ts
+++ b/packages/client/lib/commands/ZLEXCOUNT.ts
@@ -4,6 +4,13 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the number of elements in the sorted set between the lexicographical range specified by min and max.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param min - Minimum lexicographical value (inclusive).
+   * @param max - Maximum lexicographical value (inclusive).
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/ZMPOP.ts
+++ b/packages/client/lib/commands/ZMPOP.ts
@@ -33,6 +33,13 @@ export type ZMPopArguments = Tail<Parameters<typeof parseZMPopArguments>>;
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Removes and returns up to count members with the highest/lowest scores from the first non-empty sorted set.
+   * @param parser - The Redis command parser.
+   * @param keys - Keys of the sorted sets to pop from.
+   * @param side - Side to pop from (MIN or MAX).
+   * @param options - Optional parameters including COUNT.
+   */
   parseCommand(
     parser: CommandParser,
     keys: RedisVariadicArgument,

--- a/packages/client/lib/commands/ZMSCORE.ts
+++ b/packages/client/lib/commands/ZMSCORE.ts
@@ -5,6 +5,12 @@ import { createTransformNullableDoubleReplyResp2Func, RedisVariadicArgument } fr
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the scores associated with the specified members in the sorted set stored at key.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param member - One or more members to get scores for.
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, member: RedisVariadicArgument) {
     parser.push('ZMSCORE');
     parser.pushKey(key);

--- a/packages/client/lib/commands/ZPOPMAX.ts
+++ b/packages/client/lib/commands/ZPOPMAX.ts
@@ -4,6 +4,11 @@ import { transformDoubleReply } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Removes and returns the member with the highest score in the sorted set.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('ZPOPMAX');
     parser.pushKey(key);

--- a/packages/client/lib/commands/ZPOPMAX_COUNT.ts
+++ b/packages/client/lib/commands/ZPOPMAX_COUNT.ts
@@ -4,6 +4,12 @@ import { transformSortedSetReply } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Removes and returns up to count members with the highest scores in the sorted set.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param count - Number of members to pop.
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, count: number) {
     parser.push('ZPOPMAX');
     parser.pushKey(key);

--- a/packages/client/lib/commands/ZPOPMIN.ts
+++ b/packages/client/lib/commands/ZPOPMIN.ts
@@ -4,6 +4,11 @@ import ZPOPMAX from './ZPOPMAX';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Removes and returns the member with the lowest score in the sorted set.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('ZPOPMIN');
     parser.pushKey(key);

--- a/packages/client/lib/commands/ZPOPMIN_COUNT.ts
+++ b/packages/client/lib/commands/ZPOPMIN_COUNT.ts
@@ -4,6 +4,12 @@ import { transformSortedSetReply } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Removes and returns up to count members with the lowest scores in the sorted set.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param count - Number of members to pop.
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, count: number) {
     parser.push('ZPOPMIN');
     parser.pushKey(key);

--- a/packages/client/lib/commands/ZRANDMEMBER.ts
+++ b/packages/client/lib/commands/ZRANDMEMBER.ts
@@ -3,6 +3,11 @@ import { RedisArgument, BlobStringReply, NullReply, Command } from '../RESP/type
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns a random member from a sorted set.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('ZRANDMEMBER');
     parser.pushKey(key);

--- a/packages/client/lib/commands/ZRANDMEMBER_COUNT.ts
+++ b/packages/client/lib/commands/ZRANDMEMBER_COUNT.ts
@@ -4,6 +4,12 @@ import ZRANDMEMBER from './ZRANDMEMBER';
 
 export default {
   IS_READ_ONLY: ZRANDMEMBER.IS_READ_ONLY,
+  /**
+   * Returns one or more random members from a sorted set.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param count - Number of members to return.
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, count: number) {
     ZRANDMEMBER.parseCommand(parser, key);
     parser.push(count.toString());

--- a/packages/client/lib/commands/ZRANDMEMBER_COUNT_WITHSCORES.ts
+++ b/packages/client/lib/commands/ZRANDMEMBER_COUNT_WITHSCORES.ts
@@ -5,6 +5,12 @@ import ZRANDMEMBER_COUNT from './ZRANDMEMBER_COUNT';
 
 export default {
   IS_READ_ONLY: ZRANDMEMBER_COUNT.IS_READ_ONLY,
+  /**
+   * Returns one or more random members with their scores from a sorted set.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param count - Number of members to return.
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, count: number) {
     ZRANDMEMBER_COUNT.parseCommand(parser, key, count);
     parser.push('WITHSCORES');

--- a/packages/client/lib/commands/ZRANGE.ts
+++ b/packages/client/lib/commands/ZRANGE.ts
@@ -49,6 +49,14 @@ export function zRangeArgument(
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the specified range of elements in the sorted set.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param min - Minimum index, score or lexicographical value.
+   * @param max - Maximum index, score or lexicographical value.
+   * @param options - Optional parameters for range retrieval (BY, REV, LIMIT).
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/ZRANGEBYLEX.ts
+++ b/packages/client/lib/commands/ZRANGEBYLEX.ts
@@ -12,6 +12,14 @@ export interface ZRangeByLexOptions {
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns all the elements in the sorted set at key with a lexicographical value between min and max.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param min - Minimum lexicographical value.
+   * @param max - Maximum lexicographical value.
+   * @param options - Optional parameters including LIMIT.
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/ZRANGEBYSCORE.ts
+++ b/packages/client/lib/commands/ZRANGEBYSCORE.ts
@@ -14,6 +14,14 @@ export declare function transformReply(): Array<RedisArgument>;
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns all the elements in the sorted set with a score between min and max.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param min - Minimum score.
+   * @param max - Maximum score.
+   * @param options - Optional parameters including LIMIT.
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/ZRANGEBYSCORE_WITHSCORES.ts
+++ b/packages/client/lib/commands/ZRANGEBYSCORE_WITHSCORES.ts
@@ -5,6 +5,10 @@ import ZRANGEBYSCORE from './ZRANGEBYSCORE';
 export default {
   CACHEABLE: ZRANGEBYSCORE.CACHEABLE,
   IS_READ_ONLY: ZRANGEBYSCORE.IS_READ_ONLY,
+  /**
+   * Returns all the elements in the sorted set with a score between min and max, with their scores.
+   * @param args - Same parameters as the ZRANGEBYSCORE command.
+   */
   parseCommand(...args: Parameters<typeof ZRANGEBYSCORE.parseCommand>) {
     const parser = args[0];
 

--- a/packages/client/lib/commands/ZRANGESTORE.ts
+++ b/packages/client/lib/commands/ZRANGESTORE.ts
@@ -13,6 +13,15 @@ export interface ZRangeStoreOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Stores the result of a range operation on a sorted set into a new sorted set.
+   * @param parser - The Redis command parser.
+   * @param destination - Destination key where the result will be stored.
+   * @param source - Key of the source sorted set.
+   * @param min - Minimum index, score or lexicographical value.
+   * @param max - Maximum index, score or lexicographical value.
+   * @param options - Optional parameters for the range operation (BY, REV, LIMIT).
+   */
   parseCommand(
     parser: CommandParser,
     destination: RedisArgument,

--- a/packages/client/lib/commands/ZRANGE_WITHSCORES.ts
+++ b/packages/client/lib/commands/ZRANGE_WITHSCORES.ts
@@ -5,6 +5,10 @@ import ZRANGE from './ZRANGE';
 export default {
   CACHEABLE: ZRANGE.CACHEABLE,
   IS_READ_ONLY: ZRANGE.IS_READ_ONLY,
+  /**
+   * Returns the specified range of elements in the sorted set with their scores.
+   * @param args - Same parameters as the ZRANGE command.
+   */
   parseCommand(...args: Parameters<typeof ZRANGE.parseCommand>) {
     const parser = args[0];
 

--- a/packages/client/lib/commands/ZRANK.ts
+++ b/packages/client/lib/commands/ZRANK.ts
@@ -4,6 +4,12 @@ import { RedisArgument, NumberReply, NullReply, Command } from '../RESP/types';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the rank of a member in the sorted set, with scores ordered from low to high.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param member - Member to get the rank for.
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, member: RedisArgument) {
     parser.push('ZRANK');
     parser.pushKey(key);

--- a/packages/client/lib/commands/ZRANK_WITHSCORE.ts
+++ b/packages/client/lib/commands/ZRANK_WITHSCORE.ts
@@ -4,6 +4,10 @@ import ZRANK from './ZRANK';
 export default {
   CACHEABLE: ZRANK.CACHEABLE,
   IS_READ_ONLY: ZRANK.IS_READ_ONLY,
+  /**
+   * Returns the rank of a member in the sorted set with its score.
+   * @param args - Same parameters as the ZRANK command.
+   */
   parseCommand(...args: Parameters<typeof ZRANK.parseCommand>) {
     const parser = args[0];
 

--- a/packages/client/lib/commands/ZREM.ts
+++ b/packages/client/lib/commands/ZREM.ts
@@ -4,6 +4,12 @@ import { RedisVariadicArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Removes the specified members from the sorted set.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param member - One or more members to remove.
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/ZREMRANGEBYLEX.ts
+++ b/packages/client/lib/commands/ZREMRANGEBYLEX.ts
@@ -4,6 +4,13 @@ import { transformStringDoubleArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Removes all elements in the sorted set with lexicographical values between min and max.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param min - Minimum lexicographical value.
+   * @param max - Maximum lexicographical value.
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/ZREMRANGEBYRANK.ts
+++ b/packages/client/lib/commands/ZREMRANGEBYRANK.ts
@@ -3,6 +3,13 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Removes all elements in the sorted set with rank between start and stop.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param start - Minimum rank (starting from 0).
+   * @param stop - Maximum rank.
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/ZREMRANGEBYSCORE.ts
+++ b/packages/client/lib/commands/ZREMRANGEBYSCORE.ts
@@ -4,6 +4,13 @@ import { transformStringDoubleArgument } from './generic-transformers';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Removes all elements in the sorted set with scores between min and max.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param min - Minimum score.
+   * @param max - Maximum score.
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/ZREVRANK.ts
+++ b/packages/client/lib/commands/ZREVRANK.ts
@@ -4,6 +4,12 @@ import { NumberReply, NullReply, Command, RedisArgument } from '../RESP/types';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the rank of a member in the sorted set, with scores ordered from high to low.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param member - Member to get the rank for.
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, member: RedisArgument) {
     parser.push('ZREVRANK');
     parser.pushKey(key);

--- a/packages/client/lib/commands/ZSCAN.ts
+++ b/packages/client/lib/commands/ZSCAN.ts
@@ -10,6 +10,13 @@ export interface HScanEntry {
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Incrementally iterates over a sorted set.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param cursor - Cursor position to start the scan from.
+   * @param options - Optional scan parameters (COUNT, MATCH, TYPE).
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/client/lib/commands/ZSCORE.ts
+++ b/packages/client/lib/commands/ZSCORE.ts
@@ -6,6 +6,12 @@ import { transformNullableDoubleReply } from './generic-transformers';
 export default {
   CACHEABLE: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the score of a member in a sorted set.
+   * @param parser - The Redis command parser.
+   * @param key - Key of the sorted set.
+   * @param member - Member to get the score for.
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, member: RedisArgument) {
     parser.push('ZSCORE');
     parser.pushKey(key);

--- a/packages/client/lib/commands/ZUNION.ts
+++ b/packages/client/lib/commands/ZUNION.ts
@@ -8,6 +8,12 @@ export interface ZUnionOptions {
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the union of multiple sorted sets.
+   * @param parser - The Redis command parser.
+   * @param keys - Keys of the sorted sets to combine.
+   * @param options - Optional parameters for the union operation.
+   */
   parseCommand(parser: CommandParser, keys: ZKeys, options?: ZUnionOptions) {
     parser.push('ZUNION');
     parseZKeysArguments(parser, keys);

--- a/packages/client/lib/commands/ZUNIONSTORE.ts
+++ b/packages/client/lib/commands/ZUNIONSTORE.ts
@@ -8,6 +8,13 @@ export interface ZUnionOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Stores the union of multiple sorted sets in a new sorted set.
+   * @param parser - The Redis command parser.
+   * @param destination - Destination key where the result will be stored.
+   * @param keys - Keys of the sorted sets to combine.
+   * @param options - Optional parameters for the union operation.
+   */
   parseCommand(
     parser: CommandParser,
     destination: RedisArgument,

--- a/packages/client/lib/commands/ZUNION_WITHSCORES.ts
+++ b/packages/client/lib/commands/ZUNION_WITHSCORES.ts
@@ -5,6 +5,10 @@ import ZUNION from './ZUNION';
 
 export default {
   IS_READ_ONLY: ZUNION.IS_READ_ONLY,
+  /**
+   * Returns the union of multiple sorted sets with their scores.
+   * @param args - Same parameters as the ZUNION command.
+   */
   parseCommand(...args: Parameters<typeof ZUNION.parseCommand>) {
     const parser = args[0];
 

--- a/packages/client/lib/sentinel/commands/SENTINEL_MASTER.ts
+++ b/packages/client/lib/sentinel/commands/SENTINEL_MASTER.ts
@@ -3,6 +3,11 @@ import { CommandParser } from '../../client/parser';
 import { transformTuplesReply } from '../../commands/generic-transformers';
 
 export default {
+  /**
+   * Returns information about the specified master.
+   * @param parser - The Redis command parser.
+   * @param dbname - Name of the master.
+   */
   parseCommand(parser: CommandParser, dbname: RedisArgument) {
     parser.push('SENTINEL', 'MASTER', dbname);
   },

--- a/packages/client/lib/sentinel/commands/SENTINEL_MONITOR.ts
+++ b/packages/client/lib/sentinel/commands/SENTINEL_MONITOR.ts
@@ -2,6 +2,14 @@ import { CommandParser } from '../../client/parser';
 import { RedisArgument, SimpleStringReply, Command } from '../../RESP/types';
 
 export default {
+  /**
+   * Instructs a Sentinel to monitor a new master with the specified parameters.
+   * @param parser - The Redis command parser.
+   * @param dbname - Name that identifies the master.
+   * @param host - Host of the master.
+   * @param port - Port of the master.
+   * @param quorum - Number of Sentinels that need to agree to trigger a failover.
+   */
   parseCommand(parser: CommandParser, dbname: RedisArgument, host: RedisArgument, port: RedisArgument, quorum: RedisArgument) {
     parser.push('SENTINEL', 'MONITOR', dbname, host, port, quorum);
   },

--- a/packages/client/lib/sentinel/commands/SENTINEL_REPLICAS.ts
+++ b/packages/client/lib/sentinel/commands/SENTINEL_REPLICAS.ts
@@ -3,6 +3,11 @@ import { RedisArgument, ArrayReply, BlobStringReply, MapReply, Command, TypeMapp
 import { transformTuplesReply } from '../../commands/generic-transformers';
 
 export default {
+  /**
+   * Returns a list of replicas for the specified master.
+   * @param parser - The Redis command parser.
+   * @param dbname - Name of the master.
+   */
   parseCommand(parser: CommandParser, dbname: RedisArgument) {
     parser.push('SENTINEL', 'REPLICAS', dbname);
   },

--- a/packages/client/lib/sentinel/commands/SENTINEL_SENTINELS.ts
+++ b/packages/client/lib/sentinel/commands/SENTINEL_SENTINELS.ts
@@ -3,6 +3,11 @@ import { RedisArgument, ArrayReply, MapReply, BlobStringReply, Command, TypeMapp
 import { transformTuplesReply } from '../../commands/generic-transformers';
 
 export default {
+  /**
+   * Returns a list of Sentinel instances for the specified master.
+   * @param parser - The Redis command parser.
+   * @param dbname - Name of the master.
+   */
   parseCommand(parser: CommandParser, dbname: RedisArgument) {
     parser.push('SENTINEL', 'SENTINELS', dbname);
   },

--- a/packages/client/lib/sentinel/commands/SENTINEL_SET.ts
+++ b/packages/client/lib/sentinel/commands/SENTINEL_SET.ts
@@ -7,6 +7,12 @@ export type SentinelSetOptions = Array<{
 }>;
 
 export default {
+  /**
+   * Sets configuration parameters for a specific master.
+   * @param parser - The Redis command parser.
+   * @param dbname - Name of the master.
+   * @param options - Configuration options to set as option-value pairs.
+   */
   parseCommand(parser: CommandParser, dbname: RedisArgument, options: SentinelSetOptions) {
     parser.push('SENTINEL', 'SET', dbname);
 

--- a/packages/json/lib/commands/ARRAPPEND.ts
+++ b/packages/json/lib/commands/ARRAPPEND.ts
@@ -4,6 +4,16 @@ import { RedisArgument, NumberReply, ArrayReply, NullReply, Command } from '@red
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Appends one or more values to the end of an array in a JSON document.
+   * Returns the new array length after append, or null if the path does not exist.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key to append to
+   * @param path - Path to the array in the JSON document
+   * @param json - The first value to append
+   * @param jsons - Additional values to append
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/json/lib/commands/ARRINDEX.ts
+++ b/packages/json/lib/commands/ARRINDEX.ts
@@ -11,6 +11,18 @@ export interface JsonArrIndexOptions {
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the index of the first occurrence of a value in a JSON array.
+   * If the specified value is not found, it returns -1, or null if the path does not exist.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the array
+   * @param path - Path to the array in the JSON document
+   * @param json - The value to search for
+   * @param options - Optional range parameters for the search
+   * @param options.range.start - Starting index for the search
+   * @param options.range.stop - Optional ending index for the search
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/json/lib/commands/ARRINSERT.ts
+++ b/packages/json/lib/commands/ARRINSERT.ts
@@ -4,6 +4,17 @@ import { RedisJSON, transformRedisJsonArgument } from './helpers';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Inserts one or more values into an array at the specified index.
+   * Returns the new array length after insert, or null if the path does not exist.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the array
+   * @param path - Path to the array in the JSON document
+   * @param index - The position where to insert the values
+   * @param json - The first value to insert
+   * @param jsons - Additional values to insert
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/json/lib/commands/ARRLEN.ts
+++ b/packages/json/lib/commands/ARRLEN.ts
@@ -7,6 +7,15 @@ export interface JsonArrLenOptions {
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the length of an array in a JSON document.
+   * Returns null if the path does not exist or the value is not an array.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the array
+   * @param options - Optional parameters
+   * @param options.path - Path to the array in the JSON document
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, options?: JsonArrLenOptions) {
     parser.push('JSON.ARRLEN');
     parser.pushKey(key);

--- a/packages/json/lib/commands/ARRPOP.ts
+++ b/packages/json/lib/commands/ARRPOP.ts
@@ -10,6 +10,16 @@ export interface RedisArrPopOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Removes and returns an element from an array in a JSON document.
+   * Returns null if the path does not exist or the value is not an array.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the array
+   * @param options - Optional parameters
+   * @param options.path - Path to the array in the JSON document
+   * @param options.index - Optional index to pop from. Default is -1 (last element)
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, options?: RedisArrPopOptions) {
     parser.push('JSON.ARRPOP');
     parser.pushKey(key);

--- a/packages/json/lib/commands/ARRTRIM.ts
+++ b/packages/json/lib/commands/ARRTRIM.ts
@@ -3,6 +3,16 @@ import { RedisArgument, ArrayReply, NumberReply, NullReply, Command } from '@red
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Trims an array in a JSON document to include only elements within the specified range.
+   * Returns the new array length after trimming, or null if the path does not exist.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the array
+   * @param path - Path to the array in the JSON document
+   * @param start - Starting index (inclusive)
+   * @param stop - Ending index (inclusive)
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, path: RedisArgument, start: number, stop: number) {
     parser.push('JSON.ARRTRIM');
     parser.pushKey(key);

--- a/packages/json/lib/commands/CLEAR.ts
+++ b/packages/json/lib/commands/CLEAR.ts
@@ -7,6 +7,15 @@ export interface JsonClearOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Clears container values (arrays/objects) in a JSON document.
+   * Returns the number of values cleared (0 or 1), or null if the path does not exist.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the JSON document
+   * @param options - Optional parameters
+   * @param options.path - Path to the container to clear
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, options?: JsonClearOptions) {
     parser.push('JSON.CLEAR');
     parser.pushKey(key);

--- a/packages/json/lib/commands/DEBUG_MEMORY.ts
+++ b/packages/json/lib/commands/DEBUG_MEMORY.ts
@@ -7,6 +7,15 @@ export interface JsonDebugMemoryOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Reports memory usage details for a JSON document value.
+   * Returns size in bytes of the value, or null if the key or path does not exist.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the JSON document
+   * @param options - Optional parameters
+   * @param options.path - Path to the value to examine
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, options?: JsonDebugMemoryOptions) {
     parser.push('JSON.DEBUG', 'MEMORY');
     parser.pushKey(key);

--- a/packages/json/lib/commands/DEL.ts
+++ b/packages/json/lib/commands/DEL.ts
@@ -7,6 +7,15 @@ export interface JsonDelOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Deletes a value from a JSON document.
+   * Returns the number of paths deleted (0 or 1), or null if the key does not exist.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the JSON document
+   * @param options - Optional parameters
+   * @param options.path - Path to the value to delete
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, options?: JsonDelOptions) {
     parser.push('JSON.DEL');
     parser.pushKey(key);

--- a/packages/json/lib/commands/FORGET.ts
+++ b/packages/json/lib/commands/FORGET.ts
@@ -7,6 +7,15 @@ export interface JsonForgetOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Alias for JSON.DEL - Deletes a value from a JSON document.
+   * Returns the number of paths deleted (0 or 1), or null if the key does not exist.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the JSON document
+   * @param options - Optional parameters 
+   * @param options.path - Path to the value to delete
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, options?: JsonForgetOptions) {
     parser.push('JSON.FORGET');
     parser.pushKey(key);

--- a/packages/json/lib/commands/GET.ts
+++ b/packages/json/lib/commands/GET.ts
@@ -9,6 +9,15 @@ export interface JsonGetOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Gets values from a JSON document.
+   * Returns the value at the specified path, or null if the key or path does not exist.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the JSON document
+   * @param options - Optional parameters
+   * @param options.path - Path(s) to the value(s) to retrieve
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/json/lib/commands/MERGE.ts
+++ b/packages/json/lib/commands/MERGE.ts
@@ -4,6 +4,15 @@ import { RedisJSON, transformRedisJsonArgument } from './helpers';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Merges a given JSON value into a JSON document.
+   * Returns OK on success, or null if the key does not exist.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the JSON document
+   * @param path - Path to merge into
+   * @param value - JSON value to merge
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, path: RedisArgument, value: RedisJSON) {
     parser.push('JSON.MERGE');
     parser.pushKey(key);

--- a/packages/json/lib/commands/MGET.ts
+++ b/packages/json/lib/commands/MGET.ts
@@ -4,6 +4,14 @@ import { transformRedisJsonNullReply } from './helpers';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Gets values at a specific path from multiple JSON documents.
+   * Returns an array of values at the path from each key, null for missing keys/paths.
+   * 
+   * @param parser - The Redis command parser
+   * @param keys - Array of keys containing JSON documents
+   * @param path - Path to retrieve from each document
+   */
   parseCommand(parser: CommandParser, keys: Array<RedisArgument>, path: RedisArgument) {
     parser.push('JSON.MGET');
     parser.pushKeys(keys);

--- a/packages/json/lib/commands/MSET.ts
+++ b/packages/json/lib/commands/MSET.ts
@@ -10,6 +10,16 @@ export interface JsonMSetItem {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Sets multiple JSON values in multiple documents.
+   * Returns OK on success.
+   * 
+   * @param parser - The Redis command parser
+   * @param items - Array of objects containing key, path, and value to set
+   * @param items[].key - The key containing the JSON document
+   * @param items[].path - Path in the document to set
+   * @param items[].value - JSON value to set at the path
+   */
   parseCommand(parser: CommandParser, items: Array<JsonMSetItem>) {
     parser.push('JSON.MSET');
 

--- a/packages/json/lib/commands/NUMINCRBY.ts
+++ b/packages/json/lib/commands/NUMINCRBY.ts
@@ -3,6 +3,15 @@ import { RedisArgument, ArrayReply, NumberReply, DoubleReply, NullReply, BlobStr
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Increments a numeric value stored in a JSON document by a given number.
+   * Returns the value after increment, or null if the key/path doesn't exist or value is not numeric.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the JSON document
+   * @param path - Path to the numeric value
+   * @param by - Amount to increment by
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, path: RedisArgument, by: number) {
     parser.push('JSON.NUMINCRBY');
     parser.pushKey(key);

--- a/packages/json/lib/commands/NUMMULTBY.ts
+++ b/packages/json/lib/commands/NUMMULTBY.ts
@@ -4,6 +4,15 @@ import NUMINCRBY from './NUMINCRBY';
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Multiplies a numeric value stored in a JSON document by a given number.
+   * Returns the value after multiplication, or null if the key/path doesn't exist or value is not numeric.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the JSON document
+   * @param path - Path to the numeric value
+   * @param by - Amount to multiply by
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, path: RedisArgument, by: number) {
     parser.push('JSON.NUMMULTBY');
     parser.pushKey(key);

--- a/packages/json/lib/commands/OBJKEYS.ts
+++ b/packages/json/lib/commands/OBJKEYS.ts
@@ -7,6 +7,15 @@ export interface JsonObjKeysOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Returns the keys in the object stored in a JSON document.
+   * Returns array of keys, array of arrays for multiple paths, or null if path doesn't exist.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the JSON document
+   * @param options - Optional parameters
+   * @param options.path - Path to the object to examine
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, options?: JsonObjKeysOptions) {
     parser.push('JSON.OBJKEYS');
     parser.pushKey(key);

--- a/packages/json/lib/commands/OBJLEN.ts
+++ b/packages/json/lib/commands/OBJLEN.ts
@@ -7,6 +7,15 @@ export interface JsonObjLenOptions {
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the number of keys in the object stored in a JSON document.
+   * Returns length of object, array of lengths for multiple paths, or null if path doesn't exist.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the JSON document
+   * @param options - Optional parameters
+   * @param options.path - Path to the object to examine
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, options?: JsonObjLenOptions) {
     parser.push('JSON.OBJLEN');
     parser.pushKey(key);

--- a/packages/json/lib/commands/RESP.ts
+++ b/packages/json/lib/commands/RESP.ts
@@ -5,6 +5,14 @@ type RESPReply = Array<string | number | RESPReply>;
 
 export default {
     IS_READ_ONLY: true,
+    /**
+     * Returns the JSON value at the specified path in RESP (Redis Serialization Protocol) format.
+     * Returns the value in RESP form, useful for language-independent processing.
+     * 
+     * @param parser - The Redis command parser
+     * @param key - The key containing the JSON document
+     * @param path - Optional path to the value in the document
+     */
     parseCommand(parser: CommandParser, key: RedisArgument, path?: string) {
       parser.push('JSON.RESP');
       parser.pushKey(key);

--- a/packages/json/lib/commands/SET.ts
+++ b/packages/json/lib/commands/SET.ts
@@ -16,6 +16,19 @@ export interface JsonSetOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Sets a JSON value at a specific path in a JSON document.
+   * Returns OK on success, or null if condition (NX/XX) is not met.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the JSON document
+   * @param path - Path in the document to set
+   * @param json - JSON value to set at the path
+   * @param options - Optional parameters
+   * @param options.condition - Set condition: NX (only if doesn't exist) or XX (only if exists)
+   * @deprecated options.NX - Use options.condition instead
+   * @deprecated options.XX - Use options.condition instead
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/json/lib/commands/STRAPPEND.ts
+++ b/packages/json/lib/commands/STRAPPEND.ts
@@ -8,6 +8,16 @@ export interface JsonStrAppendOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Appends a string to a string value stored in a JSON document.
+   * Returns new string length after append, or null if the path doesn't exist or value is not a string.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the JSON document
+   * @param append - String to append
+   * @param options - Optional parameters
+   * @param options.path - Path to the string value
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, append: string, options?: JsonStrAppendOptions) {
     parser.push('JSON.STRAPPEND');
     parser.pushKey(key);

--- a/packages/json/lib/commands/STRLEN.ts
+++ b/packages/json/lib/commands/STRLEN.ts
@@ -7,6 +7,15 @@ export interface JsonStrLenOptions {
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the length of a string value stored in a JSON document.
+   * Returns string length, array of lengths for multiple paths, or null if path doesn't exist.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the JSON document
+   * @param options - Optional parameters
+   * @param options.path - Path to the string value
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, options?: JsonStrLenOptions) {
     parser.push('JSON.STRLEN');
     parser.pushKey(key);

--- a/packages/json/lib/commands/TOGGLE.ts
+++ b/packages/json/lib/commands/TOGGLE.ts
@@ -3,6 +3,14 @@ import { RedisArgument, ArrayReply, NumberReply, NullReply, Command, } from '@re
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Toggles a boolean value stored in a JSON document.
+   * Returns 1 if value was toggled to true, 0 if toggled to false, or null if path doesn't exist.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the JSON document
+   * @param path - Path to the boolean value
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, path: RedisArgument) {
     parser.push('JSON.TOGGLE');
     parser.pushKey(key);

--- a/packages/json/lib/commands/TYPE.ts
+++ b/packages/json/lib/commands/TYPE.ts
@@ -7,6 +7,15 @@ export interface JsonTypeOptions {
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Returns the type of JSON value at a specific path in a JSON document.
+   * Returns the type as a string, array of types for multiple paths, or null if path doesn't exist.
+   * 
+   * @param parser - The Redis command parser
+   * @param key - The key containing the JSON document
+   * @param options - Optional parameters
+   * @param options.path - Path to examine
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, options?: JsonTypeOptions) {
     parser.push('JSON.TYPE');
     parser.pushKey(key);

--- a/packages/search/lib/commands/AGGREGATE.ts
+++ b/packages/search/lib/commands/AGGREGATE.ts
@@ -141,6 +141,18 @@ export interface AggregateReply {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: false,
+  /**
+   * Performs an aggregation query on a RediSearch index.
+   * @param parser - The command parser
+   * @param index - The index name to query
+   * @param query - The text query to use as filter, use * to indicate no filtering
+   * @param options - Optional parameters for aggregation:
+   *   - VERBATIM: disable stemming in query evaluation
+   *   - LOAD: specify fields to load from documents
+   *   - STEPS: sequence of aggregation steps (GROUPBY, SORTBY, APPLY, LIMIT, FILTER)
+   *   - PARAMS: bind parameters for query evaluation
+   *   - TIMEOUT: maximum time to run the query
+   */
   parseCommand(parser: CommandParser, index: RedisArgument, query: RedisArgument, options?: FtAggregateOptions) {
     parser.push('FT.AGGREGATE', index, query);
 

--- a/packages/search/lib/commands/AGGREGATE_WITHCURSOR.ts
+++ b/packages/search/lib/commands/AGGREGATE_WITHCURSOR.ts
@@ -19,6 +19,16 @@ export interface AggregateWithCursorReply extends AggregateReply {
 
 export default {
   IS_READ_ONLY: AGGREGATE.IS_READ_ONLY,
+  /**
+   * Performs an aggregation with a cursor for retrieving large result sets.
+   * @param parser - The command parser
+   * @param index - Name of the index to query
+   * @param query - The aggregation query
+   * @param options - Optional parameters:
+   *   - All options supported by FT.AGGREGATE
+   *   - COUNT: Number of results to return per cursor fetch
+   *   - MAXIDLE: Maximum idle time for cursor in milliseconds
+   */
   parseCommand(parser: CommandParser, index: RedisArgument, query: RedisArgument, options?: FtAggregateWithCursorOptions) {
     AGGREGATE.parseCommand(parser, index, query, options);
     parser.push('WITHCURSOR');

--- a/packages/search/lib/commands/ALIASADD.ts
+++ b/packages/search/lib/commands/ALIASADD.ts
@@ -4,6 +4,12 @@ import { RedisArgument, SimpleStringReply, Command } from '@redis/client/dist/li
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Adds an alias to a RediSearch index.
+   * @param parser - The command parser
+   * @param alias - The alias to add
+   * @param index - The index name to alias
+   */
   parseCommand(parser: CommandParser, alias: RedisArgument, index: RedisArgument) {
     parser.push('FT.ALIASADD', alias, index);
   },

--- a/packages/search/lib/commands/ALIASDEL.ts
+++ b/packages/search/lib/commands/ALIASDEL.ts
@@ -4,6 +4,11 @@ import { RedisArgument, SimpleStringReply, Command } from '@redis/client/dist/li
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Removes an existing alias from a RediSearch index.
+   * @param parser - The command parser
+   * @param alias - The alias to remove
+   */
   parseCommand(parser: CommandParser, alias: RedisArgument) {
     parser.push('FT.ALIASDEL', alias);
   },

--- a/packages/search/lib/commands/ALIASUPDATE.ts
+++ b/packages/search/lib/commands/ALIASUPDATE.ts
@@ -4,6 +4,12 @@ import { SimpleStringReply, Command, RedisArgument } from '@redis/client/dist/li
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Updates the index pointed to by an existing alias.
+   * @param parser - The command parser
+   * @param alias - The existing alias to update
+   * @param index - The new index name that the alias should point to
+   */
   parseCommand(parser: CommandParser, alias: RedisArgument, index: RedisArgument) {
     parser.push('FT.ALIASUPDATE', alias, index);
   },

--- a/packages/search/lib/commands/ALTER.ts
+++ b/packages/search/lib/commands/ALTER.ts
@@ -5,6 +5,12 @@ import { RediSearchSchema, parseSchema } from './CREATE';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Alters an existing RediSearch index schema by adding new fields.
+   * @param parser - The command parser
+   * @param index - The index to alter
+   * @param schema - The schema definition containing new fields to add
+   */
   parseCommand(parser: CommandParser, index: RedisArgument, schema: RediSearchSchema) {
     parser.push('FT.ALTER', index, 'SCHEMA', 'ADD');
     parseSchema(parser, schema);

--- a/packages/search/lib/commands/CONFIG_GET.ts
+++ b/packages/search/lib/commands/CONFIG_GET.ts
@@ -4,6 +4,11 @@ import { ArrayReply, TuplesReply, BlobStringReply, NullReply, UnwrapReply, Comma
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Gets a RediSearch configuration option value.
+   * @param parser - The command parser
+   * @param option - The name of the configuration option to retrieve
+   */
   parseCommand(parser: CommandParser, option: string) {
     parser.push('FT.CONFIG', 'GET', option);
   },

--- a/packages/search/lib/commands/CONFIG_SET.ts
+++ b/packages/search/lib/commands/CONFIG_SET.ts
@@ -8,6 +8,12 @@ type FtConfigProperties = 'a' | 'b' | (string & {}) | Buffer;
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Sets a RediSearch configuration option value.
+   * @param parser - The command parser
+   * @param property - The name of the configuration option to set
+   * @param value - The value to set for the configuration option
+   */
   parseCommand(parser: CommandParser, property: FtConfigProperties, value: RedisArgument) {
     parser.push('FT.CONFIG', 'SET', property, value);
   },

--- a/packages/search/lib/commands/CREATE.ts
+++ b/packages/search/lib/commands/CREATE.ts
@@ -292,6 +292,22 @@ export interface CreateOptions {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Creates a new search index with the given schema and options.
+   * @param parser - The command parser
+   * @param index - Name of the index to create
+   * @param schema - Index schema defining field names and types (TEXT, NUMERIC, GEO, TAG, VECTOR, GEOSHAPE)
+   * @param options - Optional parameters:
+   *   - ON: Type of container to index (HASH or JSON)
+   *   - PREFIX: Prefixes for document keys to index
+   *   - FILTER: Expression that filters indexed documents
+   *   - LANGUAGE/LANGUAGE_FIELD: Default language for indexing
+   *   - SCORE/SCORE_FIELD: Document ranking parameters
+   *   - MAXTEXTFIELDS: Index all text fields without specifying them
+   *   - TEMPORARY: Create a temporary index
+   *   - NOOFFSETS/NOHL/NOFIELDS/NOFREQS: Index optimization flags
+   *   - STOPWORDS: Custom stopword list
+   */
   parseCommand(parser: CommandParser, index: RedisArgument, schema: RediSearchSchema, options?: CreateOptions) {
     parser.push('FT.CREATE', index);
 

--- a/packages/search/lib/commands/CURSOR_DEL.ts
+++ b/packages/search/lib/commands/CURSOR_DEL.ts
@@ -4,6 +4,12 @@ import { SimpleStringReply, Command, RedisArgument, NumberReply, UnwrapReply } f
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Deletes a cursor from an index.
+   * @param parser - The command parser
+   * @param index - The index name that contains the cursor
+   * @param cursorId - The cursor ID to delete
+   */
   parseCommand(parser: CommandParser, index: RedisArgument, cursorId: UnwrapReply<NumberReply>) {
     parser.push('FT.CURSOR', 'DEL', index, cursorId.toString());
   },

--- a/packages/search/lib/commands/CURSOR_READ.ts
+++ b/packages/search/lib/commands/CURSOR_READ.ts
@@ -9,6 +9,14 @@ export interface FtCursorReadOptions {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Reads from an existing cursor to get more results from an index.
+   * @param parser - The command parser
+   * @param index - The index name that contains the cursor
+   * @param cursor - The cursor ID to read from
+   * @param options - Optional parameters:
+   *   - COUNT: Maximum number of results to return
+   */
   parseCommand(parser: CommandParser, index: RedisArgument, cursor: UnwrapReply<NumberReply>, options?: FtCursorReadOptions) {
     parser.push('FT.CURSOR', 'READ', index, cursor.toString());
 

--- a/packages/search/lib/commands/DICTADD.ts
+++ b/packages/search/lib/commands/DICTADD.ts
@@ -5,6 +5,12 @@ import { RedisVariadicArgument } from '@redis/client/dist/lib/commands/generic-t
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Adds terms to a dictionary.
+   * @param parser - The command parser
+   * @param dictionary - Name of the dictionary to add terms to
+   * @param term - One or more terms to add to the dictionary
+   */
   parseCommand(parser: CommandParser, dictionary: RedisArgument, term: RedisVariadicArgument) {
     parser.push('FT.DICTADD', dictionary);
     parser.pushVariadic(term);

--- a/packages/search/lib/commands/DICTDEL.ts
+++ b/packages/search/lib/commands/DICTDEL.ts
@@ -5,6 +5,12 @@ import { RedisVariadicArgument } from '@redis/client/dist/lib/commands/generic-t
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Deletes terms from a dictionary.
+   * @param parser - The command parser
+   * @param dictionary - Name of the dictionary to remove terms from
+   * @param term - One or more terms to delete from the dictionary
+   */
   parseCommand(parser: CommandParser, dictionary: RedisArgument, term: RedisVariadicArgument) {
     parser.push('FT.DICTDEL', dictionary);
     parser.pushVariadic(term);

--- a/packages/search/lib/commands/DICTDUMP.ts
+++ b/packages/search/lib/commands/DICTDUMP.ts
@@ -4,6 +4,11 @@ import { RedisArgument, ArrayReply, SetReply, BlobStringReply, Command } from '@
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns all terms in a dictionary.
+   * @param parser - The command parser
+   * @param dictionary - Name of the dictionary to dump
+   */
   parseCommand(parser: CommandParser, dictionary: RedisArgument) {
     parser.push('FT.DICTDUMP', dictionary);
   },

--- a/packages/search/lib/commands/DROPINDEX.ts
+++ b/packages/search/lib/commands/DROPINDEX.ts
@@ -8,6 +8,13 @@ export interface FtDropIndexOptions {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Deletes an index and all associated documents.
+   * @param parser - The command parser
+   * @param index - Name of the index to delete
+   * @param options - Optional parameters:
+   *   - DD: Also delete the indexed documents themselves
+   */
   parseCommand(parser: CommandParser, index: RedisArgument, options?: FtDropIndexOptions) {
     parser.push('FT.DROPINDEX', index);
 

--- a/packages/search/lib/commands/EXPLAIN.ts
+++ b/packages/search/lib/commands/EXPLAIN.ts
@@ -11,6 +11,15 @@ export interface FtExplainOptions {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the execution plan for a complex query.
+   * @param parser - The command parser
+   * @param index - Name of the index to explain query against
+   * @param query - The query string to explain
+   * @param options - Optional parameters:
+   *   - PARAMS: Named parameters to use in the query
+   *   - DIALECT: Version of query dialect to use (defaults to 1)
+   */
   parseCommand(
     parser: CommandParser,
     index: RedisArgument,

--- a/packages/search/lib/commands/EXPLAINCLI.ts
+++ b/packages/search/lib/commands/EXPLAINCLI.ts
@@ -9,6 +9,14 @@ export interface FtExplainCLIOptions {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the execution plan for a complex query in a more verbose format than FT.EXPLAIN.
+   * @param parser - The command parser
+   * @param index - Name of the index to explain query against
+   * @param query - The query string to explain
+   * @param options - Optional parameters:
+   *   - DIALECT: Version of query dialect to use (defaults to 1)
+   */
   parseCommand(
     parser: CommandParser, 
     index: RedisArgument, 

--- a/packages/search/lib/commands/INFO.ts
+++ b/packages/search/lib/commands/INFO.ts
@@ -7,6 +7,11 @@ import { TuplesReply } from '@redis/client/dist/lib/RESP/types';
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns information and statistics about an index.
+   * @param parser - The command parser
+   * @param index - Name of the index to get information about
+   */
   parseCommand(parser: CommandParser, index: RedisArgument) {
     parser.push('FT.INFO', index);
   },

--- a/packages/search/lib/commands/PROFILE_AGGREGATE.ts
+++ b/packages/search/lib/commands/PROFILE_AGGREGATE.ts
@@ -6,6 +6,15 @@ import { ProfileOptions, ProfileRawReplyResp2, ProfileReplyResp2, } from './PROF
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Profiles the execution of an aggregation query for performance analysis.
+   * @param parser - The command parser
+   * @param index - Name of the index to profile query against
+   * @param query - The aggregation query to profile
+   * @param options - Optional parameters:
+   *   - LIMITED: Collect limited timing information only
+   *   - All options supported by FT.AGGREGATE command
+   */
   parseCommand(
     parser: CommandParser,
     index: string,

--- a/packages/search/lib/commands/PROFILE_SEARCH.ts
+++ b/packages/search/lib/commands/PROFILE_SEARCH.ts
@@ -22,6 +22,15 @@ export interface ProfileOptions {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Profiles the execution of a search query for performance analysis.
+   * @param parser - The command parser
+   * @param index - Name of the index to profile query against
+   * @param query - The search query to profile
+   * @param options - Optional parameters:
+   *   - LIMITED: Collect limited timing information only
+   *   - All options supported by FT.SEARCH command
+   */
   parseCommand(
     parser: CommandParser,
     index: RedisArgument,

--- a/packages/search/lib/commands/SEARCH.ts
+++ b/packages/search/lib/commands/SEARCH.ts
@@ -161,6 +161,21 @@ export function parseSearchOptions(parser: CommandParser, options?: FtSearchOpti
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Searches a RediSearch index with the given query.
+   * @param parser - The command parser
+   * @param index - The index name to search
+   * @param query - The text query to search. For syntax, see https://redis.io/docs/stack/search/reference/query_syntax
+   * @param options - Optional search parameters including:
+   *   - VERBATIM: do not try to use stemming for query expansion
+   *   - NOSTOPWORDS: do not filter stopwords from the query
+   *   - INKEYS/INFIELDS: restrict the search to specific keys/fields
+   *   - RETURN: limit which fields are returned
+   *   - SUMMARIZE/HIGHLIGHT: create search result highlights
+   *   - LIMIT: pagination control
+   *   - SORTBY: sort results by a specific field
+   *   - PARAMS: bind parameters to the query
+   */
   parseCommand(parser: CommandParser, index: RedisArgument, query: RedisArgument, options?: FtSearchOptions) {
     parser.push('FT.SEARCH', index, query);
 

--- a/packages/search/lib/commands/SEARCH_NOCONTENT.ts
+++ b/packages/search/lib/commands/SEARCH_NOCONTENT.ts
@@ -4,6 +4,14 @@ import SEARCH, { SearchRawReply } from './SEARCH';
 export default {
   NOT_KEYED_COMMAND: SEARCH.NOT_KEYED_COMMAND,
   IS_READ_ONLY: SEARCH.IS_READ_ONLY,
+  /**
+   * Performs a search query but returns only document ids without their contents.
+   * @param args - Same parameters as FT.SEARCH:
+   *   - parser: The command parser
+   *   - index: Name of the index to search
+   *   - query: The text query to search
+   *   - options: Optional search parameters
+   */
   parseCommand(...args: Parameters<typeof SEARCH.parseCommand>) {
     SEARCH.parseCommand(...args);  
     args[0].push('NOCONTENT');

--- a/packages/search/lib/commands/SPELLCHECK.ts
+++ b/packages/search/lib/commands/SPELLCHECK.ts
@@ -16,6 +16,16 @@ export interface FtSpellCheckOptions {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Performs spelling correction on a search query.
+   * @param parser - The command parser
+   * @param index - Name of the index to use for spelling corrections
+   * @param query - The search query to check for spelling
+   * @param options - Optional parameters:
+   *   - DISTANCE: Maximum Levenshtein distance for spelling suggestions
+   *   - TERMS: Custom dictionary terms to include/exclude
+   *   - DIALECT: Version of query dialect to use (defaults to 1)
+   */
   parseCommand(parser: CommandParser, index: RedisArgument, query: RedisArgument, options?: FtSpellCheckOptions) {
     parser.push('FT.SPELLCHECK', index, query);
 

--- a/packages/search/lib/commands/SUGADD.ts
+++ b/packages/search/lib/commands/SUGADD.ts
@@ -8,6 +8,16 @@ export interface FtSugAddOptions {
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Adds a suggestion string to an auto-complete suggestion dictionary.
+   * @param parser - The command parser
+   * @param key - The suggestion dictionary key
+   * @param string - The suggestion string to add
+   * @param score - The suggestion score used for sorting
+   * @param options - Optional parameters:
+   *   - INCR: If true, increment the existing entry's score
+   *   - PAYLOAD: Optional payload to associate with the suggestion
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, string: RedisArgument, score: number, options?: FtSugAddOptions) {
     parser.push('FT.SUGADD');
     parser.pushKey(key);

--- a/packages/search/lib/commands/SUGDEL.ts
+++ b/packages/search/lib/commands/SUGDEL.ts
@@ -3,6 +3,12 @@ import { RedisArgument, NumberReply, Command } from '@redis/client/dist/lib/RESP
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Deletes a string from a suggestion dictionary.
+   * @param parser - The command parser
+   * @param key - The suggestion dictionary key
+   * @param string - The suggestion string to delete
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, string: RedisArgument) {
     parser.push('FT.SUGDEL');
     parser.pushKey(key);

--- a/packages/search/lib/commands/SUGGET.ts
+++ b/packages/search/lib/commands/SUGGET.ts
@@ -8,6 +8,15 @@ export interface FtSugGetOptions {
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Gets completion suggestions for a prefix from a suggestion dictionary.
+   * @param parser - The command parser
+   * @param key - The suggestion dictionary key
+   * @param prefix - The prefix to get completion suggestions for
+   * @param options - Optional parameters:
+   *   - FUZZY: Enable fuzzy prefix matching
+   *   - MAX: Maximum number of results to return
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, prefix: RedisArgument, options?: FtSugGetOptions) {
     parser.push('FT.SUGGET');
     parser.pushKey(key);

--- a/packages/search/lib/commands/SUGGET_WITHPAYLOADS.ts
+++ b/packages/search/lib/commands/SUGGET_WITHPAYLOADS.ts
@@ -4,6 +4,14 @@ import SUGGET from './SUGGET';
 
 export default {
   IS_READ_ONLY: SUGGET.IS_READ_ONLY,
+  /**
+   * Gets completion suggestions with their payloads from a suggestion dictionary.
+   * @param args - Same parameters as FT.SUGGET:
+   *   - parser: The command parser
+   *   - key: The suggestion dictionary key
+   *   - prefix: The prefix to get completion suggestions for
+   *   - options: Optional parameters for fuzzy matching and max results
+   */
   parseCommand(...args: Parameters<typeof SUGGET.parseCommand>) {
     SUGGET.parseCommand(...args);
     args[0].push('WITHPAYLOADS');

--- a/packages/search/lib/commands/SUGGET_WITHSCORES.ts
+++ b/packages/search/lib/commands/SUGGET_WITHSCORES.ts
@@ -9,6 +9,14 @@ type SuggestScore = {
 
 export default {
   IS_READ_ONLY: SUGGET.IS_READ_ONLY,
+  /**
+   * Gets completion suggestions with their scores from a suggestion dictionary.
+   * @param args - Same parameters as FT.SUGGET:
+   *   - parser: The command parser
+   *   - key: The suggestion dictionary key
+   *   - prefix: The prefix to get completion suggestions for
+   *   - options: Optional parameters for fuzzy matching and max results
+   */
   parseCommand(...args: Parameters<typeof SUGGET.parseCommand>) {
     SUGGET.parseCommand(...args);
     args[0].push('WITHSCORES');

--- a/packages/search/lib/commands/SUGGET_WITHSCORES_WITHPAYLOADS.ts
+++ b/packages/search/lib/commands/SUGGET_WITHSCORES_WITHPAYLOADS.ts
@@ -10,6 +10,14 @@ type SuggestScoreWithPayload = {
 
 export default {
   IS_READ_ONLY: SUGGET.IS_READ_ONLY,
+  /**
+   * Gets completion suggestions with their scores and payloads from a suggestion dictionary.
+   * @param args - Same parameters as FT.SUGGET:
+   *   - parser: The command parser
+   *   - key: The suggestion dictionary key
+   *   - prefix: The prefix to get completion suggestions for
+   *   - options: Optional parameters for fuzzy matching and max results
+   */
   parseCommand(...args: Parameters<typeof SUGGET.parseCommand>) {
     SUGGET.parseCommand(...args);
     args[0].push(

--- a/packages/search/lib/commands/SUGLEN.ts
+++ b/packages/search/lib/commands/SUGLEN.ts
@@ -3,6 +3,11 @@ import { RedisArgument, NumberReply, Command } from '@redis/client/dist/lib/RESP
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Gets the size of a suggestion dictionary.
+   * @param parser - The command parser
+   * @param key - The suggestion dictionary key
+   */
   parseCommand(parser: CommandParser, key: RedisArgument) {
     parser.push('FT.SUGLEN', key);
   },

--- a/packages/search/lib/commands/SYNDUMP.ts
+++ b/packages/search/lib/commands/SYNDUMP.ts
@@ -4,6 +4,11 @@ import { RedisArgument, MapReply, BlobStringReply, ArrayReply, UnwrapReply, Comm
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Dumps the contents of a synonym group.
+   * @param parser - The command parser
+   * @param index - Name of the index that contains the synonym group
+   */
   parseCommand(parser: CommandParser, index: RedisArgument) {
     parser.push('FT.SYNDUMP', index);
   },

--- a/packages/search/lib/commands/SYNUPDATE.ts
+++ b/packages/search/lib/commands/SYNUPDATE.ts
@@ -9,6 +9,15 @@ export interface FtSynUpdateOptions {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Updates a synonym group with new terms.
+   * @param parser - The command parser
+   * @param index - Name of the index that contains the synonym group
+   * @param groupId - ID of the synonym group to update
+   * @param terms - One or more synonym terms to add to the group
+   * @param options - Optional parameters:
+   *   - SKIPINITIALSCAN: Skip the initial scan for existing documents
+   */
   parseCommand(
     parser: CommandParser,
     index: RedisArgument,

--- a/packages/search/lib/commands/TAGVALS.ts
+++ b/packages/search/lib/commands/TAGVALS.ts
@@ -4,6 +4,12 @@ import { RedisArgument, ArrayReply, SetReply, BlobStringReply, Command } from '@
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Returns the distinct values in a TAG field.
+   * @param parser - The command parser
+   * @param index - Name of the index
+   * @param fieldName - Name of the TAG field to get values from
+   */
   parseCommand(parser: CommandParser, index: RedisArgument, fieldName: RedisArgument) {
     parser.push('FT.TAGVALS', index, fieldName);
   },

--- a/packages/search/lib/commands/_LIST.ts
+++ b/packages/search/lib/commands/_LIST.ts
@@ -4,6 +4,10 @@ import { ArrayReply, SetReply, BlobStringReply, Command } from '@redis/client/di
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Lists all existing indexes in the database.
+   * @param parser - The command parser
+   */
   parseCommand(parser: CommandParser) {
     parser.push('FT._LIST');
   },

--- a/packages/time-series/lib/commands/ADD.ts
+++ b/packages/time-series/lib/commands/ADD.ts
@@ -29,6 +29,14 @@ export interface TsAddOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Creates or appends a sample to a time series
+   * @param parser - The command parser
+   * @param key - The key name for the time series
+   * @param timestamp - The timestamp of the sample
+   * @param value - The value of the sample
+   * @param options - Optional configuration parameters
+   */
   parseCommand(
     parser: CommandParser,
     key: RedisArgument,

--- a/packages/time-series/lib/commands/ALTER.ts
+++ b/packages/time-series/lib/commands/ALTER.ts
@@ -8,6 +8,12 @@ export type TsAlterOptions = Pick<TsCreateOptions, 'RETENTION' | 'CHUNK_SIZE' | 
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Alters the configuration of an existing time series
+   * @param parser - The command parser
+   * @param key - The key name for the time series
+   * @param options - Configuration parameters to alter
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, options?: TsAlterOptions) {
     parser.push('TS.ALTER');
     parser.pushKey(key);

--- a/packages/time-series/lib/commands/CREATE.ts
+++ b/packages/time-series/lib/commands/CREATE.ts
@@ -24,6 +24,12 @@ export interface TsCreateOptions {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Creates a new time series
+   * @param parser - The command parser
+   * @param key - The key name for the new time series
+   * @param options - Optional configuration parameters
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, options?: TsCreateOptions) {
     parser.push('TS.CREATE');
     parser.pushKey(key);

--- a/packages/time-series/lib/commands/CREATERULE.ts
+++ b/packages/time-series/lib/commands/CREATERULE.ts
@@ -21,6 +21,15 @@ export type TimeSeriesAggregationType = typeof TIME_SERIES_AGGREGATION_TYPE[keyo
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Creates a compaction rule from source time series to destination time series
+   * @param parser - The command parser
+   * @param sourceKey - The source time series key
+   * @param destinationKey - The destination time series key
+   * @param aggregationType - The aggregation type to use
+   * @param bucketDuration - The duration of each bucket in milliseconds
+   * @param alignTimestamp - Optional timestamp for alignment
+   */
   parseCommand(
     parser: CommandParser,
     sourceKey: RedisArgument,

--- a/packages/time-series/lib/commands/DECRBY.ts
+++ b/packages/time-series/lib/commands/DECRBY.ts
@@ -3,6 +3,10 @@ import INCRBY, { parseIncrByArguments } from './INCRBY';
 
 export default {
   IS_READ_ONLY: INCRBY.IS_READ_ONLY,
+  /**
+   * Decreases the value of a time series by a given amount
+   * @param args - Arguments passed to the parseIncrByArguments function
+   */
   parseCommand(...args: Parameters<typeof parseIncrByArguments>) {
     const parser = args[0];
 

--- a/packages/time-series/lib/commands/DEL.ts
+++ b/packages/time-series/lib/commands/DEL.ts
@@ -4,6 +4,13 @@ import { RedisArgument, NumberReply, Command, } from '@redis/client/dist/lib/RES
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Deletes samples between two timestamps from a time series
+   * @param parser - The command parser
+   * @param key - The key name of the time series
+   * @param fromTimestamp - Start timestamp to delete from
+   * @param toTimestamp - End timestamp to delete until
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, fromTimestamp: Timestamp, toTimestamp: Timestamp) {
     parser.push('TS.DEL');
     parser.pushKey(key);

--- a/packages/time-series/lib/commands/DELETERULE.ts
+++ b/packages/time-series/lib/commands/DELETERULE.ts
@@ -3,6 +3,12 @@ import { RedisArgument, SimpleStringReply, Command } from '@redis/client/dist/li
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Deletes a compaction rule between source and destination time series
+   * @param parser - The command parser
+   * @param sourceKey - The source time series key
+   * @param destinationKey - The destination time series key
+   */
   parseCommand(parser: CommandParser, sourceKey: RedisArgument, destinationKey: RedisArgument) {
     parser.push('TS.DELETERULE');
     parser.pushKeys([sourceKey, destinationKey]);

--- a/packages/time-series/lib/commands/GET.ts
+++ b/packages/time-series/lib/commands/GET.ts
@@ -9,6 +9,12 @@ export type TsGetReply = TuplesReply<[]> | TuplesReply<[NumberReply, DoubleReply
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Gets the last sample of a time series
+   * @param parser - The command parser
+   * @param key - The key name of the time series
+   * @param options - Optional parameters for the command
+   */
   parseCommand(parser: CommandParser, key: RedisArgument, options?: TsGetOptions) {
     parser.push('TS.GET');
     parser.pushKey(key);

--- a/packages/time-series/lib/commands/INCRBY.ts
+++ b/packages/time-series/lib/commands/INCRBY.ts
@@ -12,6 +12,13 @@ export interface TsIncrByOptions {
   IGNORE?: TsIgnoreOptions;
 }
 
+/**
+ * Parses arguments for incrementing a time series value
+ * @param parser - The command parser
+ * @param key - The key name of the time series
+ * @param value - The value to increment by
+ * @param options - Optional parameters for the command
+ */
 export function parseIncrByArguments(
   parser: CommandParser,
   key: RedisArgument,
@@ -40,6 +47,10 @@ export function parseIncrByArguments(
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Increases the value of a time series by a given amount
+   * @param args - Arguments passed to the {@link parseIncrByArguments} function
+   */
   parseCommand(...args: Parameters<typeof parseIncrByArguments>) {
     const parser = args[0];
 

--- a/packages/time-series/lib/commands/INFO.ts
+++ b/packages/time-series/lib/commands/INFO.ts
@@ -73,6 +73,11 @@ export interface InfoReply {
 
 export default {
     IS_READ_ONLY: true,
+    /**
+     * Gets information about a time series
+     * @param parser - The command parser
+     * @param key - The key name of the time series
+     */
     parseCommand(parser: CommandParser, key: string) {
       parser.push('TS.INFO');
       parser.pushKey(key);

--- a/packages/time-series/lib/commands/INFO_DEBUG.ts
+++ b/packages/time-series/lib/commands/INFO_DEBUG.ts
@@ -38,6 +38,11 @@ export interface InfoDebugReply extends InfoReply {
 
 export default {
   IS_READ_ONLY: INFO.IS_READ_ONLY,
+  /**
+   * Gets debug information about a time series
+   * @param parser - The command parser
+   * @param key - The key name of the time series
+   */
   parseCommand(parser: CommandParser, key: string) {
     INFO.parseCommand(parser, key);
     parser.push('DEBUG');

--- a/packages/time-series/lib/commands/MADD.ts
+++ b/packages/time-series/lib/commands/MADD.ts
@@ -10,6 +10,11 @@ export interface TsMAddSample {
 
 export default {
   IS_READ_ONLY: false,
+  /**
+   * Adds multiple samples to multiple time series
+   * @param parser - The command parser
+   * @param toAdd - Array of samples to add to different time series
+   */
   parseCommand(parser: CommandParser, toAdd: Array<TsMAddSample>) {
     parser.push('TS.MADD');
 

--- a/packages/time-series/lib/commands/MGET.ts
+++ b/packages/time-series/lib/commands/MGET.ts
@@ -7,12 +7,22 @@ export interface TsMGetOptions {
   LATEST?: boolean;
 }
 
+/**
+ * Adds LATEST argument to command if specified
+ * @param parser - The command parser
+ * @param latest - Whether to include the LATEST argument
+ */
 export function parseLatestArgument(parser: CommandParser, latest?: boolean) {
   if (latest) {
     parser.push('LATEST');
   }
 }
 
+/**
+ * Adds FILTER argument to command
+ * @param parser - The command parser
+ * @param filter - Filter to match time series keys
+ */
 export function parseFilterArgument(parser: CommandParser, filter: RedisVariadicArgument) {
   parser.push('FILTER');
   parser.pushVariadic(filter);
@@ -37,6 +47,12 @@ export type MGetRawReply3 = MapReply<
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Gets the last samples matching a specific filter from multiple time series
+   * @param parser - The command parser
+   * @param filter - Filter to match time series keys
+   * @param options - Optional parameters for the command
+   */
   parseCommand(parser: CommandParser, filter: RedisVariadicArgument, options?: TsMGetOptions) {
     parser.push('TS.MGET');
     parseLatestArgument(parser, options?.LATEST);

--- a/packages/time-series/lib/commands/MGET_SELECTED_LABELS.ts
+++ b/packages/time-series/lib/commands/MGET_SELECTED_LABELS.ts
@@ -7,6 +7,13 @@ import { createTransformMGetLabelsReply } from './MGET_WITHLABELS';
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Gets the last samples matching a specific filter with selected labels
+   * @param parser - The command parser
+   * @param filter - Filter to match time series keys
+   * @param selectedLabels - Labels to include in the output
+   * @param options - Optional parameters for the command
+   */
   parseCommand(parser: CommandParser, filter: RedisVariadicArgument, selectedLabels: RedisVariadicArgument, options?: TsMGetOptions) {
     parser.push('TS.MGET');
     parseLatestArgument(parser, options?.LATEST);

--- a/packages/time-series/lib/commands/MGET_WITHLABELS.ts
+++ b/packages/time-series/lib/commands/MGET_WITHLABELS.ts
@@ -52,6 +52,12 @@ export function createTransformMGetLabelsReply<T extends RawLabelValue>() {
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Gets the last samples matching a specific filter with labels
+   * @param parser - The command parser
+   * @param filter - Filter to match time series keys
+   * @param options - Optional parameters for the command
+   */
   parseCommand(parser: CommandParser, filter: RedisVariadicArgument, options?: TsMGetWithLabelsOptions) {
     parser.push('TS.MGET');
     parseLatestArgument(parser, options?.LATEST);

--- a/packages/time-series/lib/commands/MRANGE.ts
+++ b/packages/time-series/lib/commands/MRANGE.ts
@@ -22,6 +22,10 @@ export type TsMRangeRawReply3 = MapReply<
   ]>
 >;
 
+/**
+ * Creates a function that parses arguments for multi-range commands
+ * @param command - The command name to use (TS.MRANGE or TS.MREVRANGE)
+ */
 export function createTransformMRangeArguments(command: RedisArgument) {
   return (
     parser: CommandParser,
@@ -45,6 +49,14 @@ export function createTransformMRangeArguments(command: RedisArgument) {
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Gets samples for time series matching a specific filter within a time range
+   * @param parser - The command parser
+   * @param fromTimestamp - Start timestamp for range
+   * @param toTimestamp - End timestamp for range
+   * @param filter - Filter to match time series keys
+   * @param options - Optional parameters for the command
+   */
   parseCommand: createTransformMRangeArguments('TS.MRANGE'),
   transformReply: {
     2(reply: TsMRangeRawReply2, _?: any, typeMapping?: TypeMapping) {

--- a/packages/time-series/lib/commands/MRANGE_GROUPBY.ts
+++ b/packages/time-series/lib/commands/MRANGE_GROUPBY.ts
@@ -25,6 +25,11 @@ export interface TsMRangeGroupBy {
   REDUCE: TimeSeriesReducer;
 }
 
+/**
+ * Adds GROUPBY arguments to command
+ * @param parser - The command parser
+ * @param groupBy - Group by parameters
+ */
 export function parseGroupByArguments(parser: CommandParser, groupBy: TsMRangeGroupBy) {
   parser.push('GROUPBY', groupBy.label, 'REDUCE', groupBy.REDUCE);
 }
@@ -51,6 +56,10 @@ export type TsMRangeGroupByRawReply3 = MapReply<
   ]>
 >;
 
+/**
+ * Creates a function that parses arguments for multi-range commands with grouping
+ * @param command - The command name to use (TS.MRANGE or TS.MREVRANGE)
+ */
 export function createTransformMRangeGroupByArguments(command: RedisArgument) {
   return (
     parser: CommandParser,
@@ -69,6 +78,10 @@ export function createTransformMRangeGroupByArguments(command: RedisArgument) {
   };
 }
 
+/**
+ * Extracts source keys from RESP3 metadata reply
+ * @param raw - Raw metadata from RESP3 reply
+ */
 export function extractResp3MRangeSources(raw: TsMRangeGroupByRawMetadataReply3) {
   const unwrappedMetadata2 = raw as unknown as UnwrapReply<typeof raw>;
   if (unwrappedMetadata2 instanceof Map) {
@@ -82,6 +95,15 @@ export function extractResp3MRangeSources(raw: TsMRangeGroupByRawMetadataReply3)
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Gets samples for time series matching a filter within a time range with grouping
+   * @param parser - The command parser
+   * @param fromTimestamp - Start timestamp for range
+   * @param toTimestamp - End timestamp for range
+   * @param filter - Filter to match time series keys
+   * @param groupBy - Group by parameters
+   * @param options - Optional parameters for the command
+   */
   parseCommand: createTransformMRangeGroupByArguments('TS.MRANGE'),
   transformReply: {
     2(reply: TsMRangeGroupByRawReply2, _?: any, typeMapping?: TypeMapping) {

--- a/packages/time-series/lib/commands/MRANGE_SELECTED_LABELS.ts
+++ b/packages/time-series/lib/commands/MRANGE_SELECTED_LABELS.ts
@@ -25,6 +25,10 @@ export type TsMRangeSelectedLabelsRawReply3 = MapReply<
   ]>
 >;
 
+/**
+ * Creates a function that parses arguments for multi-range commands with selected labels
+ * @param command - The command name to use (TS.MRANGE or TS.MREVRANGE)
+ */
 export function createTransformMRangeSelectedLabelsArguments(command: RedisArgument) {
   return (
     parser: CommandParser,
@@ -50,6 +54,15 @@ export function createTransformMRangeSelectedLabelsArguments(command: RedisArgum
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Gets samples for time series matching a filter with selected labels
+   * @param parser - The command parser
+   * @param fromTimestamp - Start timestamp for range
+   * @param toTimestamp - End timestamp for range
+   * @param selectedLabels - Labels to include in the output
+   * @param filter - Filter to match time series keys
+   * @param options - Optional parameters for the command
+   */
   parseCommand: createTransformMRangeSelectedLabelsArguments('TS.MRANGE'),
   transformReply: {
     2(reply: TsMRangeSelectedLabelsRawReply2, _?: any, typeMapping?: TypeMapping) {

--- a/packages/time-series/lib/commands/MRANGE_SELECTED_LABELS_GROUPBY.ts
+++ b/packages/time-series/lib/commands/MRANGE_SELECTED_LABELS_GROUPBY.ts
@@ -17,6 +17,10 @@ export type TsMRangeWithLabelsGroupByRawReply3 = MapReply<
   ]>
 >;
 
+/**
+ * Creates a function that parses arguments for multi-range commands with selected labels and grouping
+ * @param command - The command name to use (TS.MRANGE or TS.MREVRANGE)
+ */
 export function createMRangeSelectedLabelsGroupByTransformArguments(
   command: RedisArgument
 ) {
@@ -47,6 +51,16 @@ export function createMRangeSelectedLabelsGroupByTransformArguments(
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Gets samples for time series matching a filter with selected labels and grouping
+   * @param parser - The command parser
+   * @param fromTimestamp - Start timestamp for range
+   * @param toTimestamp - End timestamp for range
+   * @param selectedLabels - Labels to include in the output
+   * @param filter - Filter to match time series keys
+   * @param groupBy - Group by parameters
+   * @param options - Optional parameters for the command
+   */
   parseCommand: createMRangeSelectedLabelsGroupByTransformArguments('TS.MRANGE'),
   transformReply: {
     2: MRANGE_SELECTED_LABELS.transformReply[2],

--- a/packages/time-series/lib/commands/MRANGE_WITHLABELS.ts
+++ b/packages/time-series/lib/commands/MRANGE_WITHLABELS.ts
@@ -25,6 +25,10 @@ export type TsMRangeWithLabelsRawReply3 = MapReply<
   ]>
 >;
 
+/**
+ * Creates a function that parses arguments for multi-range commands with labels
+ * @param command - The command name to use (TS.MRANGE or TS.MREVRANGE)
+ */
 export function createTransformMRangeWithLabelsArguments(command: RedisArgument) {
   return (
     parser: CommandParser,
@@ -50,6 +54,14 @@ export function createTransformMRangeWithLabelsArguments(command: RedisArgument)
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Gets samples for time series matching a filter with labels
+   * @param parser - The command parser
+   * @param fromTimestamp - Start timestamp for range
+   * @param toTimestamp - End timestamp for range
+   * @param filter - Filter to match time series keys
+   * @param options - Optional parameters for the command
+   */
   parseCommand: createTransformMRangeWithLabelsArguments('TS.MRANGE'),
   transformReply: {
     2(reply: TsMRangeWithLabelsRawReply2, _?: any, typeMapping?: TypeMapping) {

--- a/packages/time-series/lib/commands/MRANGE_WITHLABELS_GROUPBY.ts
+++ b/packages/time-series/lib/commands/MRANGE_WITHLABELS_GROUPBY.ts
@@ -54,6 +54,15 @@ export function createMRangeWithLabelsGroupByTransformArguments(command: RedisAr
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Gets samples for time series matching a filter with labels and grouping
+   * @param parser - The command parser
+   * @param fromTimestamp - Start timestamp for range
+   * @param toTimestamp - End timestamp for range
+   * @param filter - Filter to match time series keys
+   * @param groupBy - Group by parameters
+   * @param options - Optional parameters for the command
+   */
   parseCommand: createMRangeWithLabelsGroupByTransformArguments('TS.MRANGE'),
   transformReply: {
     2(reply: TsMRangeWithLabelsGroupByRawReply2, _?: any, typeMapping?: TypeMapping) {

--- a/packages/time-series/lib/commands/MREVRANGE.ts
+++ b/packages/time-series/lib/commands/MREVRANGE.ts
@@ -4,6 +4,14 @@ import MRANGE, { createTransformMRangeArguments } from './MRANGE';
 export default {
   NOT_KEYED_COMMAND: MRANGE.NOT_KEYED_COMMAND,
   IS_READ_ONLY: MRANGE.IS_READ_ONLY,
+  /**
+   * Gets samples for time series matching a specific filter within a time range (in reverse order)
+   * @param parser - The command parser
+   * @param fromTimestamp - Start timestamp for range
+   * @param toTimestamp - End timestamp for range
+   * @param filter - Filter to match time series keys
+   * @param options - Optional parameters for the command
+   */
   parseCommand: createTransformMRangeArguments('TS.MREVRANGE'),
   transformReply: MRANGE.transformReply,
 } as const satisfies Command;

--- a/packages/time-series/lib/commands/MREVRANGE_GROUPBY.ts
+++ b/packages/time-series/lib/commands/MREVRANGE_GROUPBY.ts
@@ -3,6 +3,15 @@ import MRANGE_GROUPBY, { createTransformMRangeGroupByArguments } from './MRANGE_
 
 export default {
   IS_READ_ONLY: MRANGE_GROUPBY.IS_READ_ONLY,
+  /**
+   * Gets samples for time series matching a filter within a time range with grouping (in reverse order)
+   * @param parser - The command parser
+   * @param fromTimestamp - Start timestamp for range
+   * @param toTimestamp - End timestamp for range
+   * @param filter - Filter to match time series keys
+   * @param groupBy - Group by parameters
+   * @param options - Optional parameters for the command
+   */
   parseCommand: createTransformMRangeGroupByArguments('TS.MREVRANGE'),
   transformReply: MRANGE_GROUPBY.transformReply,
 } as const satisfies Command;

--- a/packages/time-series/lib/commands/MREVRANGE_SELECTED_LABELS.ts
+++ b/packages/time-series/lib/commands/MREVRANGE_SELECTED_LABELS.ts
@@ -3,6 +3,15 @@ import MRANGE_SELECTED_LABELS, { createTransformMRangeSelectedLabelsArguments } 
 
 export default {
   IS_READ_ONLY: MRANGE_SELECTED_LABELS.IS_READ_ONLY,
+  /**
+   * Gets samples for time series matching a filter with selected labels (in reverse order)
+   * @param parser - The command parser
+   * @param fromTimestamp - Start timestamp for range
+   * @param toTimestamp - End timestamp for range
+   * @param selectedLabels - Labels to include in the output
+   * @param filter - Filter to match time series keys
+   * @param options - Optional parameters for the command
+   */
   parseCommand: createTransformMRangeSelectedLabelsArguments('TS.MREVRANGE'),
   transformReply: MRANGE_SELECTED_LABELS.transformReply,
 } as const satisfies Command;

--- a/packages/time-series/lib/commands/MREVRANGE_SELECTED_LABELS_GROUPBY.ts
+++ b/packages/time-series/lib/commands/MREVRANGE_SELECTED_LABELS_GROUPBY.ts
@@ -3,6 +3,16 @@ import MRANGE_SELECTED_LABELS_GROUPBY, { createMRangeSelectedLabelsGroupByTransf
 
 export default {
   IS_READ_ONLY: MRANGE_SELECTED_LABELS_GROUPBY.IS_READ_ONLY,
+  /**
+   * Gets samples for time series matching a filter with selected labels and grouping (in reverse order)
+   * @param parser - The command parser
+   * @param fromTimestamp - Start timestamp for range
+   * @param toTimestamp - End timestamp for range
+   * @param selectedLabels - Labels to include in the output
+   * @param filter - Filter to match time series keys
+   * @param groupBy - Group by parameters
+   * @param options - Optional parameters for the command
+   */
   parseCommand: createMRangeSelectedLabelsGroupByTransformArguments('TS.MREVRANGE'),
   transformReply: MRANGE_SELECTED_LABELS_GROUPBY.transformReply,
 } as const satisfies Command;

--- a/packages/time-series/lib/commands/MREVRANGE_WITHLABELS.ts
+++ b/packages/time-series/lib/commands/MREVRANGE_WITHLABELS.ts
@@ -4,6 +4,14 @@ import MRANGE_WITHLABELS, { createTransformMRangeWithLabelsArguments } from './M
 export default {
   NOT_KEYED_COMMAND: MRANGE_WITHLABELS.NOT_KEYED_COMMAND,
   IS_READ_ONLY: MRANGE_WITHLABELS.IS_READ_ONLY,
+  /**
+   * Gets samples for time series matching a filter with labels (in reverse order)
+   * @param parser - The command parser
+   * @param fromTimestamp - Start timestamp for range
+   * @param toTimestamp - End timestamp for range
+   * @param filter - Filter to match time series keys
+   * @param options - Optional parameters for the command
+   */
   parseCommand: createTransformMRangeWithLabelsArguments('TS.MREVRANGE'),
   transformReply: MRANGE_WITHLABELS.transformReply,
 } as const satisfies Command;

--- a/packages/time-series/lib/commands/MREVRANGE_WITHLABELS_GROUPBY.ts
+++ b/packages/time-series/lib/commands/MREVRANGE_WITHLABELS_GROUPBY.ts
@@ -3,6 +3,15 @@ import MRANGE_WITHLABELS_GROUPBY, { createMRangeWithLabelsGroupByTransformArgume
 
 export default {
   IS_READ_ONLY: MRANGE_WITHLABELS_GROUPBY.IS_READ_ONLY,
+  /**
+   * Gets samples for time series matching a filter with labels and grouping (in reverse order)
+   * @param parser - The command parser
+   * @param fromTimestamp - Start timestamp for range
+   * @param toTimestamp - End timestamp for range
+   * @param filter - Filter to match time series keys
+   * @param groupBy - Group by parameters
+   * @param options - Optional parameters for the command
+   */
   parseCommand: createMRangeWithLabelsGroupByTransformArguments('TS.MREVRANGE'),
   transformReply: MRANGE_WITHLABELS_GROUPBY.transformReply,
 } as const satisfies Command;

--- a/packages/time-series/lib/commands/QUERYINDEX.ts
+++ b/packages/time-series/lib/commands/QUERYINDEX.ts
@@ -5,6 +5,11 @@ import { RedisVariadicArgument } from '@redis/client/dist/lib/commands/generic-t
 export default {
   NOT_KEYED_COMMAND: true,
   IS_READ_ONLY: true,
+  /**
+   * Queries the index for time series matching a specific filter
+   * @param parser - The command parser
+   * @param filter - Filter to match time series labels
+   */
   parseCommand(parser: CommandParser, filter: RedisVariadicArgument) {
     parser.push('TS.QUERYINDEX');
     parser.pushVariadic(filter);

--- a/packages/time-series/lib/commands/RANGE.ts
+++ b/packages/time-series/lib/commands/RANGE.ts
@@ -101,6 +101,10 @@ export function transformRangeArguments(
 
 export default {
   IS_READ_ONLY: true,
+  /**
+   * Gets samples from a time series within a time range
+   * @param args - Arguments passed to the {@link transformRangeArguments} function
+   */
   parseCommand(...args: Parameters<typeof transformRangeArguments>) {
     const parser = args[0];
 

--- a/packages/time-series/lib/commands/REVRANGE.ts
+++ b/packages/time-series/lib/commands/REVRANGE.ts
@@ -3,6 +3,10 @@ import RANGE, { transformRangeArguments } from './RANGE';
 
 export default {
   IS_READ_ONLY: RANGE.IS_READ_ONLY,
+  /**
+   * Gets samples from a time series within a time range (in reverse order)
+   * @param args - Arguments passed to the {@link transformRangeArguments} function
+   */
   parseCommand(...args: Parameters<typeof transformRangeArguments>) {
     const parser = args[0];
 


### PR DESCRIPTION
This pr covers all supported commands:

- json
- search
- bloom
- timeseries
- standard commands