### PR TITLE
feat(client): add COUNT option support to LPOS command

### DIFF
--- a/packages/client/lib/commands/LPOS.spec.ts
+++ b/packages/client/lib/commands/LPOS.spec.ts
@@ -32,13 +32,14 @@ describe('LPOS', () => {
       );
     });
 
-    it('with RANK, MAXLEN', () => {
+    it('with RANK, COUNT, MAXLEN', () => {
       assert.deepEqual(
         parseArgs(LPOS, 'key', 'element', {
           RANK: 0,
+          COUNT: 2,
           MAXLEN: 10
         }),
-        ['LPOS', 'key', 'element', 'RANK', '0', 'MAXLEN', '10']
+        ['LPOS', 'key', 'element', 'RANK', '0', 'COUNT', '2', 'MAXLEN', '10']
       );
     });
   });

--- a/packages/client/lib/commands/LPOS.spec.ts
+++ b/packages/client/lib/commands/LPOS.spec.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert';
 import testUtils, { GLOBAL } from '../test-utils';
-import LPOS from './LPOS';
+import LPOS, { LPosOptions } from './LPOS';
 import { parseArgs } from './generic-transformers';
 
 describe('LPOS', () => {
@@ -31,6 +31,14 @@ describe('LPOS', () => {
         ['LPOS', 'key', 'element', 'MAXLEN', '10']
       );
     });
+    it('with COUNT', () => {
+    assert.deepEqual(
+      parseArgs(LPOS, 'key', 'element', {
+        COUNT: 2
+      }),
+      ['LPOS', 'key', 'element', 'COUNT', '2']
+    );
+  });
 
     it('with RANK, COUNT, MAXLEN', () => {
       assert.deepEqual(

--- a/packages/client/lib/commands/LPOS.ts
+++ b/packages/client/lib/commands/LPOS.ts
@@ -1,9 +1,10 @@
 import { CommandParser } from '../client/parser';
-import { RedisArgument, NumberReply, NullReply, Command } from '../RESP/types';
+import { RedisArgument, NumberReply, NullReply,ArrayReply, Command } from '../RESP/types';
 
 export interface LPosOptions {
   RANK?: number;
   MAXLEN?: number;
+  COUNT?: number;
 }
 
 export default {
@@ -20,10 +21,12 @@ export default {
     if (options?.RANK !== undefined) {
       parser.push('RANK', options.RANK.toString());
     }
-
+    if (options?.COUNT !== undefined) {
+      parser.push('COUNT', options.COUNT.toString());
+    }
     if (options?.MAXLEN !== undefined) {
       parser.push('MAXLEN', options.MAXLEN.toString());
     }
   },
-  transformReply: undefined as unknown as () => NumberReply | NullReply
+  transformReply: undefined as unknown as () => NumberReply | NullReply | ArrayReply<NumberReply>
 } as const satisfies Command;

--- a/packages/client/lib/commands/LPOS.ts
+++ b/packages/client/lib/commands/LPOS.ts
@@ -28,5 +28,5 @@ export default {
       parser.push('MAXLEN', options.MAXLEN.toString());
     }
   },
-  transformReply: undefined as unknown as () => NumberReply | NullReply | ArrayReply<NumberReply>
+  transformReply: undefined as unknown as () => NumberReply | NullReply
 } as const satisfies Command;

--- a/packages/client/lib/commands/LPOS.ts
+++ b/packages/client/lib/commands/LPOS.ts
@@ -6,7 +6,7 @@ export interface LPosOptions {
   MAXLEN?: number;
   COUNT?: number;
 }
-
+export type LPosCountOptions = Omit<LPosOptions, 'COUNT'>;
 export default {
   parseCommand(
     parser: CommandParser,
@@ -28,5 +28,5 @@ export default {
       parser.push('MAXLEN', options.MAXLEN.toString());
     }
   },
-  transformReply: undefined as unknown as () => NumberReply | NullReply
+  transformReply: undefined as unknown as () => NumberReply | NullReply | ArrayReply<NumberReply>
 } as const satisfies Command;


### PR DESCRIPTION
### Description

This PR adds support for the `COUNT` option to the `LPOS` command. When `COUNT` is specified, Redis returns an array of matching positions instead of a single element position.

- Added `COUNT?: number` to the `LPosOptions` interface.
- Updated `LPOS` parser logic to push the `COUNT` option and its value.
- Updated `transformReply` type to include `ArrayReply<NumberReply>` to correctly type responses when `COUNT` is used.
- Added comprehensive unit tests in `LPOS.spec.ts` covering `RANK`, `COUNT`, and `MAXLEN` option combinations.

---

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive client API change aligned with Redis LPOS; limited to command parsing and types with new unit tests.
> 
> **Overview**
> Extends the **`LPOS`** client command so callers can pass Redis’s **`COUNT`** option on **`lPos`**, returning multiple list positions instead of a single index.
> 
> **`LPosOptions`** gains **`COUNT?: number`**, the command parser emits **`COUNT`** (between **`RANK`** and **`MAXLEN`** when all are set), and **`transformReply`** is widened to **`ArrayReply<NumberReply>`** when **`COUNT`** is used. A new **`LPosCountOptions`** export omits **`COUNT`** for typing elsewhere. Unit tests cover **`COUNT`** alone and combined with **`RANK`** / **`MAXLEN`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b49db130df4105898f6456ac248c1589f413da4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->