### PR TITLE
fix(client): handle ACL GETUSER null reply for nonexistent users

### DIFF
--- a/packages/client/lib/commands/ACL_GETUSER.spec.ts
+++ b/packages/client/lib/commands/ACL_GETUSER.spec.ts
@@ -13,6 +13,13 @@ describe('ACL GETUSER', () => {
     );
   });
 
+  it('transformReply passes a null reply through for nonexistent users', () => {
+    assert.equal(
+      (ACL_GETUSER.transformReply[2] as unknown as (reply: unknown) => unknown)(null),
+      null
+    );
+  });
+
   testUtils.testWithClient('client.aclGetUser', async client => {
     const reply = await client.aclGetUser('default');
 

--- a/packages/client/lib/commands/ACL_GETUSER.ts
+++ b/packages/client/lib/commands/ACL_GETUSER.ts
@@ -1,5 +1,6 @@
 import { CommandParser } from '../client/parser';
-import { RedisArgument, TuplesToMapReply, BlobStringReply, ArrayReply, UnwrapReply, Resp2Reply, Command } from '../RESP/types';
+import { RedisArgument, TuplesToMapReply, BlobStringReply, ArrayReply, UnwrapReply, Resp2Reply, Command, NullReply } from '../RESP/types';
+import { isNullReply } from './generic-transformers';
 
 type AclUser = TuplesToMapReply<[
   [BlobStringReply<'flags'>, ArrayReply<BlobStringReply>],
@@ -23,21 +24,26 @@ export default {
     parser.push('ACL', 'GETUSER', username);
   },
   transformReply: {
-    2: (reply: UnwrapReply<Resp2Reply<AclUser>>) => ({
-      flags: reply[1],
-      passwords: reply[3],
-      commands: reply[5],
-      keys: reply[7],
-      channels: reply[9],
-      selectors: (reply[11] as unknown as UnwrapReply<typeof reply[11]>)?.map(selector => {
-        const inferred = selector as unknown as UnwrapReply<typeof selector>;
-        return {
-          commands: inferred[1],
-          keys: inferred[3],
-          channels: inferred[5]
-        };
-      })
-    }),
-    3: undefined as unknown as () => AclUser
+    // NullReply when the user does not exist
+    2: (reply: UnwrapReply<Resp2Reply<AclUser>> | NullReply) => {
+      if (isNullReply(reply)) return reply;
+
+      return {
+        flags: reply[1],
+        passwords: reply[3],
+        commands: reply[5],
+        keys: reply[7],
+        channels: reply[9],
+        selectors: (reply[11] as unknown as UnwrapReply<typeof reply[11]>)?.map(selector => {
+          const inferred = selector as unknown as UnwrapReply<typeof selector>;
+          return {
+            commands: inferred[1],
+            keys: inferred[3],
+            channels: inferred[5]
+          };
+        })
+      };
+    },
+    3: undefined as unknown as () => AclUser | NullReply
   }
 } as const satisfies Command;

--- a/packages/client/types-tests/acl-getuser.types-test.ts
+++ b/packages/client/types-tests/acl-getuser.types-test.ts
@@ -1,0 +1,22 @@
+/**
+ * Compile-time regression for https://github.com/redis/node-redis/issues/2745.
+ *
+ * ACL GETUSER replies null for a nonexistent user, but the declared reply type
+ * claimed a non-null object shape and the RESP2 transformer indexed into the
+ * null reply. These assertions fail to compile against the unfixed code.
+ *
+ * Lives outside lib/ so it is not picked up by the production build / typedoc.
+ * Checked with `npm run test:types -w @redis/client`.
+ */
+import type { CommandReply, ReplyWithTypeMapping } from '../lib/RESP/types';
+import type ACL_GETUSER from '../lib/commands/ACL_GETUSER';
+
+type Assert<T extends true> = T;
+
+// The default (RESP3) client-facing reply type must include null.
+type Resp3ClientReply = ReplyWithTypeMapping<CommandReply<typeof ACL_GETUSER, 3>, {}>;
+export type Resp3ClientReplyIncludesNull = Assert<null extends Resp3ClientReply ? true : false>;
+
+// The RESP2 client-facing reply type must include null too.
+type Resp2ClientReply = ReplyWithTypeMapping<CommandReply<typeof ACL_GETUSER, 2>, {}>;
+export type Resp2ClientReplyIncludesNull = Assert<null extends Resp2ClientReply ? true : false>;


### PR DESCRIPTION
## Summary

ACL GETUSER replies null when the user does not exist, but the declared reply type claimed a non-null object shape and the RESP2 transformer crashed indexing into the null reply (`TypeError: Cannot read properties of null (reading '1')`), as reported in #2745.

The RESP2 transformer now passes a null reply through unchanged, and `NullReply` is part of the declared reply type for both protocols, following the existing FUNCTION_STATS pattern.

## Testing

Reproduced the crash by calling the RESP2 transformer with a null reply on master; it throws the exact TypeError from #2745. Added a unit assertion that the transformer returns null unchanged, plus compile-time regression tests asserting null is part of the client-facing reply type for both protocols (`npm run test:types -w @redis/client` fails before this change, passes after).

## Checklist

- [x] Bug reproduced before fix
- [x] Root cause identified
- [x] Bug fixed
- [x] Tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow reply-transform and type fix for one command; no auth, protocol, or data-path changes beyond correctly returning null.
> 
> **Overview**
> Fixes `ACL GETUSER` crashing on RESP2 when the user does not exist (`TypeError` from indexing into `null`), and types the reply as nullable for both RESP2 and RESP3 (#2745).
> 
> The RESP2 transformer now returns `null` unchanged via `isNullReply`. Adds a unit check for that path and a compile-time types test that `null` is part of the client-facing reply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc4cedcae4adf6adf51ae2a0bb59db6258b9e81c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->