### PR TITLE
Update command-options.md with proper key 'RESP_TYPES'

### DIFF
--- a/docs/command-options.md
+++ b/docs/command-options.md
@@ -12,7 +12,7 @@ Some [RESP types](./RESP.md) can be mapped to more than one JavaScript type. For
 await client.get('key'); // `string | null`
 
 const proxyClient = client.withTypeMapping({
-  [TYPES.BLOB_STRING]: Buffer
+  [RESP_TYPES.BLOB_STRING]: Buffer
 });
 
 await proxyClient.get('key'); // `Buffer | null`


### PR DESCRIPTION
### Description
 The documentation has a typo uses TYPES instead of RESP_TYPES which caused confusing among users.
[linked issue](https://github.com/redis/node-redis/issues/2593#issuecomment-3041479904)
We are getting 
```
Cannot find name 'TYPES'.ts(2304)
any
```

> This is a simple fix changing [TYPES.BLOB_STRING] to [RESP_TYPES.BLOB_STRING]

---

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
