### PR TITLE
chore(actions): add action to close stale issues

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,25 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+permissions: {}
+jobs:
+  stale:
+    permissions:
+      issues: write  #  to close stale issues (actions/stale)
+      pull-requests: write  #  to close stale PRs (actions/stale)
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v9
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is marked stale. It will be closed in 30 days if it is not updated.'
+        stale-pr-message: 'This pull request is marked stale. It will be closed in 30 days if it is not updated.'
+        days-before-stale: 365
+        days-before-close: 30
+        stale-issue-label: "Stale"
+        stale-pr-label: "Stale"
+        operations-per-run: 10
+        remove-stale-when-updated: true


### PR DESCRIPTION
New workflow named "Close stale issues" that runs daily using a cron schedule. It marks issues and pull requests as stale after 365 days of inactivity and closes them after 30 days if there are no updates.