### PR TITLE
fix(cluster): handle MOVED and ASK redirects for atomic MULTI

### DIFF
--- a/packages/client/lib/client/commands-queue.ts
+++ b/packages/client/lib/client/commands-queue.ts
@@ -720,10 +720,8 @@ export default class RedisCommandsQueue {
    * connection, preserving the order they were originally sent in, and get
    * sent here as originally queued. If a key has by then moved to another
    * node, that surfaces as a normal MOVED/ASK error through this method's
-   * caller - unlike single commands, MULTI/pipeline execution doesn't go
-   * through cluster's redirect-and-retry loop, so this isn't automatically
-   * retried, but that's an existing, separate limitation this method isn't
-   * responsible for preventing.
+   * caller. Atomic MULTI execution retries through the cluster redirect loop;
+   * non-atomic pipeline execution intentionally does not.
    */
   extractCommandsForSlots(slots: Set<number>): CommandToWrite[] {
     const result: CommandToWrite[] = [];

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -1914,7 +1914,8 @@ export default class RedisClient<
   async _executeMulti(
     commands: Array<RedisMultiQueuedCommand>,
     selectedDB?: number,
-    slotNumber?: number
+    slotNumber?: number,
+    chainId = Symbol('MULTI Chain')
   ) {
     assertNoHimportSessionCommands(commands);
 
@@ -1940,7 +1941,6 @@ export default class RedisClient<
     return trace(CHANNELS.TRACE_BATCH,
       async () => {
         const typeMapping = this._commandOptions?.typeMapping;
-        const chainId = Symbol('MULTI Chain');
         const promises: Array<Promise<unknown>> = [
           this._self.#queue.addCommand(['MULTI'], { chainId, slotNumber }),
         ];

--- a/packages/client/lib/cluster/batch-routing.spec.ts
+++ b/packages/client/lib/cluster/batch-routing.spec.ts
@@ -1,5 +1,7 @@
 import { strict as assert } from 'node:assert';
+import calculateSlot from 'cluster-key-slot';
 import RedisCluster from '.';
+import { ErrorReply } from '../errors';
 
 describe('Cluster batch routing', () => {
   it('passes the selected slot to MULTI execution', async () => {
@@ -56,5 +58,134 @@ describe('Cluster batch routing', () => {
       ['OK']
     );
     assert.equal(capturedSlotNumber, 456);
+  });
+
+  it('retries MULTI after a MOVED redirect', async () => {
+    const cluster = RedisCluster.create({ rootNodes: [] });
+    const key = 'key';
+    const slotNumber = calculateSlot(key);
+    const attempts: Array<{ client: string; slotNumber?: number }> = [];
+
+    const redirectedClient = {
+      _clientId: 'redirected',
+      _executeMulti: async (
+        _commands: unknown,
+        _selectedDB?: number,
+        routedSlot?: number
+      ) => {
+        attempts.push({ client: 'redirected', slotNumber: routedSlot });
+        return ['OK'];
+      }
+    };
+    const staleClient = {
+      _clientId: 'stale',
+      _executeMulti: async (
+        _commands: unknown,
+        _selectedDB?: number,
+        routedSlot?: number
+      ): Promise<Array<unknown>> => {
+        attempts.push({ client: 'stale', slotNumber: routedSlot });
+        throw new ErrorReply(`MOVED ${slotNumber} 127.0.0.1:7001`);
+      }
+    };
+    let currentClient = staleClient;
+
+    cluster._slots.getClientAndSlotNumber = async () => ({
+      client: currentClient as never,
+      slotNumber
+    });
+    cluster._slots.rediscover = async () => {
+      currentClient = redirectedClient as typeof staleClient;
+    };
+
+    assert.deepEqual(
+      await cluster.multi().set(key, 'value').exec(),
+      ['OK']
+    );
+    assert.deepEqual(attempts, [
+      { client: 'stale', slotNumber },
+      { client: 'redirected', slotNumber }
+    ]);
+  });
+
+  it('keeps ASKING and the redirected MULTI in the same queue chain', async () => {
+    const cluster = RedisCluster.create({ rootNodes: [] });
+    const key = 'key';
+    const slotNumber = calculateSlot(key);
+    let askingChainId: symbol | undefined;
+    let multiChainId: symbol | undefined;
+    let redirectedSlot: number | undefined;
+
+    const redirectedClient = {
+      _clientId: 'redirected',
+      sendCommand: async (
+        args: ReadonlyArray<string>,
+        options?: { chainId?: symbol }
+      ) => {
+        assert.deepEqual(args, ['ASKING']);
+        askingChainId = options?.chainId;
+        return 'OK';
+      },
+      _executeMulti: async (
+        _commands: unknown,
+        _selectedDB?: number,
+        routedSlot?: number,
+        chainId?: symbol
+      ) => {
+        redirectedSlot = routedSlot;
+        multiChainId = chainId;
+        return ['OK'];
+      }
+    };
+    const staleClient = {
+      _clientId: 'stale',
+      _executeMulti: async (): Promise<Array<unknown>> => {
+        throw new ErrorReply(`ASK ${slotNumber} 127.0.0.1:7001`);
+      }
+    };
+
+    cluster._slots.getClientAndSlotNumber = async () => ({
+      client: staleClient as never,
+      slotNumber
+    });
+    cluster._slots.getMasterByAddress = async () => redirectedClient as never;
+
+    assert.deepEqual(
+      await cluster.multi().get(key).exec(),
+      ['OK']
+    );
+    assert.notEqual(askingChainId, undefined);
+    assert.equal(multiChainId, askingChainId);
+    assert.equal(redirectedSlot, slotNumber);
+  });
+
+  it('does not retry a non-atomic pipeline after MOVED', async () => {
+    const cluster = RedisCluster.create({ rootNodes: [] });
+    const key = 'key';
+    const slotNumber = calculateSlot(key);
+    let attempts = 0;
+    let rediscoveries = 0;
+
+    const client = {
+      _executePipeline: async (): Promise<Array<unknown>> => {
+        attempts++;
+        throw new ErrorReply(`MOVED ${slotNumber} 127.0.0.1:7001`);
+      }
+    };
+
+    cluster._slots.getClientAndSlotNumber = async () => ({
+      client: client as never,
+      slotNumber
+    });
+    cluster._slots.rediscover = async () => {
+      rediscoveries++;
+    };
+
+    await assert.rejects(
+      cluster.multi().get(key).execAsPipeline(),
+      error => error instanceof ErrorReply && error.message.startsWith('MOVED')
+    );
+    assert.equal(attempts, 1);
+    assert.equal(rediscoveries, 0);
   });
 });

--- a/packages/client/lib/cluster/index.ts
+++ b/packages/client/lib/cluster/index.ts
@@ -815,8 +815,20 @@ export default class RedisCluster<
     type Multi = new (...args: ConstructorParameters<typeof RedisClusterMultiCommand>) => RedisClusterMultiCommandType<[], M, F, S, RESP, TYPE_MAPPING>;
     return new (this as this & { Multi: Multi }).Multi(
       async (firstKey, isReadonly, commands) => {
-        const { client, slotNumber } = await this._self._slots.getClientAndSlotNumber(firstKey, isReadonly);
-        return client._executeMulti(commands, undefined, slotNumber);
+        const parser = new BasicCommandParser();
+        if (firstKey !== undefined) parser.markRoutingKey(firstKey);
+
+        return this._self._execute(
+          parser,
+          isReadonly,
+          undefined,
+          (client, options) => client._executeMulti(
+            commands,
+            undefined,
+            options?.slotNumber,
+            options?.chainId
+          )
+        );
       },
       async (firstKey, isReadonly, commands) => {
         const { client, slotNumber } = await this._self._slots.getClientAndSlotNumber(firstKey, isReadonly);

--- a/packages/client/lib/cluster/multi-redirect.spec.ts
+++ b/packages/client/lib/cluster/multi-redirect.spec.ts
@@ -62,13 +62,16 @@ describe('Cluster MULTI redirects', () => {
     } catch (error) {
       // After any post-failover failure, repair the cached topology before
       // test-utils flushes the cluster so the original error is not masked.
-      await cluster.get(key).catch(() => undefined);
+      await cluster.set(key, '0').catch(() => undefined);
       throw error;
     }
   }, {
     serverArguments: [],
     numberOfMasters: 2,
     numberOfReplicas: 1,
+    clusterConfiguration: {
+      useReplicas: true
+    },
     testTimeout: 30000
   });
 });

--- a/packages/client/lib/cluster/multi-redirect.spec.ts
+++ b/packages/client/lib/cluster/multi-redirect.spec.ts
@@ -1,0 +1,74 @@
+import { strict as assert } from 'node:assert';
+import { setTimeout } from 'node:timers/promises';
+import calculateSlot from 'cluster-key-slot';
+import testUtils from '../test-utils';
+import { ErrorReply } from '../errors';
+
+describe('Cluster MULTI redirects', () => {
+  testUtils.testWithCluster('retries MULTI after master failover while the previous master remains reachable', async cluster => {
+    const key = 'multi-failover-key';
+    const slot = calculateSlot(key);
+
+    await cluster.set(key, '0');
+
+    const shard = cluster.slots[slot];
+    const previousMaster = shard.master;
+    assert.ok(shard.replicas?.length);
+    const replica = shard.replicas[0];
+    const [previousMasterClient, replicaClient] = await Promise.all([
+      cluster.nodeClient(previousMaster),
+      cluster.nodeClient(replica)
+    ]);
+
+    assert.equal(await previousMasterClient.wait(1, 5000), 1);
+
+    try {
+      await replicaClient.clusterFailover();
+
+      for (let i = 0; i < 200; i++) {
+        const [replicaInfo, previousMasterInfo] = await Promise.all([
+          replicaClient.sendCommand<string>(['INFO', 'replication']),
+          previousMasterClient.sendCommand<string>(['INFO', 'replication'])
+        ]);
+        if (
+          replicaInfo.includes('role:master') &&
+          previousMasterInfo.includes('role:slave')
+        ) {
+          break;
+        }
+        if (i === 199) {
+          assert.fail('Cluster failover did not complete');
+        }
+        await setTimeout(50);
+      }
+
+      // The previous master is still reachable, so no reconnect event can repair
+      // the stale slot map. MULTI must handle the MOVED reply itself.
+      assert.equal(await previousMasterClient.ping(), 'PONG');
+      assert.equal(cluster.slots[slot].master.id, previousMaster.id);
+      await assert.rejects(
+        previousMasterClient.get(key),
+        error => error instanceof ErrorReply && error.message.startsWith(`MOVED ${slot} `)
+      );
+
+      assert.deepEqual(
+        await cluster.multi()
+          .incr(key)
+          .get(key)
+          .exec(),
+        [1, '1']
+      );
+      assert.equal(cluster.slots[slot].master.id, replica.id);
+    } catch (error) {
+      // After any post-failover failure, repair the cached topology before
+      // test-utils flushes the cluster so the original error is not masked.
+      await cluster.get(key).catch(() => undefined);
+      throw error;
+    }
+  }, {
+    serverArguments: [],
+    numberOfMasters: 2,
+    numberOfReplicas: 1,
+    testTimeout: 30000
+  });
+});


### PR DESCRIPTION
### Description

Fixes #3394.

After a coordinated Redis Cluster failover, the previous primary can remain reachable while returning `MOVED` for slots owned by the promoted replica. Regular cluster commands recover through the redirect loop, but atomic `MULTI/EXEC` called `_executeMulti()` directly and could not refresh a stale slot map.

This change routes atomic cluster transactions through the existing redirect loop so queue-time `MOVED` and `ASK` replies can refresh routing and retry.

`execAsPipeline()` remains on its direct non-retrying path because a pipeline can be partially applied. The redirect `chainId` is passed to `_executeMulti()` so `ASKING` and `MULTI ... EXEC` stay in the same queue chain.

Only explicit Redis routing errors are retried. Socket errors, timeouts, and other ambiguous failures remain non-retried.

No public API or configuration is changed.

### Testing

- Added a unit test for retrying `MULTI` after `MOVED`.
- Added a unit test for sharing the queue chain between `ASKING` and redirected `MULTI`.
- Added a unit test confirming that non-atomic pipelines are not retried.
- Added a coordinated failover integration test with the previous primary still reachable.
- Build, lint, type checks, and 25 related unit tests pass locally.

---

### Checklist

- [ ] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? Not applicable: no public API or configuration changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster transaction routing and retry behavior on redirect errors; scope is limited to atomic MULTI and internal APIs, with explicit tests for MOVED/ASK and failover.
> 
> **Overview**
> Fixes stale-slot failures after failover when the old primary still answers with **MOVED** by routing cluster **`multi().exec()`** through **`_execute`** instead of calling **`_executeMulti`** on a one-shot client pick.
> 
> **`_executeMulti`** accepts an optional **`chainId`** from the redirect path so **`ASKING`** and the retried **`MULTI … EXEC`** share one queue chain. **`execAsPipeline()`** is unchanged and still does not retry on **MOVED**.
> 
> Docs in **`extractCommandsForSlots`** note that atomic MULTI can retry via the redirect loop while non-atomic pipelines do not. Tests cover **MOVED** retry, **ASK** chain sharing, pipeline no-retry, and a live failover with a reachable stale master.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b06219661b3f6b7557f120816c303e08507a3b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->