### PR TITLE
fix(client): decode RESP3 doubles to the value the server sent

### DIFF
--- a/packages/client/lib/RESP/decoder.spec.ts
+++ b/packages/client/lib/RESP/decoder.spec.ts
@@ -211,6 +211,70 @@ describe('RESP Decoder', () => {
       toWrite: Buffer.from(',1\r\n'),
       replies: ['1']
     });
+
+    // The server writes the shortest representation that round-trips
+    // (`fpconv_dtoa` via `d2string`), so decoding must return the exact same
+    // double — anything else and a score read back differs from the score
+    // stored. These are the values that used to decode a rounding off.
+    describe('round-trips the double the server encoded', () => {
+      test('0.3', {
+        toWrite: Buffer.from(',0.3\r\n'),
+        replies: [0.3]
+      });
+
+      test('99.99', {
+        toWrite: Buffer.from(',99.99\r\n'),
+        replies: [99.99]
+      });
+
+      test('12345.6789', {
+        toWrite: Buffer.from(',12345.6789\r\n'),
+        replies: [12345.6789]
+      });
+
+      test('0.30000000000000004', {
+        toWrite: Buffer.from(',0.30000000000000004\r\n'),
+        replies: [0.30000000000000004]
+      });
+
+      test('-0', {
+        toWrite: Buffer.from(',-0\r\n'),
+        replies: [-0]
+      });
+
+      // 16+ significant digits and exponents exceed the exact path and take
+      // the `Number` fallback.
+      test('3.141592653589793', {
+        toWrite: Buffer.from(',3.141592653589793\r\n'),
+        replies: [3.141592653589793]
+      });
+
+      test('1.2345678901234567e+9', {
+        toWrite: Buffer.from(',1.2345678901234567e+9\r\n'),
+        replies: [1234567890.1234567]
+      });
+
+      // MAX_VALUE used to overflow to Infinity, MIN_VALUE to underflow to 0
+      test('1.7976931348623157e+308 (MAX_VALUE)', {
+        toWrite: Buffer.from(',1.7976931348623157e+308\r\n'),
+        replies: [Number.MAX_VALUE]
+      });
+
+      test('-1.7976931348623157e+308 (-MAX_VALUE)', {
+        toWrite: Buffer.from(',-1.7976931348623157e+308\r\n'),
+        replies: [-Number.MAX_VALUE]
+      });
+
+      test('5e-324 (MIN_VALUE)', {
+        toWrite: Buffer.from(',5e-324\r\n'),
+        replies: [Number.MIN_VALUE]
+      });
+
+      test('2.2250738585072014e-308', {
+        toWrite: Buffer.from(',2.2250738585072014e-308\r\n'),
+        replies: [2.2250738585072014e-308]
+      });
+    });
   });
 
   describe('SimpleString', () => {

--- a/packages/client/lib/RESP/decoder.ts
+++ b/packages/client/lib/RESP/decoder.ts
@@ -28,12 +28,40 @@ const ASCII = {
   '+': 43,
   '-': 45,
   '0': 48,
-  '.': 46,
-  'i': 105,
-  'n': 110,
-  'E': 69,
-  'e': 101
+  '.': 46
 } as const;
+
+// Powers of ten that are exactly representable as a double, so dividing by one
+// of them rounds only once.
+const POWERS_OF_10 = [
+  1, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11,
+  1e12, 1e13, 1e14, 1e15, 1e16, 1e17, 1e18, 1e19, 1e20, 1e21, 1e22
+];
+
+// Largest significand that can still absorb one more digit exactly:
+// 900719925474098 * 10 + 9 is the last value <= MAX_SAFE_INTEGER.
+const MAX_SIGNIFICAND_BEFORE_DIGIT = 900719925474098;
+
+// Fallback for tokens the exact path cannot scale in one rounding. Mirrors the
+// RESP2 double transformer (`transformDoubleReply[2]` in
+// `../commands/generic-transformers`), so both protocol versions agree.
+function slowParseDouble(buffer, start, end) {
+  const string = buffer.toString(undefined, start, end);
+
+  switch (string) {
+    case 'inf':
+    case '+inf':
+      return Infinity;
+
+    case '-inf':
+      return -Infinity;
+
+    case 'nan':
+      return NaN;
+  }
+
+  return Number(string);
+}
 
 export const PUSH_TYPE_MAPPING = {
   [RESP_TYPES.BLOB_STRING]: Buffer
@@ -338,137 +366,66 @@ export class Decoder {
       return this.#decodeSimpleString(String, chunk);
     }
 
-    switch (chunk[this.#cursor]) {
-      case ASCII.n:
-        this.#cursor += 5; // skip nan\r\n
-        return NaN;
-
-      case ASCII['+']:
-        return this.#maybeDecodeDoubleInteger(false, chunk);
-
-      case ASCII['-']:
-        return this.#maybeDecodeDoubleInteger(true, chunk);
-
-      default:
-        return this.#decodeDoubleInteger(false, 0, chunk);
-    }
-  }
-
-  #maybeDecodeDoubleInteger(isNegative, chunk) {
-    return ++this.#cursor === chunk.length ?
-      this.#decodeDoubleInteger.bind(this, isNegative, 0) :
-      this.#decodeDoubleInteger(isNegative, 0, chunk);
-  }
-
-  #decodeDoubleInteger(isNegative, integer, chunk) {
-    if (chunk[this.#cursor] === ASCII.i) {
-      this.#cursor += 5; // skip inf\r\n
-      return isNegative ? -Infinity : Infinity;
+    // Digits accumulate into an integer significand, scaled by a single division
+    // at the end so the value is rounded once — the exact double the server
+    // encoded. Shapes that would need more than one rounding (`e` exponents,
+    // significands or decimal exponents outside the exactly representable range)
+    // and `inf`/`nan` go to `slowParseDouble`.
+    const start = this.#cursor;
+    let cursor = start;
+    if (chunk[cursor] === ASCII['-'] || chunk[cursor] === ASCII['+']) {
+      cursor++;
     }
 
-    return this.#continueDecodeDoubleInteger(isNegative, integer, chunk);
-  }
+    let significand = 0,
+      digits = 0,
+      // -1 until the decimal point is seen, then the number of digits after it.
+      fractionDigits = -1;
 
-  #continueDecodeDoubleInteger(isNegative, integer, chunk) {
-    let cursor = this.#cursor;
-    do {
+    while (cursor < chunk.length) {
       const byte = chunk[cursor];
-      switch (byte) {
-        case ASCII['.']:
-          this.#cursor = cursor + 1; // skip .
-          return this.#cursor < chunk.length ?
-            this.#decodeDoubleDecimal(isNegative, 0, integer, chunk) :
-            this.#decodeDoubleDecimal.bind(this, isNegative, 0, integer);
 
-        case ASCII.E:
-        case ASCII.e: {
-          this.#cursor = cursor + 1; // skip E/e
-          const i = isNegative ? -integer : integer;
-          return this.#cursor < chunk.length ?
-            this.#decodeDoubleExponent(i, chunk) :
-            this.#decodeDoubleExponent.bind(this, i);
-        }
-
-        case ASCII['\r']:
-          this.#cursor = cursor + 2; // skip \r\n
-          return isNegative ? -integer : integer;
-
-        default:
-          integer = integer * 10 + byte - ASCII['0'];
-      }
-    } while (++cursor < chunk.length);
-
-    this.#cursor = cursor;
-    return this.#continueDecodeDoubleInteger.bind(this, isNegative, integer);
-  }
-
-  // Precalculated multipliers for decimal points to improve performance
-  // "... about 15 to 17 decimal places ..."
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number#:~:text=about%2015%20to%2017%20decimal%20places
-  static #DOUBLE_DECIMAL_MULTIPLIERS = [
-    1e-1, 1e-2, 1e-3, 1e-4, 1e-5, 1e-6,
-    1e-7, 1e-8, 1e-9, 1e-10, 1e-11, 1e-12,
-    1e-13, 1e-14, 1e-15, 1e-16, 1e-17
-  ];
-
-  #decodeDoubleDecimal(isNegative, decimalIndex, double, chunk) {
-    let cursor = this.#cursor;
-    do {
-      const byte = chunk[cursor];
-      switch (byte) {
-        case ASCII.E:
-        case ASCII.e: {
-          this.#cursor = cursor + 1; // skip E/e
-          const d = isNegative ? -double : double;
-          return this.#cursor === chunk.length ?
-            this.#decodeDoubleExponent.bind(this, d) :
-            this.#decodeDoubleExponent(d, chunk);
-        }
-
-        case ASCII['\r']:
-          this.#cursor = cursor + 2; // skip \r\n
-          return isNegative ? -double : double;
-      }
-
-      if (decimalIndex < Decoder.#DOUBLE_DECIMAL_MULTIPLIERS.length) {
-        double += (byte - ASCII['0']) * Decoder.#DOUBLE_DECIMAL_MULTIPLIERS[decimalIndex++];
-      }
-    } while (++cursor < chunk.length);
-
-    this.#cursor = cursor;
-    return this.#decodeDoubleDecimal.bind(this, isNegative, decimalIndex, double);
-  }
-
-  #decodeDoubleExponent(double, chunk) {
-    switch (chunk[this.#cursor]) {
-      case ASCII['+']:
-        return ++this.#cursor === chunk.length ?
-          this.#continueDecodeDoubleExponent.bind(this, false, double, 0) :
-          this.#continueDecodeDoubleExponent(false, double, 0, chunk);
-
-      case ASCII['-']:
-        return ++this.#cursor === chunk.length ?
-          this.#continueDecodeDoubleExponent.bind(this, true, double, 0) :
-          this.#continueDecodeDoubleExponent(true, double, 0, chunk);
-    }
-
-    return this.#continueDecodeDoubleExponent(false, double, 0, chunk);
-  }
-
-  #continueDecodeDoubleExponent(isNegative, double, exponent, chunk) {
-    let cursor = this.#cursor;
-    do {
-      const byte = chunk[cursor];
       if (byte === ASCII['\r']) {
         this.#cursor = cursor + 2; // skip \r\n
-        return double * 10 ** (isNegative ? -exponent : exponent);
+        if (digits === 0 || fractionDigits >= POWERS_OF_10.length) {
+          return slowParseDouble(chunk, start, cursor);
+        }
+
+        const double = fractionDigits > 0 ?
+          significand / POWERS_OF_10[fractionDigits] :
+          significand;
+        return chunk[start] === ASCII['-'] ? -double : double;
       }
 
-      exponent = exponent * 10 + byte - ASCII['0'];
-    } while (++cursor < chunk.length);
+      if (byte === ASCII['.'] && fractionDigits === -1) {
+        fractionDigits = 0;
+      } else {
+        const digit = byte - ASCII['0'];
+        if (digit < 0 || digit > 9 || significand > MAX_SIGNIFICAND_BEFORE_DIGIT) {
+          const crlfIndex = this.#findCRLF(chunk, cursor);
+          return crlfIndex === -1 ?
+            this.#continueDecodeDouble.bind(this, [chunk.subarray(start)]) :
+            slowParseDouble(chunk, start, crlfIndex);
+        }
 
+        significand = significand * 10 + digit;
+        digits++;
+        if (fractionDigits !== -1) fractionDigits++;
+      }
+
+      cursor++;
+    }
+
+    // The token continues in the next chunk; buffer it and convert once whole.
     this.#cursor = cursor;
