### PR TITLE
fix(sentinel): properly pass reconnectStrategy

### DIFF
--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -716,7 +716,7 @@ class RedisSentinelInternal<
     );
   }
 
-  #createClient(node: RedisNode, clientOptions: RedisClientOptions, reconnectStrategy?: undefined | false) {
+  #createClient(node: RedisNode, clientOptions: RedisClientOptions, reconnectStrategy?: false) {
     return RedisClient.create({
       //first take the globally set RESP
       RESP: this.#RESP,
@@ -726,7 +726,7 @@ class RedisSentinelInternal<
         ...clientOptions.socket,
         host: node.host,
         port: node.port,
-        reconnectStrategy
+        ...(reconnectStrategy !== undefined && { reconnectStrategy })
       }
     });
   }


### PR DESCRIPTION
Properly pass reconnectStrategy to master/replica nodes. Before that strategies passed in the nodeClientOptions.socket object were ignored.

fixes #3061

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
