### PR TITLE
fix(client): require XADD TRIM strategy to match the command grammar

### DIFF
--- a/packages/client/lib/commands/XADD.spec.ts
+++ b/packages/client/lib/commands/XADD.spec.ts
@@ -31,10 +31,11 @@ describe('XADD', () => {
           field: 'value'
         }, {
           TRIM: {
-            threshold: 1000
+            strategy: 'MINID',
+            threshold: 5
           }
         }),
-        ['XADD', 'key', '1000', '*', 'field', 'value']
+        ['XADD', 'key', 'MINID', '5', '*', 'field', 'value']
       );
     });
 
@@ -58,11 +59,12 @@ describe('XADD', () => {
           field: 'value'
         }, {
           TRIM: {
+            strategy: 'MAXLEN',
             strategyModifier: '=',
             threshold: 1000
           }
         }),
-        ['XADD', 'key', '=', '1000', '*', 'field', 'value']
+        ['XADD', 'key', 'MAXLEN', '=', '1000', '*', 'field', 'value']
       );
     });
 
@@ -72,11 +74,12 @@ describe('XADD', () => {
           field: 'value'
         }, {
           TRIM: {
+            strategy: 'MAXLEN',
             threshold: 1000,
             limit: 1
           }
         }),
-        ['XADD', 'key', '1000', 'LIMIT', '1', '*', 'field', 'value']
+        ['XADD', 'key', 'MAXLEN', '1000', 'LIMIT', '1', '*', 'field', 'value']
       );
     });
 
@@ -86,11 +89,12 @@ describe('XADD', () => {
           field: 'value'
         }, {
           TRIM: {
+            strategy: 'MAXLEN',
             threshold: 1000,
             limit: 0
           }
         }),
-        ['XADD', 'key', '1000', 'LIMIT', '0', '*', 'field', 'value']
+        ['XADD', 'key', 'MAXLEN', '1000', 'LIMIT', '0', '*', 'field', 'value']
       );
     });
 
@@ -100,11 +104,12 @@ describe('XADD', () => {
           field: 'value'
         }, {
           TRIM: {
+            strategy: 'MAXLEN',
             threshold: 1000,
             policy: STREAM_DELETION_POLICY.DELREF
           }
         }),
-        ['XADD', 'key', '1000', 'DELREF', '*', 'field', 'value']
+        ['XADD', 'key', 'MAXLEN', '1000', 'DELREF', '*', 'field', 'value']
       );
     });
 

--- a/packages/client/lib/commands/XADD.ts
+++ b/packages/client/lib/commands/XADD.ts
@@ -83,9 +83,7 @@ export function parseXAddArguments(
 
   // Trimming options
   if (options?.TRIM) {
-    if (options.TRIM.strategy) {
-      parser.push(options.TRIM.strategy);
-    }
+    parser.push(options.TRIM.strategy);
 
     if (options.TRIM.strategyModifier) {
       parser.push(options.TRIM.strategyModifier);

--- a/packages/client/lib/commands/XADD.ts
+++ b/packages/client/lib/commands/XADD.ts
@@ -32,7 +32,11 @@ export interface XAddOptions {
     iid: RedisArgument;
   };
   TRIM?: {
-    strategy?: 'MAXLEN' | 'MINID';
+    /**
+     * Required by the XADD grammar: without MAXLEN or MINID the server parses
+     * the threshold as the entry ID instead of trimming.
+     */
+    strategy: 'MAXLEN' | 'MINID';
     strategyModifier?: '=' | '~';
     threshold: number;
     limit?: number;

--- a/packages/client/lib/commands/XADD_NOMKSTREAM.spec.ts
+++ b/packages/client/lib/commands/XADD_NOMKSTREAM.spec.ts
@@ -33,10 +33,11 @@ describe('XADD NOMKSTREAM', () => {
           field: 'value'
         }, {
           TRIM: {
-            threshold: 1000
+            strategy: 'MINID',
+            threshold: 5
           }
         }),
-        ['XADD', 'key', 'NOMKSTREAM', '1000', '*', 'field', 'value']
+        ['XADD', 'key', 'NOMKSTREAM', 'MINID', '5', '*', 'field', 'value']
       );
     });
 
@@ -60,11 +61,12 @@ describe('XADD NOMKSTREAM', () => {
           field: 'value'
         }, {
           TRIM: {
+            strategy: 'MAXLEN',
             strategyModifier: '=',
             threshold: 1000
           }
         }),
-        ['XADD', 'key', 'NOMKSTREAM', '=', '1000', '*', 'field', 'value']
+        ['XADD', 'key', 'NOMKSTREAM', 'MAXLEN', '=', '1000', '*', 'field', 'value']
       );
     });
 
@@ -74,11 +76,12 @@ describe('XADD NOMKSTREAM', () => {
           field: 'value'
         }, {
           TRIM: {
+            strategy: 'MAXLEN',
             threshold: 1000,
             limit: 1
           }
         }),
-        ['XADD', 'key', 'NOMKSTREAM', '1000', 'LIMIT', '1', '*', 'field', 'value']
+        ['XADD', 'key', 'NOMKSTREAM', 'MAXLEN', '1000', 'LIMIT', '1', '*', 'field', 'value']
       );
     });
 
@@ -88,11 +91,12 @@ describe('XADD NOMKSTREAM', () => {
           field: 'value'
         }, {
           TRIM: {
+            strategy: 'MAXLEN',
             threshold: 1000,
             policy: STREAM_DELETION_POLICY.DELREF
           }
         }),
-        ['XADD', 'key', 'NOMKSTREAM', '1000', 'DELREF', '*', 'field', 'value']
+        ['XADD', 'key', 'NOMKSTREAM', 'MAXLEN', '1000', 'DELREF', '*', 'field', 'value']
       );
     });
 

--- a/packages/client/types-tests/xadd-trim.types-test.ts
+++ b/packages/client/types-tests/xadd-trim.types-test.ts
@@ -1,0 +1,16 @@
+/**
+ * Compile-time regression: XADD's TRIM.strategy must be required. The official
+ * grammar makes MAXLEN|MINID mandatory inside the trim block; with the strategy
+ * omitted, parseXAddArguments emitted a bare threshold which the server parses
+ * as the entry ID instead of a trim instruction.
+ *
+ * Lives outside `lib/` so it is not picked up by the production build /
+ * typedoc. Checked with `npm run test:types -w @redis/client`.
+ */
+import { XAddOptions } from '../lib/commands/XADD';
+
+export function xaddTrimRequiresStrategy(): void {
+    // @ts-expect-error TRIM.strategy is required alongside threshold
+    const invalidTrim: NonNullable<XAddOptions['TRIM']> = { threshold: 1000 };
+    console.log(invalidTrim);
+}


### PR DESCRIPTION
## SummaryXAddOptions made TRIM.strategy optional while the XADD grammar makes MAXLEN|MINID mandatory inside the trim block. Omitting it emitted a bare number that the server parses as the entry ID (streamParseStrictIDOrReply), so the command added a wrong-ID entry with garbage fields or errored instead of trimming. strategy is now required, matching the XTRIM client API; five spec cases asserted the malformed argv and were corrected.## TestingCompile-time regression test rejects a strategy-less TRIM object: it compiled on master (TS2578) and fails after the fix. Verified against xadd.json and t_stream.c; parser assertions, type tests, build and lint run locally; Docker-backed integration tests run in CI.## Checklist- bug reproduced before fix- root cause identified- bug fixed- tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking TypeScript API for callers that passed `TRIM` without `strategy`, but the old behavior sent invalid commands to Redis; runtime behavior is corrected for properly typed callers.
> 
> **Overview**
> **Fixes incorrect `XADD` argv when `TRIM` omitted `MAXLEN`/`MINID`.** The client previously allowed `TRIM` with only `threshold`, which produced a bare number before the entry ID; Redis treats that as the stream ID, so adds could use wrong IDs or fail instead of trimming.
> 
> `XAddOptions.TRIM.strategy` is now **required** (aligned with `XTRIM`), and `parseXAddArguments` always emits `MAXLEN` or `MINID` before the threshold and related trim tokens. Unit expectations in `XADD` and `XADD_NOMKSTREAM` specs were updated for modifier, limit, and policy cases; a compile-time test in `types-tests` rejects strategy-less `TRIM` objects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0b0ad7fadd8b25f36066a44d8604be290b13c08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

### Release note

XADD TRIM.strategy is now required at compile time: MAXLEN/MINID is mandatory in the XADD grammar, so callers omitting it would previously emit a bare threshold the server parsed as an entry ID.