### PR TITLE
fix(commands): expire, expireAt are not readonly

### DIFF
--- a/packages/client/lib/commands/EXPIRE.ts
+++ b/packages/client/lib/commands/EXPIRE.ts
@@ -2,7 +2,6 @@ import { CommandParser } from '../client/parser';
 import { RedisArgument, NumberReply, Command } from '../RESP/types';
 
 export default {
-  IS_READ_ONLY: true,
   /**
    * Sets a timeout on key. After the timeout has expired, the key will be automatically deleted
    * @param parser - The Redis command parser

--- a/packages/client/lib/commands/EXPIREAT.ts
+++ b/packages/client/lib/commands/EXPIREAT.ts
@@ -3,7 +3,6 @@ import { RedisArgument, NumberReply, Command } from '../RESP/types';
 import { transformEXAT } from './generic-transformers';
 
 export default {
-  IS_READ_ONLY: true,
   /**
    * Sets the expiration for a key at a specific Unix timestamp
    * @param parser - The Redis command parser


### PR DESCRIPTION
fixes #3044

`expire` and `expireAt` commands are not readonly because they modify the server's state. 
