### PR TITLE
docs: update SchemaFieldTypes to SCHEMA_FIELD_TYPE for redis@5.x

### DIFF
--- a/packages/search/README.md
+++ b/packages/search/README.md
@@ -19,11 +19,11 @@ Before we can perform any searches, we need to tell RediSearch how to index our 
 ```javascript
 await client.ft.create('idx:animals', {
   name: {
-    type: SchemaFieldTypes.TEXT,
+    type: SCHEMA_FIELD_TYPE.TEXT,
     SORTABLE: true
   },
-  species: SchemaFieldTypes.TAG,
-  age: SchemaFieldTypes.NUMERIC
+  species: SCHEMA_FIELD_TYPE.TAG,
+  age: SCHEMA_FIELD_TYPE.NUMERIC
 }, {
   ON: 'HASH',
   PREFIX: 'noderedis:animals'
@@ -91,15 +91,15 @@ One way we might choose to index these documents is as follows:
 ```javascript
 await client.ft.create('idx:users', {
   '$.name': {
-    type: SchemaFieldTypes.TEXT,
+    type: SCHEMA_FIELD_TYPE.TEXT,
     SORTABLE: 'UNF'
   },
   '$.age': {
-    type: SchemaFieldTypes.NUMERIC,
+    type: SCHEMA_FIELD_TYPE.NUMERIC,
     AS: 'age'
   },
   '$.coins': {
-    type: SchemaFieldTypes.NUMERIC,
+    type: SCHEMA_FIELD_TYPE.NUMERIC,
     AS: 'coins'
   }
 }, {


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

docs: fix stale SchemaFieldTypes usage for redis@5.x in search docs

Closes: #2985

Redis v5 introduced a breaking change: `SchemaFieldTypes` was replaced with `SCHEMA_FIELD_TYPE` [^enum-to-constants].

Updated the documentation in `packages/search` to reflect the correct usage:
- For redis@4.x, `SchemaFieldTypes` is correct
- For redis@5.x, `SCHEMA_FIELD_TYPE` must be used

Previous docs were misleading and based on pre-v5 enums. This change ensures accurate guidance across versions.


---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

