### PR TITLE
fix(client): expose watch, rbs and rbp fields in CLIENT INFO and CLIENT LIST replies

### DIFF
--- a/packages/client/lib/commands/CLIENT_INFO.spec.ts
+++ b/packages/client/lib/commands/CLIENT_INFO.spec.ts
@@ -14,6 +14,15 @@ describe('CLIENT INFO', () => {
     );
   });
 
+  it('transformReply parses fields added in newer Redis versions', () => {
+    const reply = CLIENT_INFO.transformReply(
+      'id=3 addr=127.0.0.1:6379 laddr=127.0.0.1:53000 fd=8 name= age=10 idle=0 flags=N db=0 sub=0 psub=0 ssub=0 multi=0 watch=2 qbuf=26 qbuf-free=20448 argv-mem=120 multi-mem=0 rbs=1024 rbp=2048 obl=0 oll=0 omem=0 tot-mem=22264 events=r cmd=client user=default redir=-1 resp=2' as unknown as Parameters<typeof CLIENT_INFO.transformReply>[0]
+    );
+    assert.equal(reply.watch, 2);
+    assert.equal(reply.rbs, 1024);
+    assert.equal(reply.rbp, 2048);
+  });
+
   testUtils.testWithClient('client.clientInfo', async client => {
     const reply = await client.clientInfo();
     assert.equal(typeof reply.id, 'number');

--- a/packages/client/lib/commands/CLIENT_INFO.ts
+++ b/packages/client/lib/commands/CLIENT_INFO.ts
@@ -31,6 +31,18 @@ export interface ClientInfoReply {
    * available since 7.0
    */
   multiMem?: number;
+  /**
+   * available since 7.4
+   */
+  watch?: number;
+  /**
+   * available since 7.0
+   */
+  rbs?: number;
+  /**
+   * available since 7.0
+   */
+  rbp?: number;
   obl: number;
   oll: number;
   omem: number;
@@ -118,6 +130,18 @@ export default {
 
     if (map.resp !== undefined) {
       reply.resp = Number(map.resp);
+    }
+
+    if (map.watch !== undefined) {
+      reply.watch = Number(map.watch);
+    }
+
+    if (map.rbs !== undefined) {
+      reply.rbs = Number(map.rbs);
+    }
+
+    if (map.rbp !== undefined) {
+      reply.rbp = Number(map.rbp);
     }
 
     return reply;


### PR DESCRIPTION
## Summary
CLIENT INFO and CLIENT LIST replies silently dropped three server fields: rbs and rbp (returned since Redis 7.0) and watch (added in 7.4). catClientInfoString in networking.c emits them, but ClientInfoReply and the reply parser ignored them, so consumers could not read buffer stats or watched-key counts. They are now optional typed fields parsed with the same guarded Number() pattern as the other version-gated fields. CLIENT LIST shares the transformer, so both commands are covered.

## Testing
Reproduced with a captured CLIENT INFO string containing watch=2 rbs=1024 rbp=2048: the new spec assertion failed on master (fields undefined) and passes after the fix. Parser spec, type tests, client build and eslint run locally; Docker-backed integration tests run in CI.

## Checklist
- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Parser-only additive fields on a read-only command; no auth, protocol, or connection-behavior changes.
> 
> **Overview**
> Exposes three Redis client-info fields that the parser previously dropped: `watch` (7.4) and `rbs`/`rbp` (7.0). They are now optional numbers on `ClientInfoReply`, so `CLIENT INFO` and `CLIENT LIST` (which reuses the same transformer) can report watched-key counts and output-buffer stats.
> 
> Adds a unit test that feeds a captured reply string and asserts the new fields parse correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f54aea3a854b0285b26f02c8c03a765383ea8c16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->