### PR TITLE
fix(client): back pool task queue with a doubly-linked list

### DIFF
--- a/packages/client/lib/client/pool.ts
+++ b/packages/client/lib/client/pool.ts
@@ -238,7 +238,12 @@ export class RedisClientPool<
     return this._self.#idleClients.length + this._self.#clientsInUse.length;
   }
 
-  readonly #tasksQueue = new SinglyLinkedList<{
+  // Doubly-linked so the acquire-timeout path can remove a queued task by node
+  // alone. A singly-linked list forces the caller to supply the predecessor,
+  // and the pool's only source for that was a `tail` snapshot captured when the
+  // task was enqueued — stale by the time the timeout fires, which corrupted
+  // the queue. `node.previous` is always live, so no predecessor is passed.
+  readonly #tasksQueue = new DoublyLinkedList<{
     timeout: NodeJS.Timeout | undefined;
     resolve: (value: unknown) => unknown;
     reject: (reason?: unknown) => unknown;
@@ -457,14 +462,13 @@ export class RedisClientPool<
       }
 
       const waitStartTimestamp = performance.now();
-      const client = this._self.#idleClients.shift(),
-        { tail } = this._self.#tasksQueue;
+      const client = this._self.#idleClients.shift();
       if (!client) {
         let timeout;
         if (this._self.#options.acquireTimeout > 0) {
           timeout = setTimeout(
             () => {
-              this._self.#tasksQueue.remove(task, tail);
+              this._self.#tasksQueue.remove(task);
               reject(new TimeoutError(`Timeout waiting for a client after ${this._self.#options.acquireTimeout}ms`));
             },
             this._self.#options.acquireTimeout


### PR DESCRIPTION
Addresses the second defect reported in #3397 (2 of 2).

### Background

The pool's `#tasksQueue` was a `SinglyLinkedList`, whose `remove(node, parent)` trusts the caller to supply the node's predecessor. `execute()` captured that predecessor as a `tail` snapshot when the task was enqueued and reused it in the `acquireTimeout` handler. By the time the timeout fires, that snapshot can be stale (its target already removed), so removing a non-head task corrupts the queue: a live task is orphaned (never shifted, never served) and an already-removed task can be handed a client, while `tasksQueueLength` silently misreports.

This is latent in the shipped code because the `acquireTimeout` handler is the only remover and same-duration timers expire in push order, so it always removes the current head — where `parent` is ignored. It stops being safe the moment any non-FIFO remover is added.

### Change

Switch `#tasksQueue` to `DoublyLinkedList` (already used for `#clientsInUse` in the same file), whose `remove(node)` reads the live `node.previous` and needs no caller-supplied predecessor. The `tail` capture and the `parent` argument are dropped. `SinglyLinkedList` is retained for the push/shift-only users (`#idleClients`, sentinel wait-queue, command-queue reply list).

### Notes

- This is distinct from the `DoublyLinkedList`/`#clientsInUse` corruption fixed in #3062 / #3085.
- No behavioral test is included: as noted above, the defect is not reachable through the pool's public API today (the sole `remove` caller is FIFO), so a pool-level test cannot trigger it without adding a synthetic non-FIFO remover. Existing pool tests (including the `acquireTimeout` FIFO removal path) pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core pool scheduling and queued-task removal; behavior should match today for FIFO timeouts but fixes correctness for arbitrary removals.
> 
> **Overview**
> Fixes a latent **queue corruption** risk when a pooled task’s **acquire timeout** fires: the wait queue no longer relies on a **`tail` snapshot** as the predecessor for `remove`.
> 
> `#tasksQueue` is now a **`DoublyLinkedList`** (same pattern as `#clientsInUse`), so timeout handling calls **`remove(task)`** and uses live **`node.previous`** instead of **`remove(task, tail)`** from enqueue time. **`SinglyLinkedList`** stays for push/shift-only lists (`#idleClients`, etc.).
> 
> Today the bug is hard to hit because timeouts remove in FIFO order (head only), but any non-FIFO removal would have been unsafe with the old API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e45aeb69f6fadc31f9d9c5f33eb17da9a64505eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->