### PR TITLE
fix(client): include NOKEY in MIGRATE reply type

### DIFF
--- a/packages/client/lib/commands/MIGRATE.ts
+++ b/packages/client/lib/commands/MIGRATE.ts
@@ -60,5 +60,5 @@ export default {
       parser.pushKeys(key);
     }
   },
-  transformReply: undefined as unknown as () => SimpleStringReply<'OK'>
+  transformReply: undefined as unknown as () => SimpleStringReply<'OK' | 'NOKEY'>
 } as const satisfies Command;

--- a/packages/client/types-tests/migrate-reply.types-test.ts
+++ b/packages/client/types-tests/migrate-reply.types-test.ts
@@ -1,0 +1,20 @@
+/**
+ * Compile-time regression: MIGRATE replies +NOKEY when every requested key is
+ * missing on the source instance (cluster.c addReplySds "+NOKEY"), so the
+ * declared status union must include NOKEY alongside OK.
+ *
+ * Lives outside `lib/` so it is not picked up by the production build /
+ * typedoc. Checked with `npm run test:types -w @redis/client`.
+ */
+import { createClient } from '../index';
+
+type Client = ReturnType<typeof createClient>;
+
+export function migrateReplyIncludesNokey(reply: Awaited<ReturnType<Client['migrate']>>): void {
+    // Comparing against NOKEY must be a legal check on the declared union.
+    if (reply === 'NOKEY') {
+        console.log('nothing migrated');
+        return;
+    }
+    console.log(reply);
+}


### PR DESCRIPTION
## Summary
MIGRATE was typed as replying only OK, but when every requested key is missing on the source the server replies +NOKEY (cluster.c addReplySds, comment: reply with NOKEY to signal there was nothing to migrate). Users comparing against NOKEY got a TypeScript no-overlap error. The declared union now includes both statuses.

## Testing
Compile-time regression test compares the migrate() result against NOKEY: it fails on master with TS2367 and passes after widening. Verified against cluster.c source; type tests, build and lint run locally; Docker-backed integration tests run in CI.

## Checklist
- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only change to a command reply union; no runtime, auth, or data-handling behavior is modified.
> 
> **Overview**
> Widens `MIGRATE`'s typed reply from `'OK'` to `'OK' | 'NOKEY'` so TypeScript accepts the Redis status returned when every requested key is missing on the source.
> 
> Adds a compile-time types test that compares `client.migrate()` against `'NOKEY'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dff0c95bab76a8c71221fe1bb6f25d79e9e2904b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->