### PR TITLE
fix(client): make unstable cmds throw

### DIFF
--- a/docs/v5.md
+++ b/docs/v5.md
@@ -42,9 +42,9 @@ RESP3 uses a different mechanism for handling Pub/Sub messages. Instead of modif
 
 ## Known Limitations
 
-### Unstable Module Commands
+### Unstable Commands
 
-Some Redis module commands have unstable RESP3 transformations. These commands will throw an error when used with RESP3 unless you explicitly opt in to using them by setting `unstableResp3: true` in your client configuration:
+Some Redis commands have unstable RESP3 transformations. These commands will throw an error when used with RESP3 unless you explicitly opt in to using them by setting `unstableResp3: true` in your client configuration:
 
 ```javascript
 const client = createClient({

--- a/packages/client/lib/commander.ts
+++ b/packages/client/lib/commander.ts
@@ -38,7 +38,11 @@ export function attachConfig<
     Class: any = class extends BaseClass {};
 
   for (const [name, command] of Object.entries(commands)) {
-    Class.prototype[name] = createCommand(command, RESP);
+    if (config?.RESP == 3 && command.unstableResp3 && !config.unstableResp3) {
+      Class.prototype[name] = throwResp3SearchModuleUnstableError;
+    } else {
+      Class.prototype[name] = createCommand(command, RESP);
+    }
   }
 
   if (config?.modules) {

--- a/packages/client/lib/commands/XREAD.spec.ts
+++ b/packages/client/lib/commands/XREAD.spec.ts
@@ -131,4 +131,37 @@ describe('XREAD', () => {
     client: GLOBAL.SERVERS.OPEN,
     cluster: GLOBAL.CLUSTERS.OPEN
   });
+
+  testUtils.testWithClient('client.xRead should throw with resp3 and unstableResp3: false', async client => {
+    assert.throws(
+      () => client.xRead({
+        key: 'key',
+        id: '0-0'
+      }),
+      {
+        message: 'Some RESP3 results for Redis Query Engine responses may change. Refer to the readme for guidance'
+      }
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    clientOptions: {
+      RESP: 3
+    }
+  });
+
+  testUtils.testWithClient('client.xRead should not throw with resp3 and unstableResp3: true', async client => {
+    assert.doesNotThrow(
+      () => client.xRead({
+        key: 'key',
+        id: '0-0'
+      })
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    clientOptions: {
+      RESP: 3,
+      unstableResp3: true
+    }
+  });
+
 });

--- a/packages/client/lib/commands/XREADGROUP.spec.ts
+++ b/packages/client/lib/commands/XREADGROUP.spec.ts
@@ -155,4 +155,36 @@ describe('XREADGROUP', () => {
     client: GLOBAL.SERVERS.OPEN,
     cluster: GLOBAL.CLUSTERS.OPEN
   });
+
+  testUtils.testWithClient('client.xReadGroup should throw with resp3 and unstableResp3: false', async client => {
+    assert.throws(
+      () => client.xReadGroup('group', 'consumer', {
+        key: 'key',
+        id: '>'
+      }),
+      {
+        message: 'Some RESP3 results for Redis Query Engine responses may change. Refer to the readme for guidance'
+      }
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    clientOptions: {
+      RESP: 3
+    }
+  });
+
+  testUtils.testWithClient('client.xReadGroup should not throw with resp3 and unstableResp3: true', async client => {
+    assert.doesNotThrow(
+      () => client.xReadGroup('group', 'consumer', {
+        key: 'key',
+        id: '>'
+      })
+    );
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    clientOptions: {
+      RESP: 3,
+      unstableResp3: true
+    }
+  });
 });


### PR DESCRIPTION
As per [the docs](https://github.com/redis/node-redis/blob/master/docs/v5.md), unstableResp3 commands should throw when client is created with { RESP: 3, unstableResp3: false|undefined }

fixes #2989

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
