### PR TITLE
perf(ts)!: move multi() away from RedisClient

### DIFF
--- a/packages/client/index.ts
+++ b/packages/client/index.ts
@@ -12,7 +12,9 @@ export { VerbatimString } from './lib/RESP/verbatim-string';
 export { defineScript } from './lib/lua-script';
 export * from './lib/errors';
 
+import { RedisFunctions, RedisModules, RedisScripts, RespVersions, TypeMapping } from './lib/RESP/types';
 import RedisClient, { RedisClientOptions, RedisClientType } from './lib/client';
+import RedisClientMultiCommand, { RedisClientMultiCommandType } from './lib/client/multi-command';
 export { RedisClientOptions, RedisClientType };
 export const createClient = RedisClient.create;
 export { CommandParser } from './lib/client/parser';
@@ -37,3 +39,13 @@ export { REDIS_FLUSH_MODES } from './lib/commands/FLUSHALL';
 
 export { BasicClientSideCache, BasicPooledClientSideCache } from './lib/client/cache';
 
+
+
+export const MULTI = < M extends RedisModules, F extends RedisFunctions, S extends RedisScripts, RESP extends RespVersions, TYPE_MAPPING extends TypeMapping >(client: RedisClientType) => {
+  type Multi = new (...args: ConstructorParameters<typeof RedisClientMultiCommand>) => RedisClientMultiCommandType<[], M, F, S, RESP, TYPE_MAPPING>;
+  return new ((this as any).Multi as Multi)(
+    client._executeMulti.bind(client),
+    client._executePipeline.bind(client),
+    client._commandOptions?.typeMapping
+  );
+}


### PR DESCRIPTION
RedisClientMultiCommandType is slow to typecheck because of its recursive nature and the fact that it has many ( around 700 ) methods. Most of the users dont use multi(), so there is no point to incur the ts costs to them. One possible solution is to move the multi() method away from the main RedisClient, thus typechecking will not apply to RedisClientMultiCommandType.

This is a breaking change.

Usage before:

```ts
import { createClient } from 'redis';
const client = createClient();
cont result = await client.multi()
  .set('foo', 3)
  .get('bar')
  .execTyped();
```

Usage after:

```ts
import { createClient, multi } from 'redis';
const client = createClient();
cont result = await multi(client)
  .set('foo', 3)
  .get('bar')
  .execTyped();
```

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
