### PR TITLE
fix(client): correct CLUSTER BUMPEPOCH reply type

### DIFF
--- a/packages/client/lib/commands/CLUSTER_BUMPEPOCH.ts
+++ b/packages/client/lib/commands/CLUSTER_BUMPEPOCH.ts
@@ -5,5 +5,6 @@ export default {
   parseCommand(parser: CommandParser) {
     parser.push('CLUSTER', 'BUMPEPOCH');
   },
-  transformReply: undefined as unknown as () => SimpleStringReply<'BUMPED' | 'STILL'>
+  // the reply is "BUMPED <epoch>" or "STILL <epoch>", not a bare literal
+  transformReply: undefined as unknown as () => SimpleStringReply
 } as const satisfies Command;

--- a/packages/client/types-tests/cluster-bumpepoch.types-test.ts
+++ b/packages/client/types-tests/cluster-bumpepoch.types-test.ts
@@ -1,0 +1,27 @@
+/**
+ * Compile-time regression for the CLUSTER BUMPEPOCH reply type.
+ *
+ * Redis replies with the simple string "BUMPED <epoch>" or "STILL <epoch>"
+ * (cluster_legacy.c), but the reply was declared as the literal union
+ * 'BUMPED' | 'STILL', so `reply === 'BUMPED'` compiled while never matching
+ * at runtime. The declared client-facing reply type must be a plain string.
+ *
+ * Lives outside lib/ so it is not picked up by the production build / typedoc.
+ * Checked with `npm run test:types -w @redis/client`.
+ */
+import type { CommandReply, ReplyWithTypeMapping } from '../lib/RESP/types';
+import type CLUSTER_BUMPEPOCH from '../lib/commands/CLUSTER_BUMPEPOCH';
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+
+type Assert<T extends true> = T;
+
+type ClientReply = ReplyWithTypeMapping<CommandReply<typeof CLUSTER_BUMPEPOCH, 3>, {}>;
+
+// must be a plain string: the epoch is appended to the literal prefix
+export type ClientReplyIsString = Assert<Equal<ClientReply, string>>;
+
+// must NOT collapse back to the bare literals
+export type NotBareLiterals = Assert<Equal<ClientReply, 'BUMPED' | 'STILL'> extends true ? false : true>;


### PR DESCRIPTION
## Summary

CLUSTER BUMPEPOCH replies the simple string "BUMPED &lt;epoch&gt;" or "STILL &lt;epoch&gt;" (cluster_legacy.c formats it with sdscatprintf), but the reply was typed as the literal union 'BUMPED' | 'STILL'. Code like `reply === 'BUMPED'` compiled while never matching at runtime because the epoch is always appended. The reply is now declared as a plain string, matching CLUSTER_REPLICATE and the existing runtime assertion in the spec.

## Testing

Compile-time regression test asserts the client-facing reply type equals string and is not the bare literal union; it fails before this change and passes after (`npm run test:types -w @redis/client`). lint:changed and the client package build pass. Runtime behavior is unchanged; the existing spec already asserts typeof reply === 'string'.

## Checklist

- [x] Bug reproduced before fix
- [x] Root cause identified
- [x] Bug fixed
- [x] Tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only correction for one cluster command reply; no runtime or security changes.
> 
> **Overview**
> Fixes the TypeScript reply type for `CLUSTER BUMPEPOCH`. Redis returns `"BUMPED <epoch>"` or `"STILL <epoch>"`, but the client typed the reply as the bare literals `'BUMPED' | 'STILL'`, so checks like `reply === 'BUMPED'` type-checked while never matching at runtime.
> 
> The command now uses a plain `SimpleStringReply`. A compile-time types test asserts the client-facing type is `string` and not the old literal union. Runtime behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15ca6b40d56881d4cf88ca83bb1d93e4052fc2fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->