### PR TITLE
fix(client): name all members of StreamMessagesRawReply tuple

### DIFF
--- a/packages/client/lib/commands/generic-transformers.spec.ts
+++ b/packages/client/lib/commands/generic-transformers.spec.ts
@@ -1,4 +1,6 @@
 import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import * as ts from 'typescript';
 import { BasicCommandParser } from '../client/parser';
 import { pushScanArguments } from './SCAN';
 import { parseGeoSearchArguments, parseGeoSearchOptions } from './GEOSEARCH';
@@ -769,6 +771,38 @@ describe('Generic Transformers', () => {
                 }]),
                 ['0', '1', '2', '3']
             );
+        });
+    });
+
+    describe('tuple reply declarations', () => {
+        // Mixing labeled and unlabeled members in a tuple type makes the
+        // emitted declarations fail to compile for consumers using TypeScript
+        // versions that enforce TS5084 ("Tuple members must all have names or
+        // all not have names"), see
+        // https://github.com/redis/node-redis/issues/3009. Labels are erased
+        // during type checking, so the invariant is verified by walking the
+        // source AST rather than relying on tsc diagnostics.
+        it('tuple reply types should not mix named and unnamed members', () => {
+            const file = __filename.replace('generic-transformers.spec.ts', 'generic-transformers.ts');
+            const source = ts.createSourceFile(
+                file,
+                readFileSync(file, 'utf8'),
+                ts.ScriptTarget.Latest,
+                true
+            );
+            const offenders: Array<number> = [];
+            (function visit(node: ts.Node) {
+                if (ts.isTupleTypeNode(node)) {
+                    const named = node.elements
+                        .filter((element) => !ts.isRestTypeNode(element))
+                        .map((element) => ts.isNamedTupleMember(element));
+                    if (named.includes(true) && named.includes(false)) {
+                        offenders.push(source.getLineAndCharacterOfPosition(node.getStart()).line + 1);
+                    }
+                }
+                ts.forEachChild(node, visit);
+            })(source);
+            assert.deepEqual(offenders, []);
         });
     });
 });

--- a/packages/client/lib/commands/generic-transformers.spec.ts
+++ b/packages/client/lib/commands/generic-transformers.spec.ts
@@ -1,6 +1,4 @@
 import { strict as assert } from 'node:assert';
-import { readFileSync } from 'node:fs';
-import * as ts from 'typescript';
 import { BasicCommandParser } from '../client/parser';
 import { pushScanArguments } from './SCAN';
 import { parseGeoSearchArguments, parseGeoSearchOptions } from './GEOSEARCH';
@@ -771,38 +769,6 @@ describe('Generic Transformers', () => {
                 }]),
                 ['0', '1', '2', '3']
             );
-        });
-    });
-
-    describe('tuple reply declarations', () => {
-        // Mixing labeled and unlabeled members in a tuple type makes the
-        // emitted declarations fail to compile for consumers using TypeScript
-        // versions that enforce TS5084 ("Tuple members must all have names or
-        // all not have names"), see
-        // https://github.com/redis/node-redis/issues/3009. Labels are erased
-        // during type checking, so the invariant is verified by walking the
-        // source AST rather than relying on tsc diagnostics.
-        it('tuple reply types should not mix named and unnamed members', () => {
-            const file = __filename.replace('generic-transformers.spec.ts', 'generic-transformers.ts');
-            const source = ts.createSourceFile(
-                file,
-                readFileSync(file, 'utf8'),
-                ts.ScriptTarget.Latest,
-                true
-            );
-            const offenders: Array<number> = [];
-            (function visit(node: ts.Node) {
-                if (ts.isTupleTypeNode(node)) {
-                    const named = node.elements
-                        .filter((element) => !ts.isRestTypeNode(element))
-                        .map((element) => ts.isNamedTupleMember(element));
-                    if (named.includes(true) && named.includes(false)) {
-                        offenders.push(source.getLineAndCharacterOfPosition(node.getStart()).line + 1);
-                    }
-                }
-                ts.forEachChild(node, visit);
-            })(source);
-            assert.deepEqual(offenders, []);
         });
     });
 });

--- a/packages/client/lib/commands/generic-transformers.ts
+++ b/packages/client/lib/commands/generic-transformers.ts
@@ -740,7 +740,7 @@ export function transformStreamMessagesReply(
   return reply.map(transformStreamMessageReply.bind(undefined, typeMapping));
 }
 
-type StreamMessagesRawReply = TuplesReply<[name: BlobStringReply, ArrayReply<StreamMessageRawReply>]>;
+type StreamMessagesRawReply = TuplesReply<[name: BlobStringReply, messages: ArrayReply<StreamMessageRawReply>]>;
 export type StreamsMessagesRawReply2 = ArrayReply<StreamMessagesRawReply>;
 
 export function transformStreamsMessagesReplyResp2(


### PR DESCRIPTION
## Summary
Fixes #3009. The emitted declaration for StreamMessagesRawReply mixed a labeled tuple member with an unlabeled one, so consumer builds using TypeScript versions that enforce TS5084 failed inside generic-transformers.d.ts. Both members are now labeled, matching StreamMessageRawReply and neighboring stream reply types.

## Testing
Compiled a consumer project against the built dist with tsc 5.0.4 and declaration emit: TS5084 at generic-transformers.d.ts(255,67) before the change, clean after. Removed the AST-walking spec per review since it parsed a source file for a narrow type-label fix. Ran test:types, the client unit suite, lint and build.

## Checklist
- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed
