### PR TITLE
fix(client): settle argument-less unsubscribe while patterns remain

### DIFF
--- a/packages/client/lib/client/commands-queue.ts
+++ b/packages/client/lib/client/commands-queue.ts
@@ -201,7 +201,8 @@ export default class RedisCommandsQueue {
     } else if (isShardedUnsubscribe || PubSub.isStatusReply(push)) {
       const head = this.#waitingForReply.head!.value;
       if (
-        (Number.isNaN(head.channelsCounter!) && push[2] === 0) ||
+        (Number.isNaN(head.channelsCounter!) &&
+          push[2] === this.#pubSub.residualAfterUnsubscribeAll(push)) ||
         --head.channelsCounter! === 0
       ) {
         this.#waitingForReply.shift()!.resolve();

--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -1135,6 +1135,9 @@ describe('Client', () => {
         // Following commands must receive their own replies (no off-by-one misalignment).
         assert.equal(await subscriber.ping('AAA'), 'AAA');
         assert.equal(await subscriber.ping('BBB'), 'BBB');
+
+        // Leave subscriber mode so the harness teardown (flushAll) is accepted on RESP2.
+        await subscriber.pUnsubscribe();
       }, {
         ...GLOBAL.SERVERS.OPEN,
         clientOptions: { ...GLOBAL.SERVERS.OPEN.clientOptions, RESP: resp }
@@ -1153,27 +1156,9 @@ describe('Client', () => {
 
         assert.equal(await subscriber.ping('AAA'), 'AAA');
         assert.equal(await subscriber.ping('BBB'), 'BBB');
-      }, {
-        ...GLOBAL.SERVERS.OPEN,
-        clientOptions: { ...GLOBAL.SERVERS.OPEN.clientOptions, RESP: resp }
-      });
-    }
 
-    for (const resp of [2, 3] as const) {
-      testUtils.testWithClient(`argument-less pUnsubscribe() with an active channel resolves and keeps replies aligned (RESP${resp})`, async subscriber => {
-        await subscriber.pSubscribe(['pat1*', 'pat2*'], () => {});
-        await subscriber.subscribe('ch', () => {});
-
-        // The mirror of the case above. A PUNSUBSCRIBE reply carries the same
-        // combined channel + pattern count, so an argument-less pUnsubscribe()
-        // never sees 0 while a channel subscription remains. One channel vs two
-        // patterns keeps the residual asymmetric, so reading the pattern count
-        // where the channel count belongs is caught here too.
-        await assert.doesNotReject(subscriber.pUnsubscribe());
-
-        // Following commands must receive their own replies (no off-by-one misalignment).
-        assert.equal(await subscriber.ping('AAA'), 'AAA');
-        assert.equal(await subscriber.ping('BBB'), 'BBB');
+        // Leave subscriber mode so the harness teardown (flushAll) is accepted on RESP2.
+        await subscriber.unsubscribe();
       }, {
         ...GLOBAL.SERVERS.OPEN,
         clientOptions: { ...GLOBAL.SERVERS.OPEN.clientOptions, RESP: resp }

--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -1119,6 +1119,67 @@ describe('Client', () => {
       }
     }, GLOBAL.SERVERS.OPEN);
 
+    for (const resp of [2, 3] as const) {
+      testUtils.testWithClient(`argument-less unsubscribe() with an active pattern resolves and keeps replies aligned (RESP${resp})`, async subscriber => {
+        await subscriber.subscribe(['ch1', 'ch2'], () => {});
+        await subscriber.pSubscribe('pat*', () => {});
+
+        // Argument-less UNSUBSCRIBE while a pattern subscription remains: Redis
+        // reports the remaining channel + pattern count, not 0, so a naive `=== 0`
+        // completion check never resolves and the eventual confirm gets mismatched
+        // to the following command's reply. Two channels vs one pattern keeps the
+        // residual asymmetric, so using the wrong subscription type's count is
+        // caught too (it would misalign the following replies).
+        await assert.doesNotReject(subscriber.unsubscribe());
+
+        // Following commands must receive their own replies (no off-by-one misalignment).
+        assert.equal(await subscriber.ping('AAA'), 'AAA');
+        assert.equal(await subscriber.ping('BBB'), 'BBB');
+      }, {
+        ...GLOBAL.SERVERS.OPEN,
+        clientOptions: { ...GLOBAL.SERVERS.OPEN.clientOptions, RESP: resp }
+      });
+
+      testUtils.testWithClient(`argument-less pUnsubscribe() with an active channel resolves and keeps replies aligned (RESP${resp})`, async subscriber => {
+        await subscriber.subscribe('ch1', () => {});
+        await subscriber.pSubscribe(['pat1*', 'pat2*'], () => {});
+
+        // Mirror of the UNSUBSCRIBE case for the PATTERNS branch: an argument-less
+        // PUNSUBSCRIBE while a channel subscription remains gets a non-zero remaining
+        // count (the channel), so completion must key off the remaining channel count,
+        // not 0. One channel vs two patterns keeps the residual asymmetric so using the
+        // wrong subscription type's count is caught too.
+        await assert.doesNotReject(subscriber.pUnsubscribe());
+
+        assert.equal(await subscriber.ping('AAA'), 'AAA');
+        assert.equal(await subscriber.ping('BBB'), 'BBB');
+      }, {
+        ...GLOBAL.SERVERS.OPEN,
+        clientOptions: { ...GLOBAL.SERVERS.OPEN.clientOptions, RESP: resp }
+      });
+    }
+
+    for (const resp of [2, 3] as const) {
+      testUtils.testWithClient(`argument-less pUnsubscribe() with an active channel resolves and keeps replies aligned (RESP${resp})`, async subscriber => {
+        await subscriber.pSubscribe(['pat1*', 'pat2*'], () => {});
+        await subscriber.subscribe('ch', () => {});
+
+        // The mirror of the case above. A PUNSUBSCRIBE reply carries the same
+        // combined channel + pattern count, so an argument-less pUnsubscribe()
+        // never sees 0 while a channel subscription remains. One channel vs two
+        // patterns keeps the residual asymmetric, so reading the pattern count
+        // where the channel count belongs is caught here too.
+        await assert.doesNotReject(subscriber.pUnsubscribe());
+
+        // Following commands must receive their own replies (no off-by-one misalignment).
+        assert.equal(await subscriber.ping('AAA'), 'AAA');
+        assert.equal(await subscriber.ping('BBB'), 'BBB');
+      }, {
+        ...GLOBAL.SERVERS.OPEN,
+        clientOptions: { ...GLOBAL.SERVERS.OPEN.clientOptions, RESP: resp }
+      });
+    }
+
     testUtils.testWithClient('should resubscribe', async publisher => {
       const subscriber = await publisher.duplicate().connect();
 

--- a/packages/client/lib/client/pub-sub.ts
+++ b/packages/client/lib/client/pub-sub.ts
@@ -125,7 +125,7 @@ export class PubSub {
     const args: Array<RedisArgument> = [COMMANDS[type].subscribe],
       channelsArray = PubSub.#channelsArray(channels);
     for (const channel of channelsArray) {
-      let channelListeners = this.listeners[type].get(channel);
+      const channelListeners = this.listeners[type].get(channel);
       if (!channelListeners || channelListeners.unsubscribing) {
         args.push(channel);
       }
@@ -492,7 +492,7 @@ export class PubSub {
       messageString = channelString === '__redis__:invalidate' ?
         // https://github.com/redis/redis/pull/7469
         // https://github.com/redis/redis/issues/7463
-        (message === null ? null : (message as any as Array<Buffer>).map(x => x.toString())) as any :
+        (message === null ? null : (message as unknown as Array<Buffer>).map(x => x.toString())) as unknown as string :
         message.toString();
     for (const listener of listeners.strings) {
       listener(messageString, channelString);

--- a/packages/client/lib/client/pub-sub.ts
+++ b/packages/client/lib/client/pub-sub.ts
@@ -74,6 +74,23 @@ export class PubSub {
     return COMMANDS[PUBSUB_TYPE.SHARDED].unsubscribe.equals(firstElement);
   }
 
+  // The count Redis reports on an UNSUBSCRIBE/PUNSUBSCRIBE reply is the total of the
+  // remaining channel + pattern subscriptions (sharded channels are counted separately).
+  // An argument-less UNSUBSCRIBE therefore does not drive that count to 0 while pattern
+  // subscriptions remain (and vice versa), so completion is reached when only the other
+  // type's subscriptions are left, not at 0.
+  residualAfterUnsubscribeAll(reply: Array<Buffer>): number {
+    const firstElement = typeof reply[0] === 'string' ? Buffer.from(reply[0]) : reply[0];
+    if (COMMANDS[PUBSUB_TYPE.PATTERNS].unsubscribe.equals(firstElement)) {
+      return this.listeners[PUBSUB_TYPE.CHANNELS].size;
+    }
+    if (COMMANDS[PUBSUB_TYPE.CHANNELS].unsubscribe.equals(firstElement)) {
+      return this.listeners[PUBSUB_TYPE.PATTERNS].size;
+    }
+    // sharded: Redis tracks its counter independently, so it does reach 0
+    return 0;
+  }
+
   static #channelsArray(channels: string | Array<string>) {
     return (Array.isArray(channels) ? channels : [channels]);
   }


### PR DESCRIPTION
### Description

An argument-less `unsubscribe()` or `pUnsubscribe()` hangs when a subscription of the other type is still active, and it misaligns later replies.

The completion check for an argument-less unsubscribe waited for the reply count to reach 0. Redis reports the remaining channel plus pattern count on each UNSUBSCRIBE or PUNSUBSCRIBE reply, and sharded subscriptions are tracked separately, so with a pattern still subscribed the count never reaches 0. The command hangs, and when the server confirmation finally arrives it is matched to the next queued command, so a following PING receives the unsubscribe reply.

This settles the command when the reported count reaches the number of remaining subscriptions of the opposite type instead of 0. Argument-specified unsubscribe and sharded paths keep their previous behavior.

Reproduction, against a real server on both RESP2 and RESP3:

```
await client.subscribe('ch', () => {});
await client.pSubscribe('pat*', () => {});
await client.unsubscribe();      // never resolves before this change
await client.ping('a');          // returns the unsubscribe reply before this change
```

Added tests for both directions (channels left after `pUnsubscribe()`, patterns left after `unsubscribe()`) on RESP2 and RESP3. They use an asymmetric channel and pattern count so that using the wrong subscription type's count is caught as well.

### Checklist

- [ ] Does `npm test` pass with this change (including linting)? Type check and lint pass. The full mocha suite spins its own Redis test container per case, which did not come up within the harness timeout on my machine, so I verified the change against a local server with the reproduction above rather than the full suite.
- [x] Is the new or changed code fully tested?
- [ ] Is a documentation update included? N/A, this is a bug fix with no API change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Pub/Sub reply matching in the command queue; a wrong residual would hang unsubscribes or steal later command replies. Scope is small and covered by new tests.
> 
> **Overview**
> Fixes argument-less `unsubscribe()` / `pUnsubscribe()` hanging (and misaligning later replies) when the other subscription type is still active.
> 
> Redis reports remaining **channel + pattern** count on those replies, so the old `=== 0` completion check never fired. The queue now treats the command as complete when the reported count equals remaining subscriptions of the *other* type (`residualAfterUnsubscribeAll`). Sharded unsubscribes still complete at 0.
> 
> Tests cover both directions on RESP2 and RESP3, with asymmetric channel vs pattern counts so the wrong residual would fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9f3c3140575c695f748f8c8426a263508b056d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->