### PR TITLE
fix(client): correct HELLO modules reply type

### DIFF
--- a/packages/client/lib/commands/HELLO.ts
+++ b/packages/client/lib/commands/HELLO.ts
@@ -17,7 +17,14 @@ export type HelloReply = TuplesToMapReply<[
   [BlobStringReply<'id'>, NumberReply],
   [BlobStringReply<'mode'>, BlobStringReply],
   [BlobStringReply<'role'>, BlobStringReply],
-  [BlobStringReply<'modules'>, ArrayReply<BlobStringReply>]
+  [BlobStringReply<'modules'>, ArrayReply<TuplesToMapReply<[
+    [BlobStringReply<'name'>, BlobStringReply],
+    [BlobStringReply<'ver'>, NumberReply],
+    /** added in 7.0 */
+    [BlobStringReply<'path'>, BlobStringReply],
+    /** added in 7.0 */
+    [BlobStringReply<'args'>, ArrayReply<BlobStringReply>]
+  ]>>]
 ]>;
 
 export default {

--- a/packages/client/lib/commands/HELLO.ts
+++ b/packages/client/lib/commands/HELLO.ts
@@ -19,11 +19,8 @@ export type HelloReply = TuplesToMapReply<[
   [BlobStringReply<'role'>, BlobStringReply],
   [BlobStringReply<'modules'>, ArrayReply<TuplesToMapReply<[
     [BlobStringReply<'name'>, BlobStringReply],
-    [BlobStringReply<'ver'>, NumberReply],
-    /** added in 7.0 */
-    [BlobStringReply<'path'>, BlobStringReply],
-    /** added in 7.0 */
-    [BlobStringReply<'args'>, ArrayReply<BlobStringReply>]
+    [BlobStringReply<'ver'>, NumberReply]
+    /** path and args exist only on Redis 7.0+ */
   ]>>]
 ]>;
 

--- a/packages/client/types-tests/hello.types-test.ts
+++ b/packages/client/types-tests/hello.types-test.ts
@@ -1,8 +1,9 @@
 /**
  * Compile-time regression: each entry of the HELLO reply's modules field is a
- * structured entry (name, ver, and path/args since 7.0), not a plain string.
- * The declared reply type used to label it Array<BlobStringReply>, so
- * consumers had no type-safe access to the module fields.
+ * structured entry (name, ver), not a plain string. The declared reply type
+ * used to label it Array<BlobStringReply>, so consumers had no type-safe
+ * access to the module fields. path and args exist only on Redis 7.0+ and are
+ * intentionally left out of the declared shape, mirroring MODULE LIST.
  *
  * Lives outside `lib/` so it is not picked up by the production build /
  * typedoc. Checked with `npm run test:types -w @redis/client`.
@@ -18,15 +19,13 @@ export function helloModulesAreStructured(entry: ModuleEntry): void {
     if (!Array.isArray(entry)) {
         const name: string = entry.name;
         const ver: number = entry.ver;
-        const path: string = entry.path;
-        const args: string[] = entry.args;
 
         // A module version is a number, not a string.
         // @ts-expect-error module versions are numbers
         const notAString: string = entry.ver;
 
         if (process.env.NODE_ENV !== 'production') {
-            console.log(name, ver, path, args, notAString);
+            console.log(name, ver, notAString);
         }
 
         return;

--- a/packages/client/types-tests/hello.types-test.ts
+++ b/packages/client/types-tests/hello.types-test.ts
@@ -1,0 +1,39 @@
+/**
+ * Compile-time regression: each entry of the HELLO reply's modules field is a
+ * structured entry (name, ver, and path/args since 7.0), not a plain string.
+ * The declared reply type used to label it Array<BlobStringReply>, so
+ * consumers had no type-safe access to the module fields.
+ *
+ * Lives outside `lib/` so it is not picked up by the production build /
+ * typedoc. Checked with `npm run test:types -w @redis/client`.
+ */
+import { createClient } from '../index';
+
+type Client = ReturnType<typeof createClient>;
+type HelloReply = Awaited<ReturnType<Client['hello']>>;
+type ModuleEntry = HelloReply['modules'][number];
+
+export function helloModulesAreStructured(entry: ModuleEntry): void {
+    // Mapped (RESP3-style) entries must expose the server's fields.
+    if (!Array.isArray(entry)) {
+        const name: string = entry.name;
+        const ver: number = entry.ver;
+        const path: string = entry.path;
+        const args: string[] = entry.args;
+
+        // A module version is a number, not a string.
+        // @ts-expect-error module versions are numbers
+        const notAString: string = entry.ver;
+
+        if (process.env.NODE_ENV !== 'production') {
+            console.log(name, ver, path, args, notAString);
+        }
+
+        return;
+    }
+
+    // Flat (RESP2-style) entries stay arrays.
+    if (entry.length < 0) {
+        console.log(entry);
+    }
+}


### PR DESCRIPTION
## Summary
HELLO declared each modules entry as Array<BlobStringReply>, but the server sends one structured entry per loaded module. This declares the entries with the same TuplesToMapReply shape MODULE LIST uses, matching addReplyLoadedModules in the server. path and args exist only on Redis 7.0+, so like MODULE LIST the type narrows to name and ver and leaves newer fields out of the declared shape. The RESP2 path still passes modules through raw (flat arrays), so parity with MODULE LIST holds only for RESP3 mapped replies.

## Testing
Reproduced at compile time: with the old declaration each module entry resolved to string and accessing name or ver failed tsc. Added packages/client/types-tests/hello.types-test.ts, which fails before the fix and passes after. Ran test:types, lint and build locally; full suites run in CI.

## Checklist
- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed