### PR TITLE
fix(client): type ACL GETUSER flags as RESP3 SET

### DIFF
--- a/packages/client/lib/commands/ACL_GETUSER.ts
+++ b/packages/client/lib/commands/ACL_GETUSER.ts
@@ -1,8 +1,8 @@
 import { CommandParser } from '../client/parser';
-import { RedisArgument, TuplesToMapReply, BlobStringReply, ArrayReply, UnwrapReply, Resp2Reply, Command } from '../RESP/types';
+import { RedisArgument, TuplesToMapReply, BlobStringReply, ArrayReply, SetReply, UnwrapReply, Resp2Reply, Command } from '../RESP/types';
 
 type AclUser = TuplesToMapReply<[
-  [BlobStringReply<'flags'>, ArrayReply<BlobStringReply>],
+  [BlobStringReply<'flags'>, SetReply<BlobStringReply>],
   [BlobStringReply<'passwords'>, ArrayReply<BlobStringReply>],
   [BlobStringReply<'commands'>, BlobStringReply],
   /** changed to BlobStringReply in 7.0 */

--- a/packages/client/types-tests/acl-getuser-flags.types-test.ts
+++ b/packages/client/types-tests/acl-getuser-flags.types-test.ts
@@ -1,0 +1,24 @@
+/**
+ * Compile-time regression: ACL GETUSER's flags field must be typed as a
+ * RESP3 SET. acl.c emits the flags element with setDeferredSetLen, so RESP3
+ * clients receive a set on the wire, while ArrayReply promised an array.
+ * Sibling commands already model this with SetReply (FUNCTION LIST,
+ * CLIENT TRACKINGINFO); RESP2 replies remain arrays either way.
+ *
+ * Lives outside `lib/` so it is not picked up by the production build /
+ * typedoc. Checked with `npm run test:types -w @redis/client`.
+ */
+import ACL_GETUSER from '../lib/commands/ACL_GETUSER';
+import { RESP_TYPES } from '../lib/RESP/decoder';
+import { CommandReply, ReplyWithTypeMapping } from '../lib/RESP/types';
+
+type FlagsWithSetMapping = ReplyWithTypeMapping<
+  CommandReply<typeof ACL_GETUSER, 3>,
+  { [RESP_TYPES.SET]: typeof Set }
+>;
+
+export function aclGetUserFlagsAreSets(reply: FlagsWithSetMapping): void {
+    // With SET mapped, flags resolves to the RESP3 wire type.
+    const flags: Set<string> = reply.flags;
+    console.log(flags.size > 0 ? 'has flags' : 'no flags');
+}

--- a/packages/client/types-tests/acl-getuser-flags.types-test.ts
+++ b/packages/client/types-tests/acl-getuser-flags.types-test.ts
@@ -1,9 +1,9 @@
 /**
- * Compile-time regression: ACL GETUSER's flags field must be typed as a
- * RESP3 SET. acl.c emits the flags element with setDeferredSetLen, so RESP3
- * clients receive a set on the wire, while ArrayReply promised an array.
- * Sibling commands already model this with SetReply (FUNCTION LIST,
- * CLIENT TRACKINGINFO); RESP2 replies remain arrays either way.
+ * Compile-time regression: ACL GETUSER's flags field must model the RESP3
+ * set that acl.c emits (setDeferredSetLen). The wire element is a set, but it
+ * decodes to a plain Array unless callers map RESP_TYPES.SET to Set, which is
+ * exactly how SetReply types it. Sibling commands already use SetReply
+ * (FUNCTION LIST, CLIENT TRACKINGINFO); replies remain arrays by default.
  *
  * Lives outside `lib/` so it is not picked up by the production build /
  * typedoc. Checked with `npm run test:types -w @redis/client`.
@@ -18,7 +18,7 @@ type FlagsWithSetMapping = ReplyWithTypeMapping<
 >;
 
 export function aclGetUserFlagsAreSets(reply: FlagsWithSetMapping): void {
-    // With SET mapped, flags resolves to the RESP3 wire type.
+    // With SET mapped to Set, flags resolves to Set<string>.
     const flags: Set<string> = reply.flags;
     console.log(flags.size > 0 ? 'has flags' : 'no flags');
 }

--- a/packages/client/types-tests/acl-getuser-flags.types-test.ts
+++ b/packages/client/types-tests/acl-getuser-flags.types-test.ts
@@ -18,6 +18,9 @@ type FlagsWithSetMapping = ReplyWithTypeMapping<
 >;
 
 export function aclGetUserFlagsAreSets(reply: FlagsWithSetMapping): void {
+    // The reply includes null when the user does not exist.
+    if (reply === null) return;
+
     // With SET mapped to Set, flags resolves to Set<string>.
     const flags: Set<string> = reply.flags;
     console.log(flags.size > 0 ? 'has flags' : 'no flags');


### PR DESCRIPTION
## Summary
ACL GETUSER declares flags as an array, but acl.c emits the flags element with setDeferredSetLen, so RESP3 replies carry a set that decodes to a plain Array unless callers opt in with a { [RESP_TYPES.SET]: Set } type mapping. Sibling commands already model this shape with SetReply (FUNCTION LIST, CLIENT TRACKINGINFO). flags is now SetReply<BlobStringReply>: replies remain arrays by default, and clients that map RESP_TYPES.SET to Set see Set<string>.

## Testing
Compile-time regression test resolves the reply under a SET type mapping and asserts flags is Set<string>; it fails on master with TS2740 and passes after the fix. Parser spec, type tests, build and lint run locally; Docker-backed integration tests run in CI.

## Checklist
- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only fix for RESP3 reply typing plus a types-test; no runtime or wire behavior changes.
> 
> **Overview**
> **ACL GETUSER** now types the `flags` field as `SetReply<BlobStringReply>` instead of `ArrayReply`, matching the RESP3 set Redis emits on the wire and aligning with commands like **FUNCTION LIST** and **CLIENT TRACKINGINFO**.
> 
> Default decoding behavior is unchanged (still arrays unless callers opt in). With `{ [RESP_TYPES.SET]: Set }` mapping, `flags` correctly resolves to `Set<string>`.
> 
> A compile-time regression test under `types-tests/` asserts that mapping so the wrong array typing cannot return.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d82984bc0814ac43e63407d5afd01beb69647a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->