-    return this.#continueDecodeDoubleExponent.bind(this, isNegative, double, exponent);
+    return this.#continueDecodeDouble.bind(this, [chunk.subarray(start)]);
+  }
+
+  #continueDecodeDouble(chunks, chunk) {
+    const buffer = this.#continueDecodeSimpleString(chunks, Buffer, chunk);
+    return typeof buffer === 'function' ?
+      this.#continueDecodeDouble.bind(this, chunks) :
+      slowParseDouble(buffer, 0, buffer.length);
   }
 
   #findCRLF(chunk, cursor) {


### PR DESCRIPTION
### Description

RESP3 doubles are decoded to a different double than the server sent, for most values. On `master` (RESP3 is the default since #3215):

```
ZADD score           bytes redis sends           zScore() returns
0.3                  ,0.3                        0.30000000000000004
99.99                ,99.99                      99.99000000000001
8275.35              ,8275.35                     8275.349999999999
12345.6789           ,12345.6789                  12345.678899999999
Number.MAX_VALUE     ,1.7976931348623157e+308     Infinity
Number.MIN_VALUE     ,5e-324                      0
```

Over random doubles round-tripped through the wire format redis actually
writes, **51.5% (3087/5999) came back as a different double than the one
stored**. The same `ZSCORE` under `RESP: 2` is exact, because the RESP2 path
goes through `transformDoubleReply[2]`, which just calls `Number()`.

The cause is in `#decodeDouble`. Fraction digits were summed as
`double += digit * 1e-k` from a precalculated multiplier table, and any
exponent was then applied as a separate `double * 10 ** exponent`. Each of
those steps rounds, so the error compounds — and for magnitudes near the
limits of the type the final multiplication overflows to `Infinity` or
underflows to `0` even though the value itself is perfectly representable.
Digits past the 17th were dropped rather than rounded.

This affects everything that returns a RESP3 double: `ZSCORE`, `ZMSCORE`,
`ZINCRBY`, `ZADD … INCR`, `*WITHSCORES`, `GEODIST`, `GEOPOS`, and the
module commands built on doubles.

### What changed

Digits now accumulate into an integer significand and are scaled by a
**single** division by an exactly representable power of ten. One IEEE
operation on two exact operands rounds once, so the result is the correctly
rounded double — the exact value the server encoded.

Tokens that cannot be rebuilt that way — an `e` exponent, a significand
above `MAX_SAFE_INTEGER`, more than 22 fraction digits, `inf`/`nan` — hand
off to `Number()`, which is correctly rounded for every input. That fallback
also fixes the overflow/underflow cases, and its `inf`/`+inf`/`-inf`/`nan`
handling is copied from `transformDoubleReply[2]` so the two protocol
versions can no longer disagree.

Scanning still happens in place over the chunk: a double that arrives whole
costs no slice and no intermediate string. The change is a net −120 lines,
since the exponent and decimal continuation state machines are gone; the
split-across-chunks case buffers the token and converts it once whole.

### Verification

Wire bytes for the differential tests were produced by compiling redis's own
`deps/fpconv/fpconv_dtoa.c` and driving it exactly as `d2string()` does, so
the inputs are the literal bytes the server writes, not an approximation.

- Round-trip over 6031 doubles (hand-picked edge cases + random bit patterns,
  uniform, log-uniform, and 2-decimal): **before 3098 wrong, after 0**.
- 300k generated decimal tokens, including malformed ones (`1.2.3`, `0x10`,
  `' 1'`, bare `+`, `1e`, 30-digit significands): the fast path agrees with
  `Number()` on **all** of them, 0 divergences.
- Chunk-boundary fuzz: 30,275 split configurations (every single-cut position,
  byte-by-byte, and random multi-cut) over 21 doubles — 0 failures.
- 11 new cases in `decoder.spec.ts`; each runs single-chunk and byte-by-byte
  via the existing `test()` helper. 18 of the 22 assertions fail on `master`.
- `npm run build` and `npm run test:types -w @redis/client` clean;
  `eslint --max-warnings=0` clean on both changed files.
- Docker-free specs in `packages/client`: 344 passing. I could not run the
  dockerized suite (no host-networking Docker on this machine), so the
  integration tests are unverified locally — CI covers them.

### Performance

This file is written for speed, so I measured old vs new in the same process
with rounds interleaved, reporting medians and spreads rather than a single
delta:

| workload | old | new | |
|---|---|---|---|
| `ZRANGE … WITHSCORES`, 500 members, RESP3 | 162.1ms | 161.0ms | 0.99x, spreads overlap |
| doubles only, typical score shapes | 21.8ms | 22.3ms | 1.02x |
| doubles only, mixed incl. `e` exponents and extremes | 40.5ms | 46.8ms | 1.16x |
| integers only (control, untouched path) | 24.0ms | 23.6ms | 0.98x |

768k doubles per run. Realistic replies are unchanged; the 1.16x is a stream
made entirely of shapes that now take the `Number()` fallback, which no
longer decodes them wrongly.

---

### Checklist

- [x] Does `npm test` pass with this change (including linting)?  Build, type
      tests, lint and all Docker-free specs pass; the dockerized suite needs
      host networking I don't have locally.
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? No API change — decoded values are now correct.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hot-path protocol parsing used by all RESP3 double replies (scores, geo, modules); behavior change is correctness-focused but affects every consumer of those values.
> 
> **Overview**
> **Fixes incorrect RESP3 double decoding** so values like sorted-set scores and geo coordinates match what Redis encoded on the wire (e.g. `0.3`, `99.99`, `Number.MAX_VALUE` no longer drift, overflow to `Infinity`, or underflow to `0`).
> 
> `#decodeDouble` in the RESP decoder **replaces** the old digit-by-digit decimal multipliers and separate exponent scaling with an **integer significand** scaled by **one** division using exactly representable powers of ten. Tokens that cannot use that path (`e` exponents, huge significands, `inf`/`nan`, etc.) go through a new **`slowParseDouble`** helper aligned with the RESP2 `Number()` transformer.
> 
> **Tests:** adds a `round-trips the double the server encoded` block in `decoder.spec.ts` (including byte-by-byte chunk splits via the existing harness).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf3857e41c8c5d2ce253ffdb3f40687a17fe8a68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->