### PR TITLE
fix(client): expose MEMORY STATS fields added in Redis 7.4

### DIFF
--- a/packages/client/lib/commands/MEMORY_STATS.ts
+++ b/packages/client/lib/commands/MEMORY_STATS.ts
@@ -15,8 +15,14 @@ export type MemoryStatsReply = TuplesToMapReply<[
   [BlobStringReply<'lua.caches'>, NumberReply],
   /** added in 7.0 */
   [BlobStringReply<'functions.caches'>, NumberReply],
+  /** added in 7.4 */
+  [BlobStringReply<'overhead.db.hashtable.lut'>, NumberReply],
+  /** added in 7.4 */
+  [BlobStringReply<'overhead.db.hashtable.rehashing'>, NumberReply],
   // FIXME: 'db.0', and perhaps others' is here and is a map that should be handled?
   [BlobStringReply<'overhead.total'>, NumberReply],
+  /** added in 7.4 */
+  [BlobStringReply<'db.dict.rehashing.count'>, NumberReply],
   [BlobStringReply<'keys.count'>, NumberReply],
   [BlobStringReply<'keys.bytes-per-key'>, NumberReply],
   [BlobStringReply<'dataset.bytes'>, NumberReply],
@@ -25,6 +31,8 @@ export type MemoryStatsReply = TuplesToMapReply<[
   [BlobStringReply<'allocator.allocated'>, NumberReply],
   [BlobStringReply<'allocator.active'>, NumberReply],
   [BlobStringReply<'allocator.resident'>, NumberReply],
+  /** added in 7.4 */
+  [BlobStringReply<'allocator.muzzy'>, NumberReply],
   [BlobStringReply<'allocator-fragmentation.ratio'>, DoubleReply],
   [BlobStringReply<'allocator-fragmentation.bytes'>, NumberReply],
   [BlobStringReply<'allocator-rss.ratio'>, DoubleReply],

--- a/packages/client/types-tests/memory-stats.types-test.ts
+++ b/packages/client/types-tests/memory-stats.types-test.ts
@@ -1,0 +1,29 @@
+/**
+ * Compile-time regression: the MEMORY STATS reply type must expose the fields
+ * Redis added in 7.4 (overhead.db.hashtable.lut, overhead.db.hashtable.rehashing,
+ * db.dict.rehashing.count, allocator.muzzy). They are top-level integers in the
+ * server's reply (object.c memoryCommand), but were absent from
+ * MemoryStatsReply, so consumers could not access them without casting.
+ *
+ * Lives outside `lib/` so it is not picked up by the production build /
+ * typedoc. Checked with `npm run test:types -w @redis/client`.
+ */
+import { createClient } from '../index';
+
+type Client = ReturnType<typeof createClient>;
+type MemoryStats = Awaited<ReturnType<Client['memoryStats']>>;
+
+export function memoryStatsExposesRedis74Fields(stats: MemoryStats): void {
+    const hashtableLut: number = stats['overhead.db.hashtable.lut'];
+    const hashtableRehashing: number = stats['overhead.db.hashtable.rehashing'];
+    const dictRehashingCount: number = stats['db.dict.rehashing.count'];
+    const allocatorMuzzy: number = stats['allocator.muzzy'];
+
+    // These fields are numbers, not strings.
+    // @ts-expect-error allocator.muzzy is a number
+    const notAString: string = stats['allocator.muzzy'];
+
+    if (process.env.NODE_ENV !== 'production') {
+        console.log(hashtableLut, hashtableRehashing, dictRehashingCount, allocatorMuzzy, notAString);
+    }
+}


### PR DESCRIPTION
## Summary
Redis 7.4 added four top-level fields to MEMORY STATS: overhead.db.hashtable.lut, overhead.db.hashtable.rehashing, db.dict.rehashing.count and allocator.muzzy (object.c emits each via addReplyBulkCString + addReplyLongLong). MemoryStatsReply did not declare them, so consumers needed casts to reach these values. They are now typed as numbers in server reply order, following the existing added-in comments convention.

## Testing
Compile-time regression test indexes all four fields on the client-facing reply type; it fails on master with TS7053 and passes after the fix. Verified against Redis 7.4 source; parser spec, type tests, build and lint run locally; Docker-backed integration tests run in CI.

## Checklist
- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed