### PR TITLE
fix(client): dispose credentials subscription on every close() path

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -1542,18 +1542,6 @@ describe('Client', () => {
       return log;
     }
 
-    function countRespCommands(chunk: Buffer): number {
-      let commands = 0;
-
-      for (let i = 0; i < chunk.length; i++) {
-        if (chunk[i] === 42 && (i === 0 || chunk[i - 1] === 10)) {
-          commands++;
-        }
-      }
-
-      return commands;
-    }
-
     // Create a TCP server that accepts connections but immediately drops them <dropImmediately> times.
     // For accepted connections, reply with one `+OK` per incoming RESP command.
     function setupMockServer(dropImmediately: number) {
@@ -1575,7 +1563,54 @@ describe('Client', () => {
     }
 
   });
+
+  describe('close', () => {
+    it('disposes the credentials subscription when the command queue is empty', async () => {
+      const server = net.createServer(socket => {
+        socket.on('data', (chunk: Buffer) => {
+          socket.write('+OK\r\n'.repeat(countRespCommands(chunk)));
+        });
+      });
+      const port = await getFreePortNumber();
+      await once(server.listen(port), 'listening');
+
+      let disposed = false;
+      const client = createClient({
+        socket: {
+          host: 'localhost',
+          port
+        },
+        credentialsProvider: {
+          type: 'streaming-credentials-provider',
+          subscribe: async () => [
+            { password: 'password' },
+            { dispose: () => { disposed = true; } }
+          ],
+          onReAuthenticationError: () => {}
+        }
+      });
+
+      await client.connect();
+      await client.close();
+
+      assert.equal(disposed, true);
+
+      server.close();
+    });
+  });
 });
+
+function countRespCommands(chunk: Buffer): number {
+  let commands = 0;
+
+  for (let i = 0; i < chunk.length; i++) {
+    if (chunk[i] === 42 && (i === 0 || chunk[i - 1] === 10)) {
+      commands++;
+    }
+  }
+
+  return commands;
+}
 
 /**
  * Executes the provided function in a context where setImmediate is stubbed to not do anything.

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -2187,6 +2187,8 @@ export default class RedisClient<
       clearTimeout(this._self.#pingTimer);
       this._self.#socket.close();
       this._self.#clientSideCache?.onClose();
+      this._self.#credentialsSubscription?.dispose();
+      this._self.#credentialsSubscription = null;
 
       if (this._self.#queue.isEmpty()) {
         this._self.#unregisterFromMetrics();
@@ -2203,8 +2205,6 @@ export default class RedisClient<
         resolve();
       };
       this._self.#socket.on('data', maybeClose);
-      this._self.#credentialsSubscription?.dispose();
-      this._self.#credentialsSubscription = null;
     });
   }
 


### PR DESCRIPTION
### Description

Fixes #3390.

`close()` only disposed the streaming credentials subscription on the path where the command queue still had pending commands. On a graceful shutdown of an idle client the queue is already empty, so `close()` hit the early `return resolve()` and left the subscription alive. With `@redis/entraid` that keeps the token-refresh timer armed and the process never exits.

The dispose call now runs before the empty-queue early return, so both paths release the subscription, matching what `destroy()` already does.

The new test connects a client with a streaming credentials provider to a mock TCP server, closes it with an empty queue, and asserts the subscription was disposed.

---

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle fix aligned with `destroy()`/`quit()`; behavior change only affects graceful close with streaming auth when the queue is empty.
> 
> **Overview**
> **`close()`** now disposes the streaming **`credentialsSubscription`** at the start of shutdown, before the command-queue empty check. Previously that cleanup only ran on the branch that waited for pending replies, so an idle client could exit **`close()`** without calling **`dispose()`**—leaving token-refresh timers alive (e.g. with **`@redis/entraid`**) and preventing process exit.
> 
> A regression test connects with a streaming credentials provider, **`close()`**s with an empty queue, and asserts **`dispose`** ran. **`countRespCommands`** was hoisted to module scope for shared mock-server use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1af6ea8dccf86b22252adf9e6a80f3b1ee74524e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->