### PR TITLE
fix(client): correct XINFO GROUPS last-delivered-id reply type

### DIFF
--- a/packages/client/lib/commands/XINFO_GROUPS.ts
+++ b/packages/client/lib/commands/XINFO_GROUPS.ts
@@ -8,7 +8,7 @@ export type XInfoGroupsReply = ArrayReply<TuplesToMapReply<[
   [BlobStringReply<'name'>, BlobStringReply],
   [BlobStringReply<'consumers'>, NumberReply],
   [BlobStringReply<'pending'>, NumberReply],
-  [BlobStringReply<'last-delivered-id'>, NumberReply],
+  [BlobStringReply<'last-delivered-id'>, BlobStringReply],
   /** added in 7.0 */
   [BlobStringReply<'entries-read'>, NumberReply | NullReply],
   /** added in 7.0 */

--- a/packages/client/types-tests/xinfo-groups.types-test.ts
+++ b/packages/client/types-tests/xinfo-groups.types-test.ts
@@ -1,0 +1,25 @@
+/**
+ * Compile-time regression: the `last-delivered-id` member of the XINFO GROUPS
+ * reply is a stream entry ID string (e.g. "0-0"), not a number. The declared
+ * reply type used to label it NumberReply, so consumers saw a `number` where
+ * Redis sends a string.
+ *
+ * Lives outside `lib/` so it is not picked up by the production build /
+ * typedoc. Checked with `npm run test:types -w @redis/client`.
+ */
+import { createClient } from '../index';
+
+type Client = ReturnType<typeof createClient>;
+type Group = Awaited<ReturnType<Client['xInfoGroups']>>[number];
+type LastDeliveredId = Group['last-delivered-id'];
+
+declare const lastDeliveredId: LastDeliveredId;
+
+// Must be usable as a string.
+const asString: string = lastDeliveredId;
+
+// Must not be treated as a number.
+// @ts-expect-error stream entry IDs are strings, not numbers
+const asNumber: number = lastDeliveredId;
+
+export const XINFO_GROUPS_LAST_DELIVERED_ID_IS_A_STRING = [asString, asNumber] as const;


### PR DESCRIPTION
## Summary
The XINFO GROUPS reply type declared last-delivered-id as a number, but Redis sends a stream entry ID string (for example "0-0"), so TypeScript consumers saw the wrong primitive type and could hit runtime errors treating it as numeric. This labels it BlobStringReply, matching XINFO STREAM's last-generated-id and the runtime value already asserted by the XINFO GROUPS integration spec.

## Testing
Reproduced at compile time: with the old declaration, groups[0]['last-delivered-id'] resolves to number and assigning it to string fails tsc. Added packages/client/types-tests/xinfo-groups.types-test.ts which fails before the fix and passes after. Ran test:types, lint and the client package build locally; full suites run in CI.

## Checklist
- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only correction plus a compile-time test; no runtime or protocol behavior changes.
> 
> **Overview**
> Fixes the `XINFO GROUPS` reply type so `last-delivered-id` is a stream ID **string** (`BlobStringReply`), not a number. Redis returns values like `"0-0"`; the old `NumberReply` declaration made TypeScript treat it as `number`.
> 
> Adds a compile-time types test that asserts the field is assignable to `string` and not to `number`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73905e3d5631d34125ebef0914dceaa282633a35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->