### PR TITLE
fix(time-series): honour typeMapping for labels in RESP2 replies

### DIFF
--- a/packages/time-series/lib/commands/MGET_WITHLABELS.spec.ts
+++ b/packages/time-series/lib/commands/MGET_WITHLABELS.spec.ts
@@ -2,12 +2,26 @@ import { strict as assert } from 'node:assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import MGET_WITHLABELS from './MGET_WITHLABELS';
 import { parseArgs } from '@redis/client/lib/commands/generic-transformers';
+import { RESP_TYPES } from '@redis/client';
 
 describe('TS.MGET_WITHLABELS', () => {
   it('transformArguments', () => {
     assert.deepEqual(
       parseArgs(MGET_WITHLABELS, 'label=value'),
       ['TS.MGET', 'WITHLABELS', 'FILTER', 'label=value']
+    );
+  });
+
+  it('transformReply maps labels with the MAP type mapping', () => {
+    const reply = MGET_WITHLABELS.transformReply[2](
+      [['key', [['label', 'value']], [0, '1']]] as never,
+      undefined,
+      { [RESP_TYPES.MAP]: Map }
+    ) as unknown as Map<string, { labels: unknown }>;
+
+    assert.deepEqual(
+      reply.get('key')?.labels,
+      new Map([['label', 'value']])
     );
   });
 

--- a/packages/time-series/lib/commands/MGET_WITHLABELS.ts
+++ b/packages/time-series/lib/commands/MGET_WITHLABELS.ts
@@ -34,7 +34,7 @@ export function createTransformMGetLabelsReply<T extends RawLabelValue>() {
     2(reply: MGetLabelsRawReply2<T>, _, typeMapping?: TypeMapping) {
       return resp2MapToValue(reply, ([, labels, sample]) => {
         return {
-          labels: transformRESP2Labels(labels),
+          labels: transformRESP2Labels(labels, typeMapping),
           sample: transformSampleReply[2](sample)
         };
       }, typeMapping);

--- a/packages/time-series/lib/commands/MRANGE_WITHLABELS_GROUPBY.spec.ts
+++ b/packages/time-series/lib/commands/MRANGE_WITHLABELS_GROUPBY.spec.ts
@@ -4,6 +4,7 @@ import MRANGE_WITHLABELS_GROUPBY from './MRANGE_WITHLABELS_GROUPBY';
 import { TIME_SERIES_REDUCERS } from './MRANGE_GROUPBY';
 import { TIME_SERIES_AGGREGATION_TYPE } from './CREATERULE';
 import { parseArgs } from '@redis/client/lib/commands/generic-transformers';
+import { RESP_TYPES } from '@redis/client';
 
 describe('TS.MRANGE_WITHLABELS_GROUPBY', () => {
   it('transformArguments', () => {
@@ -38,6 +39,24 @@ describe('TS.MRANGE_WITHLABELS_GROUPBY', () => {
         'GROUPBY', 'label', 'REDUCE', 'AVG'
       ]
     );
+  });
+
+  it('transformReply maps labels with the MAP type mapping', () => {
+    const reply = MRANGE_WITHLABELS_GROUPBY.transformReply[2](
+      [[
+        'key',
+        [['label', 'value'], ['__reducer__', 'avg'], ['__source__', 'source']],
+        [[0, '1']]
+      ]] as never,
+      undefined,
+      { [RESP_TYPES.MAP]: Map }
+    ) as unknown as Map<string, { labels: unknown, sources: Array<string> }>;
+
+    assert.deepEqual(
+      reply.get('key')?.labels,
+      new Map([['label', 'value']])
+    );
+    assert.deepEqual(reply.get('key')?.sources, ['source']);
   });
 
   testUtils.testWithClient('client.ts.mRangeWithLabelsGroupBy', async client => {

--- a/packages/time-series/lib/commands/MRANGE_WITHLABELS_GROUPBY.ts
+++ b/packages/time-series/lib/commands/MRANGE_WITHLABELS_GROUPBY.ts
@@ -57,7 +57,7 @@ export default {
   transformReply: {
     2(reply: TsMRangeWithLabelsGroupByRawReply2, _?: unknown, typeMapping?: TypeMapping) {
       return resp2MapToValue(reply, ([_key, labels, samples]) => {
-        const transformed = transformRESP2LabelsWithSources(labels);
+        const transformed = transformRESP2LabelsWithSources(labels, typeMapping);
         return {
           labels: transformed.labels,
           sources: transformed.sources,


### PR DESCRIPTION
## Summary

`ts.mGetWithLabels`, `ts.mGetSelectedLabels` and the two `WITHLABELS ... GROUPBY` range commands ignored `typeMapping` for the labels map on RESP2. Both transformers pass it to `resp2MapToValue` for the outer key map but call `transformRESP2Labels` / `transformRESP2LabelsWithSources` without it, although those helpers accept it. So with `withTypeMapping({ [RESP_TYPES.MAP]: Map })` the outer container came back as a `Map` while `labels` stayed a plain object, diverging from RESP3 and from `ts.mRangeSelectedLabels`.

## Testing

Reproduced via `transformReply[2]` with a synthetic RESP2 reply and `{ [RESP_TYPES.MAP]: Map }`: `labels` was `{ label: 'value' }` instead of `Map(1) { 'label' => 'value' }`. Added a regression test to each affected spec; both fail before the change and pass after. Type check and lint pass; replies without `typeMapping` are unchanged.

## Checklist

- [x] bug reproduced before fix
- [x] root cause identified
- [x] bug fixed
- [x] tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small reply-shape fix in time-series transformers; default object replies stay the same, only typeMapping users are affected.
> 
> **Overview**
> RESP2 `labels` maps now respect `typeMapping` (e.g. `Map`) instead of always being plain objects.
> 
> `createTransformMGetLabelsReply` and the WITHLABELS GROUPBY transformer pass `typeMapping` into `transformRESP2Labels` / `transformRESP2LabelsWithSources`, matching the outer key map and RESP3. Default replies without a mapping are unchanged. Adds unit tests for `TS.MGET WITHLABELS` and `TS.MRANGE WITHLABELS GROUPBY`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c65f707bdfde76be31d34187c104e0b561f88ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->