### PR TITLE
Fix/scan count zero

### DIFF
--- a/packages/client/lib/client/commands-queue.spec.ts
+++ b/packages/client/lib/client/commands-queue.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import RedisCommandsQueue from './commands-queue';
+import { PUBSUB_TYPE } from './pub-sub';
 import { AbortError, DisconnectsClientError, TimeoutError } from '../errors';
 
 describe('RedisCommandsQueue', () => {
@@ -437,6 +438,26 @@ describe('RedisCommandsQueue', () => {
       // None of the cancellations should have reached back into the
       // already-drained source queue.
       assert.strictEqual(source.extractAllCommands().length, 0);
+    });
+  });
+
+  describe('pubsub push after a connection error', () => {
+    it('drops a stale subscribe confirmation instead of crashing', () => {
+      const queue = createQueue();
+      queue.subscribe(PUBSUB_TYPE.CHANNELS, 'foo', () => {}).catch(() => {});
+
+      // move the SUBSCRIBE command into #waitingForReply, as the socket
+      // writer does right before the bytes go out on the wire
+      queue.commandsToWrite().next();
+
+      // a connection error flushes #waitingForReply before the server's
+      // confirmation for that SUBSCRIBE is processed
+      queue.flushWaitingForReply(new Error('simulated connection error'));
+
+      // the confirmation was already in flight on the wire and arrives anyway
+      assert.doesNotThrow(() => {
+        queue.decoder.onPush([Buffer.from('subscribe'), Buffer.from('foo'), 1]);
+      });
     });
   });
 });

--- a/packages/client/lib/client/commands-queue.ts
+++ b/packages/client/lib/client/commands-queue.ts
@@ -199,10 +199,14 @@ export default class RedisCommandsQueue {
       );
       return true;
     } else if (isShardedUnsubscribe || PubSub.isStatusReply(push)) {
-      const head = this.#waitingForReply.head!.value;
+      const head = this.#waitingForReply.head;
+      // A connection error can flush `#waitingForReply` while this confirmation
+      // was already in flight on the wire - nothing left to resolve for it.
+      if (!head) return true;
+
       if (
-        (Number.isNaN(head.channelsCounter!) && push[2] === 0) ||
-        --head.channelsCounter! === 0
+        (Number.isNaN(head.value.channelsCounter!) && push[2] === 0) ||
+        --head.value.channelsCounter! === 0
       ) {
         this.#waitingForReply.shift()!.resolve();
       }

--- a/packages/client/lib/commands/HSCAN.spec.ts
+++ b/packages/client/lib/commands/HSCAN.spec.ts
@@ -30,6 +30,15 @@ describe('HSCAN', () => {
       );
     });
 
+    it('with COUNT: 0', () => {
+      assert.deepEqual(
+        parseArgs(HSCAN, 'key', '0', {
+          COUNT: 0
+        }),
+        ['HSCAN', 'key', '0', 'COUNT', '0']
+      );
+    });
+
     it('with MATCH & COUNT', () => {
       assert.deepEqual(
         parseArgs(HSCAN, 'key', '0', {
@@ -51,7 +60,7 @@ describe('HSCAN', () => {
         }
       );
     });
-    
+
     it('with tuples', () => {
       assert.deepEqual(
         HSCAN.transformReply(['0' as any, ['field', 'value'] as any]),

--- a/packages/client/lib/commands/SCAN.spec.ts
+++ b/packages/client/lib/commands/SCAN.spec.ts
@@ -30,6 +30,15 @@ describe('SCAN', () => {
       );
     });
 
+    it('with COUNT: 0', () => {
+      assert.deepEqual(
+        parseArgs(SCAN, '0', {
+          COUNT: 0
+        }),
+        ['SCAN', '0', 'COUNT', '0']
+      );
+    });
+
     it('with TYPE', () => {
       assert.deepEqual(
         parseArgs(SCAN, '0', {

--- a/packages/client/lib/commands/SCAN.ts
+++ b/packages/client/lib/commands/SCAN.ts
@@ -29,7 +29,7 @@ export function parseScanArguments(
     parser.push('MATCH', options.MATCH);
   }
 
-  if (options?.COUNT) {
+  if (options?.COUNT !== undefined) {
     parser.push('COUNT', options.COUNT.toString());
   }
 }
@@ -53,7 +53,7 @@ export function pushScanArguments(
     args.push('MATCH', options.MATCH);
   }
 
-  if (options?.COUNT) {
+  if (options?.COUNT !== undefined) {
     args.push('COUNT', options.COUNT.toString());
   }
 

--- a/packages/client/lib/commands/SSCAN.spec.ts
+++ b/packages/client/lib/commands/SSCAN.spec.ts
@@ -30,6 +30,15 @@ describe('SSCAN', () => {
       );
     });
 
+    it('with COUNT: 0', () => {
+      assert.deepEqual(
+        parseArgs(SSCAN, 'key', '0', {
+          COUNT: 0
+        }),
+        ['SSCAN', 'key', '0', 'COUNT', '0']
+      );
+    });
+
     it('with MATCH & COUNT', () => {
       assert.deepEqual(
         parseArgs(SSCAN, 'key', '0', {

--- a/packages/client/lib/commands/ZSCAN.spec.ts
+++ b/packages/client/lib/commands/ZSCAN.spec.ts
@@ -30,6 +30,15 @@ describe('ZSCAN', () => {
       );
     });
 
+    it('with COUNT: 0', () => {
+      assert.deepEqual(
+        parseArgs(ZSCAN, 'key', '0', {
+          COUNT: 0
+        }),
+        ['ZSCAN', 'key', '0', 'COUNT', '0']
+      );
+    });
+
     it('with MATCH & COUNT', () => {
       assert.deepEqual(
         parseArgs(ZSCAN, 'key', '0', {


### PR DESCRIPTION
fixes a bug where `count: 0` was ignored in the scan-family commands (`scan`, `hscan`, `sscan`, and `zscan`) because the existing truthy check treated `0` as a falsy value. the implementation now correctly checks for `undefined`, ensuring `count: 0` is passed to the server. tests were added for all four commands, and all existing tests continue to pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted argument parsing and defensive pub/sub push handling with new unit tests; no auth or data-path changes.
> 
> **Overview**
> Fixes **`COUNT: 0`** being dropped on scan-family commands (`SCAN`, `HSCAN`, `SSCAN`, `ZSCAN`) by treating `COUNT` as present when it is not `undefined` (instead of a truthy check), so `COUNT 0` is sent to Redis. Adds argument-parser tests for `COUNT: 0` on all four commands.
> 
> Separately, **`RedisCommandsQueue`** no longer throws when a pub/sub subscribe/unsubscribe status push arrives after a connection error has already flushed `#waitingForReply`: it ignores the stale confirmation instead of dereferencing an empty wait queue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 780173ab763390a6a18c394a7838b4bc86c8be21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->