### PR TITLE
fix(client): settle the close() drain when the last connect fails

### DIFF
--- a/packages/client/lib/client/pool.spec.ts
+++ b/packages/client/lib/client/pool.spec.ts
@@ -160,6 +160,59 @@ describe('RedisClientPool', () => {
     poolOptions: { minimum: 1, maximum: 1, acquireTimeout: 2000, cleanupDelay: 400  }
   });
 
+  it('close resolves when the last pending connect fails', async () => {
+    // Regression: on a failed connect `#create()` removed the client from `#clientsInUse`
+    // directly instead of going through `#returnClient()`, the only place that resolves the
+    // drain promise. `#clientsInUse` reached 0 without waking `close()`, which hung forever.
+    // Nothing listens on port 1 here, so the connect always fails.
+    const pool = RedisClientPool.create(
+      { socket: { host: '127.0.0.1', port: 1, reconnectStrategy: false } },
+      { minimum: 1, maximum: 1, acquireTimeout: 500 }
+    );
+
+    const connectPromise = pool.connect();
+    assert.equal(pool.clientsInUse, 1, 'a connecting client should count as in use');
+
+    const closePromise = pool.close().then(() => 'closed');
+    const hangGuard = new Promise<string>(resolve => {
+      setTimeout(resolve, 1000, 'hung').unref();
+    });
+
+    await assert.rejects(connectPromise);
+    assert.equal(await Promise.race([closePromise, hangGuard]), 'closed');
+  });
+
+  it('close rejects the tasks it can no longer serve when the connect fails', async () => {
+    // A task queued behind the pending connect is the one thing `close()` is still waiting
+    // for. Once that connect fails there is no client left to run it on, so it has to be
+    // settled with the connection error rather than left sitting until `acquireTimeout`.
+    const acquireTimeout = 200;
+    const pool = RedisClientPool.create(
+      { socket: { host: '127.0.0.1', port: 1, reconnectStrategy: false } },
+      { minimum: 1, maximum: 1, acquireTimeout }
+    );
+
+    const connectPromise = pool.connect();
+    const connectRejects = assert.rejects(connectPromise);
+    const taskRejects = assert.rejects(pool.execute(() => 'never runs'), /ECONNREFUSED/);
+    assert.equal(pool.tasksQueueLength, 1, 'the task should be waiting for the connecting client');
+    assert.equal(pool.clientsInUse, 1, 'the connecting client should count as in use');
+
+    const closePromise = pool.close().then(() => 'closed');
+    const hangGuard = new Promise<string>(resolve => {
+      setTimeout(resolve, 1000, 'hung').unref();
+    });
+
+    await connectRejects;
+    await taskRejects;
+    assert.equal(await Promise.race([closePromise, hangGuard]), 'closed');
+    assert.equal(pool.tasksQueueLength, 0);
+
+    // The task's acquire timer has to be cleared along with it, otherwise it fires on a node
+    // that is already out of the queue and `remove()` throws where nobody can catch it.
+    await new Promise(resolve => setTimeout(resolve, acquireTimeout + 50));
+  });
+
   testUtils.testWithClientPool('execute rejects when pool is closing', async pool => {
     // Start a long-running task to keep the pool busy during close
     const task1Promise = pool.execute(async _client => {

--- a/packages/client/lib/client/pool.ts
+++ b/packages/client/lib/client/pool.ts
@@ -444,6 +444,16 @@ export class RedisClientPool<
       await client.connect();
     } catch (err) {
       this._self.#clientsInUse.remove(node);
+      // Closing with no client left: `#returnClient()`, the only other place that signals the
+      // drain, will not run again, and nothing can pick up the queued tasks either
+      if (this._self.#isClosing && this._self.#clientsInUse.length === 0) {
+        let task;
+        while ((task = this._self.#tasksQueue.shift())) {
+          clearTimeout(task.timeout);
+          task.reject(err);
+        }
+        this._self.#drainResolve?.();
+      }
       throw err;
     }
 


### PR DESCRIPTION
### Description

Fixes #3398.

`#create()` pushes the client onto `#clientsInUse` before it awaits `client.connect()`, so a connecting client counts toward capacity. On a connect failure it removes the node directly instead of going through `#returnClient()`, which is the only place that resolves `#drainResolve`. If `close()` was already waiting for the pool to drain, `#clientsInUse` reached 0 without waking it and `close()` never settled.

Signalling the drain from that path is not enough on its own. A task queued behind the pending connect is exactly what `close()` is still waiting for, and once the connect fails there is no client left to run it on: `execute()` rejects new work while closing, and nothing will call `#returnClient()` again. So the failure path now settles those tasks with the connection error before it resolves the drain. The caller gets the real reason instead of a later `TimeoutError`, or nothing at all when `acquireTimeout` is 0.

This is scoped to a closing pool. While the pool is open a failed scale-up leaves the queued task on its existing `acquireTimeout` path, which is #3397 and a separate discussion. Draining the queue here only uses `shift()`, so it does not touch `SinglyLinkedList.remove()`.

Two tests cover it, neither needs a server:

- `close()` settles when the only pending connect fails
- a task queued behind that connect is rejected with the connection error, `close()` settles, and the task's acquire timer is cleared with it (otherwise it later fires on a node that is already out of the queue and `remove()` throws)

---

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pool shutdown and task-queue settlement on connect failure; behavior is scoped to closing pools but affects promise lifecycle and timers.
> 
> **Overview**
> Fixes a **hang in `RedisClientPool.close()`** when shutdown overlaps a failing `connect()`: `#create()` removed the in-flight client from `#clientsInUse` on error without invoking `#returnClient()`, so `#drainResolve` never ran even though the pool was empty.
> 
> On that path, when the pool is **closing** and **no clients remain in use**, the failure handler now **drains `#tasksQueue`**—`clearTimeout` on each waiter, **reject with the connect error**, then **call `#drainResolve`**—so queued `execute()` work fails with the real connection error instead of waiting on `acquireTimeout`, and `close()` can finish.
> 
> Adds two **no-server** regression tests: `close()` resolves after the only pending connect fails, and a task queued behind that connect is rejected, timers are cleared, and `close()` still completes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 274ffd39e7ae62b383979c2482a714e5dba1334b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->