### PR TITLE
fix(client): resolve pool close() when a scale-up connect fails while draining

### DIFF
--- a/packages/client/lib/client/pool.spec.ts
+++ b/packages/client/lib/client/pool.spec.ts
@@ -46,6 +46,22 @@ describe('RedisClientPool', () => {
     assert.equal(pool.HOTKEYS_RESET, undefined);
   });
 
+  it('close() does not hang when a scale-up connect fails while draining', async () => {
+    // Regression: #create() pushes onto #clientsInUse before awaiting connect, and its
+    // catch only removed the node, never resolving #drainResolve. If close() started
+    // while that connect was in flight and it then failed, #clientsInUse reached 0
+    // without the drain check ever running, so close() never settled.
+    const pool = RedisClientPool.create(
+      { socket: { host: '127.0.0.1', port: 1, reconnectStrategy: false } },
+      { minimum: 1, maximum: 1, acquireTimeout: 500 }
+    );
+
+    const connectPromise = pool.connect();
+    connectPromise.catch(() => {});
+
+    await pool.close();
+  });
+
   testUtils.testWithClientPool('sendCommand', async pool => {
     assert.equal(
       await pool.sendCommand(['PING']),

--- a/packages/client/lib/client/pool.spec.ts
+++ b/packages/client/lib/client/pool.spec.ts
@@ -62,6 +62,27 @@ describe('RedisClientPool', () => {
     await pool.close();
   });
 
+  it('close() rejects a queued task if a scale-up connect fails while draining', async () => {
+    // Regression: the drain check added above only looked at #clientsInUse, not
+    // #tasksQueue. A task queued while the sole in-flight connect is still pending
+    // (no room to scale up further, no acquireTimeout to reject it on its own) got
+    // abandoned when that connect failed: #clientsInUse hit 0 and close() resolved
+    // while the queued task stayed pending forever.
+    const pool = RedisClientPool.create(
+      { socket: { host: '127.0.0.1', port: 1, reconnectStrategy: false } },
+      { minimum: 1, maximum: 1, acquireTimeout: 0 }
+    );
+
+    const connectPromise = pool.connect();
+    connectPromise.catch(() => {});
+
+    const queuedTask = pool.execute(() => Promise.resolve());
+
+    await pool.close();
+
+    await assert.rejects(queuedTask);
+  });
+
   testUtils.testWithClientPool('sendCommand', async pool => {
     assert.equal(
       await pool.sendCommand(['PING']),

--- a/packages/client/lib/client/pool.ts
+++ b/packages/client/lib/client/pool.ts
@@ -445,6 +445,11 @@ export class RedisClientPool<
     } catch (err) {
       this._self.#clientsInUse.remove(node);
       if (this._self.#isClosing && this._self.#clientsInUse.length === 0) {
+        let orphanedTask;
+        while ((orphanedTask = this._self.#tasksQueue.shift())) {
+          clearTimeout(orphanedTask.timeout);
+          orphanedTask.reject(err);
+        }
         this._self.#drainResolve?.();
       }
       throw err;

--- a/packages/client/lib/client/pool.ts
+++ b/packages/client/lib/client/pool.ts
@@ -444,6 +444,9 @@ export class RedisClientPool<
       await client.connect();
     } catch (err) {
       this._self.#clientsInUse.remove(node);
+      if (this._self.#isClosing && this._self.#clientsInUse.length === 0) {
+        this._self.#drainResolve?.();
+      }
       throw err;
     }
 


### PR DESCRIPTION
### Description

Fixes #3398.

`#create()` pushes the new client onto `#clientsInUse` before it awaits `connect()`, so a scale-up connection counts toward capacity while it's still connecting. If `close()` starts during that window, it waits on `#drainResolve`, which only ever gets resolved from `#returnClient()`. When the in-flight connect then fails, `#create()`'s catch block just removes the node from `#clientsInUse` and rethrows, it never goes through `#returnClient()`. If that was the last client in use, `#clientsInUse` drops to 0 with no drain check ever running, and `close()` hangs forever.

The fix mirrors the drain check that `#returnClient()` already does: after removing the failed node, if the pool is closing and `#clientsInUse` is now empty, resolve `#drainResolve` directly.

Added a test that reproduces the hang against an unreachable client (connect always fails) and asserts `close()` still resolves.

---

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pool shutdown and task-queue draining in a concurrency edge case; behavior change is narrow but affects lifecycle promises for failing connects during `close()`.
> 
> **Overview**
> Fixes **#3398**: `RedisClientPool.close()` could hang forever when a scale-up `connect()` failed while the pool was already draining.
> 
> `#create()` tracks clients in `#clientsInUse` before `connect()` finishes, but on failure it only removed the node and never ran the same drain completion path as `#returnClient()`. If that was the last in-use client during `close()`, `#drainResolve` was never called.
> 
> The **`#create()`** failure handler now mirrors that drain logic: when the pool is closing and `#clientsInUse` is empty, it **rejects every task still in `#tasksQueue`** (clearing acquire timeouts) and **resolves `#drainResolve`** so `close()` can finish.
> 
> Two regression tests use an unreachable Redis endpoint (`127.0.0.1:1`) to assert `close()` settles and that a queued `execute()` is rejected when connect fails during drain.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d5e02f494677a159f16e689fb775e4e35526e85. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->