### PR TITLE
Fix: resolve doubly linked list push issue

### DIFF
--- a/packages/client/lib/client/linked-list.spec.ts
+++ b/packages/client/lib/client/linked-list.spec.ts
@@ -6,7 +6,7 @@ import {
 import { equal, deepEqual } from "assert/strict";
 
 describe("DoublyLinkedList", () => {
-  const list = new DoublyLinkedList();
+  const list = new DoublyLinkedList<number>();
 
   it("should start empty", () => {
     equal(list.length, 0);
@@ -95,6 +95,38 @@ describe("DoublyLinkedList", () => {
       count++;
     }
     equal(count, 6);
+  });
+
+  it("should handle remove on empty list", () => {
+    list.reset();
+    const node = list.push(1);
+    list.remove(node);
+    equal(list.length, 0);
+    deepEqual(Array.from(list), []);
+    list.remove(node);
+    equal(list.length, 0);
+    deepEqual(Array.from(list), []);
+  });
+
+
+  it("should safely remove nodes while iterating", () => {
+    list.reset();
+    list.push(1);
+    list.push(2);
+    list.push(3);
+    list.push(4);
+    list.push(5);
+    
+    const visited: number[] = [];
+    for (const node of list.nodes()) {
+      visited.push(node.value);
+      if (node.value % 2 === 0) {
+        list.remove(node);
+      }
+    }
+    deepEqual(visited, [1, 2, 3, 4, 5]);
+    equal(list.length, 3);
+    deepEqual(Array.from(list), [1, 3, 5]);
   });
 });
 

--- a/packages/client/lib/client/linked-list.ts
+++ b/packages/client/lib/client/linked-list.ts
@@ -29,11 +29,16 @@ export class DoublyLinkedList<T> {
     ++this.#length;
 
     if (this.#tail === undefined) {
-      return this.#tail = this.#head = {
+      this.#head = {
+        previous: undefined,
+        next: this.#tail,
+        value
+      }
+      return this.#tail = {
         previous: this.#head,
         next: undefined,
         value
-      };
+      }
     }
 
     return this.#tail = this.#tail.next = {

--- a/packages/client/lib/client/linked-list.ts
+++ b/packages/client/lib/client/linked-list.ts
@@ -83,6 +83,7 @@ export class DoublyLinkedList<T> {
   }
 
   remove(node: DoublyLinkedNode<T>) {
+    if (this.#length === 0) return;
     --this.#length;
 
     if (this.#tail === node) {

--- a/packages/client/lib/client/linked-list.ts
+++ b/packages/client/lib/client/linked-list.ts
@@ -29,13 +29,8 @@ export class DoublyLinkedList<T> {
     ++this.#length;
 
     if (this.#tail === undefined) {
-      this.#head = {
+      return this.#head = this.#tail = {
         previous: undefined,
-        next: this.#tail,
-        value
-      };
-      return this.#tail = {
-        previous: this.#head,
         next: undefined,
         value
       };
@@ -92,15 +87,18 @@ export class DoublyLinkedList<T> {
 
     if (this.#tail === node) {
       this.#tail = node.previous;
-    }
-
+    } 
     if (this.#head === node) {
       this.#head = node.next;
     } else {
-      node.previous!.next = node.next;
-      node.previous = undefined;
+      if (node.previous) {
+        node.previous.next = node.next;
+      }
     }
-
+    if (node.next) {
+      node.next.previous = node.previous;
+    }
+    node.previous = undefined;
     node.next = undefined;
   }
 

--- a/packages/client/lib/client/linked-list.ts
+++ b/packages/client/lib/client/linked-list.ts
@@ -94,7 +94,7 @@ export class DoublyLinkedList<T> {
       if (node.previous) {
         node.previous.next = node.next;
       }
-    }
+    }    
     if (node.next) {
       node.next.previous = node.previous;
     }
@@ -118,8 +118,9 @@ export class DoublyLinkedList<T> {
   *nodes() {
     let node = this.#head;
     while(node) {
+      const next = node.next
       yield node;
-      node = node.next;
+      node = next;
     }
   }
 }

--- a/packages/client/lib/client/linked-list.ts
+++ b/packages/client/lib/client/linked-list.ts
@@ -33,12 +33,12 @@ export class DoublyLinkedList<T> {
         previous: undefined,
         next: this.#tail,
         value
-      }
+      };
       return this.#tail = {
         previous: this.#head,
         next: undefined,
         value
-      }
+      };
     }
 
     return this.#tail = this.#tail.next = {

--- a/packages/client/lib/client/linked-list.ts
+++ b/packages/client/lib/client/linked-list.ts
@@ -30,7 +30,7 @@ export class DoublyLinkedList<T> {
 
     if (this.#tail === undefined) {
       return this.#head = this.#tail = {
-        previous: undefined,
+        previous: this.#head,
         next: undefined,
         value
       };
@@ -73,7 +73,7 @@ export class DoublyLinkedList<T> {
     --this.#length;
     const node = this.#head;
     if (node.next) {
-      node.next.previous = node.previous;
+      node.next.previous = undefined;
       this.#head = node.next;
       node.next = undefined;
     } else {
@@ -92,11 +92,11 @@ export class DoublyLinkedList<T> {
       this.#head = node.next;
     } else {
       if (node.previous) {
-        node.previous.next = node.next;
+          node.previous.next = node.next;
       }
-    }    
-    if (node.next) {
-      node.next.previous = node.previous;
+      if (node.next) {
+        node.next.previous = node.previous;
+      }
     }
     node.previous = undefined;
     node.next = undefined;

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -936,7 +936,7 @@ class RedisSentinelInternal<
         this.#sentinelRootNodes.splice(found, 1);
     }
     this.#reset();
-    }
+  }
 
   async close() {
     this.#destroy = true;

--- a/packages/client/lib/sentinel/index.ts
+++ b/packages/client/lib/sentinel/index.ts
@@ -928,6 +928,16 @@ class RedisSentinelInternal<
     }
   }
 
+  #handleSentinelFailure(node: RedisNode) {
+    const found = this.#sentinelRootNodes.findIndex(
+        (rootNode) => rootNode.host === node.host && rootNode.port === node.port
+    );
+    if (found !== -1) {
+        this.#sentinelRootNodes.splice(found, 1);
+    }
+    this.#reset();
+    }
+
   async close() {
     this.#destroy = true;
 
@@ -1197,8 +1207,9 @@ class RedisSentinelInternal<
           error: err
         };
         this.emit('client-error', event);
-        this.#reset();
-      });
+        this.#handleSentinelFailure(node);
+      })
+      .on('end', () => this.#handleSentinelFailure(node));
       this.#sentinelClient = client;
 
       this.#trace(`transform: adding sentinel client connect() to promise list`);


### PR DESCRIPTION
### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

- Fixed initialization problem in DoublyLinkedList.push() for an empty doubly linked list
- Resolves issue with client pool management
- An attempt to fix this issue https://github.com/redis/node-redis/issues/3062.

Now the client pool properly shut down after getting a bad connection.
---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? Just a Bug fix.

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->
