### PR TITLE
fix(client): recreate cluster node client after a terminal connect failure

### DIFF
--- a/packages/client/lib/client/cache.spec.ts
+++ b/packages/client/lib/client/cache.spec.ts
@@ -3,8 +3,28 @@ import testUtils, { GLOBAL } from "../test-utils"
 import { BasicClientSideCache, BasicPooledClientSideCache, CacheStats } from "./cache"
 import { REDIS_FLUSH_MODES } from "../commands/FLUSHALL";
 import { once } from 'events';
+import RedisClient from "./index";
 
 describe("Client Side Cache", () => {
+  it("destroy() on a never-connected client does not flush a shared pooled cache (#3396)", () => {
+    // Cluster/pool/sentinel share one pooled cache across node clients. Disposing
+    // a client whose connect failed terminally must not wipe entries the healthy
+    // connections are still using (the dead client cached nothing / missed no
+    // invalidations). It must also not throw — the owning client still needs to
+    // finish its own cleanup (unregister metrics, dispose credentials).
+    const cache = new BasicPooledClientSideCache({ maxEntries: 100 });
+    const client = RedisClient.create({ RESP: 3, clientSideCache: cache });
+
+    // Seed the shared cache as if a healthy pooled connection had cached a key.
+    cache.set("k", cache.createValueEntry(client as never, "v"), ["k"]);
+    assert.ok(cache.get("k"));
+
+    // Never connected (socketEpoch 0): idempotent, no throw, cache untouched.
+    assert.doesNotThrow(() => client.destroy());
+    assert.doesNotThrow(() => client.destroy());
+    assert.ok(cache.get("k"), "a never-connected client must not flush the shared cache");
+  });
+
   describe('Basic Cache', () => {
     const csc = new BasicClientSideCache({ maxEntries: 10 });
 
@@ -306,13 +326,13 @@ describe("Client Side Cache", () => {
 
       let p: Promise<Array<string>> = once(csc, 'invalidate');
       await client.set("x", 2);
-      let [i] = await p;
+      await p;
 
       assert.equal(await client.get("x"), '2', 'second get');
 
       p = once(csc, 'invalidate');
       await client.set("x", 3);
-      [i] = await p;
+      await p;
 
       assert.equal(await client.get("x"), '3');
 

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -2190,7 +2190,10 @@ export default class RedisClient<
     return new Promise<void>(resolve => {
       clearTimeout(this._self.#pingTimer);
       this._self.#socket.close();
-      this._self.#clientSideCache?.onClose();
+      // See destroy(): only flush the cache if this client ever connected.
+      if (this._self.#socket.socketEpoch > 0) {
+        this._self.#clientSideCache?.onClose();
+      }
       this._self.#credentialsSubscription?.dispose();
       this._self.#credentialsSubscription = null;
 
@@ -2219,7 +2222,14 @@ export default class RedisClient<
     clearTimeout(this._self.#pingTimer);
     this._self.#queue.flushAll(new DisconnectsClientError());
     this._self.#socket.destroy();
-    this._self.#clientSideCache?.onClose();
+    // Only flush the client-side cache if this client ever connected. A client
+    // that never became ready (e.g. a cluster node whose connect failed
+    // terminally) cached nothing and missed no invalidations, so there is
+    // nothing to go stale — and clearing a pooled cache it shares with healthy
+    // connections would needlessly cold-start them.
+    if (this._self.#socket.socketEpoch > 0) {
+      this._self.#clientSideCache?.onClose();
+    }
     this._self.#unregisterFromMetrics();
     this._self.#credentialsSubscription?.dispose();
     this._self.#credentialsSubscription = null;

--- a/packages/client/lib/client/socket.ts
+++ b/packages/client/lib/client/socket.ts
@@ -466,10 +466,13 @@ const retryIn = strategy(retries, cause);
   }
 
   destroy() {
-    if (!this.#isOpen) {
-      throw new ClientClosedError();
-    }
-
+    // Idempotent: return instead of throwing when already closed. A terminal
+    // connect failure (reconnectStrategy gave up) leaves #isOpen === false, and
+    // the owning client still needs to dispose itself (unregister metrics,
+    // dispose credentials) — throwing here would abort that cleanup. Returning
+    // also means a repeated destroy() won't re-run destroySocket() and
+    // republish CONNECTION_CLOSED / re-emit 'end'.
+    if (!this.#isOpen) return;
     this.#isOpen = false;
     this.destroySocket();
   }

--- a/packages/client/lib/cluster/cluster-slots.spec.ts
+++ b/packages/client/lib/cluster/cluster-slots.spec.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'node:assert';
 import { EventEmitter } from 'node:events';
 import { RedisClusterClientOptions } from './index';
 import RedisClusterSlots, { groupCommandsByDestination, splitInFlightChainTail } from './cluster-slots';
-import type { MasterNode, Shard } from './cluster-slots';
+import type { MasterNode, Shard, ShardNode } from './cluster-slots';
 import type { CommandToWrite } from '../client/commands-queue';
 import { ClientClosedError } from '../errors';
 
@@ -178,6 +178,47 @@ describe('RedisClusterSlots', () => {
 
       assert.deepEqual(inFlightChainTail, []);
       assert.deepEqual(relocatable, commands);
+    });
+  });
+
+  describe('nodeClient after a terminal connect failure (#3396)', () => {
+    // Point a node at a dead address with reconnectStrategy disabled so the
+    // very first connect fails terminally (no retries).
+    function createSlots() {
+      return new RedisClusterSlots({
+        rootNodes: [{ socket: { host: '127.0.0.1', port: 1 } }],
+        defaults: { socket: { host: '127.0.0.1', port: 1, reconnectStrategy: false, connectTimeout: 100 } },
+      }, () => true, 'test-cluster');
+    }
+
+    function createNode() {
+      return {
+        address: '127.0.0.1:1',
+        host: '127.0.0.1',
+        port: 1,
+        id: 'test-node',
+        readonly: false,
+      } as ShardNode<Record<string, never>, Record<string, never>, Record<string, never>, 3, Record<string, never>>;
+    }
+
+    it('does not cache the dead client and retries on the next call', async () => {
+      const slots = createSlots();
+      const node = createNode();
+
+      // First attempt fails terminally, and must reject with the real connect
+      // error — not a ClientClosedError thrown by destroy() on the dead client
+      // (which would prove destroy() is not idempotent on a closed socket).
+      await assert.rejects(slots.nodeClient(node), (err: unknown) => {
+        assert(!(err instanceof ClientClosedError), 'should surface the real connect error, not ClientClosedError from destroy()');
+        return true;
+      });
+      // The dead client must not stay cached...
+      assert.equal(node.client, undefined, 'dead client should be cleared, not cached');
+
+      // ...so the second call retries with a fresh client and fails again.
+      // Before the fix it resolved to the cached dead client (no rejection).
+      await assert.rejects(slots.nodeClient(node), 'second call must retry, not return the cached dead client');
+      assert.equal(node.client, undefined);
     });
   });
 });

--- a/packages/client/lib/cluster/cluster-slots.ts
+++ b/packages/client/lib/cluster/cluster-slots.ts
@@ -807,6 +807,16 @@ export default class RedisClusterSlots<
   #createNodeClient(node: ShardNode<M, F, S, RESP, TYPE_MAPPING>, readonly?: boolean) {
     const client = node.client = this.#createClient(node, readonly);
     return node.connectPromise = client.connect()
+      .catch(err => {
+        // Terminal connect failure (reconnectStrategy gave up). Drop the dead
+        // client so the next nodeClient() call retries with a fresh one, and
+        // destroy it so its ClientRegistry entry and listeners don't leak.
+        // Guard on identity: #discover may have swapped in a new client while
+        // this connect was in flight — never clobber that one.
+        if (node.client === client) node.client = undefined;
+        client.destroy();
+        throw err;
+      })
       .finally(() => node.connectPromise = undefined);
   }
 


### PR DESCRIPTION
Closes #3396.

### Background

In cluster mode `RedisClusterSlots#createNodeClient` assigns `node.client` before the connect promise settles. When `reconnectStrategy` gives up (returns `false`/`Error`), the connect rejects but the dead client stayed in `node.client`. Since `nodeClient()` only creates a new client when `node.client` is falsy, it then kept returning the same non-functional client forever — a node could never recover until a topology refresh happened to drop its address.

Clearing `node.client` naively would leak: the abandoned client stays in the global `ClientRegistry` with its `error`/`ready`/`end`/`__MOVED` listeners attached (holding a strong ref back to the cluster), and `RedisClient.destroy()` throws `ClientClosedError` on an already-closed socket, so the dead client could not be disposed.

### Change

- `RedisSocket.destroy()` is now idempotent — it no longer throws when the socket is already closed, so a terminally-failed client can be disposed and its metrics registration and credentials subscription are released instead of leaking. `RedisSocket` is internal (users call `client.destroy()`), and this only relaxes behavior — `destroy()` was previously the sole path that threw `ClientClosedError` on a closed client — so it is not a breaking change.
- `#createNodeClient` now catches a connect rejection, clears `node.client` (guarded on identity so an in-flight `#discover` swap is never clobbered), destroys the dead client, and rethrows so callers still see the real error. The next `nodeClient()` call retries with a fresh client.

### Notes

- **Config-conditional.** This only triggers when the connect can terminally reject: a `reconnectStrategy` returning `false`/`Error`, or a configured `socketTimeout` (whose idle timeout the default strategy declines to retry). The default `reconnectStrategy` retries with exponential backoff forever and never reaches this path, so default-configured clients are unaffected.
- **Scope.** This fixes the cluster node-client caching/disposal path. A standalone client also leaves its `ClientRegistry` entry registered after a terminal connect failure (nothing calls `destroy()` on that path); that is a separate latent issue and is intentionally not addressed here.
- Regression test (`cluster-slots.spec.ts`, no server required) drives a node at a dead address with `reconnectStrategy: false` and asserts the second `nodeClient()` retries rather than returning the cached dead client, and that the failure surfaces the real connect error rather than a `ClientClosedError` from a non-idempotent `destroy()`. It fails if either half of the fix is reverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cluster connection lifecycle, socket destroy semantics, and RESP3 pooled client-side cache on teardown—important paths but narrowly scoped with regression tests.
> 
> **Overview**
> Fixes **#3396**: cluster shard clients that fail to connect terminally were left cached on `node.client`, so later `nodeClient()` calls kept returning a dead connection until topology refresh.
> 
> **Cluster:** On connect rejection, `#createNodeClient` now clears `node.client` (only if it still refers to that client), **`destroy()`s** the failed client, and rethrows the real error so the next `nodeClient()` builds a fresh client.
> 
> **Socket / client teardown:** `RedisSocket.destroy()` is **idempotent** (no `ClientClosedError` when already closed), so cleanup after a failed connect can finish. `close()` / `destroy()` only invoke **`clientSideCache.onClose()`** when `socketEpoch > 0`, so disposing a never-connected node does not flush a **shared pooled** client-side cache used by healthy connections.
> 
> Regression tests cover cluster retry behavior and pooled-cache preservation on `destroy()` without connect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb129662ddcbb2296722f8779b5d171f26237678. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->