### PR TITLE
fix(client): accept sampled events in LATENCY command argument types

### DIFF
--- a/packages/client/lib/commands/LATENCY_GRAPH.ts
+++ b/packages/client/lib/commands/LATENCY_GRAPH.ts
@@ -3,6 +3,7 @@ import { BlobStringReply, Command } from '../RESP/types';
 
 export const LATENCY_EVENTS = {
   ACTIVE_DEFRAG_CYCLE: 'active-defrag-cycle',
+  AOF_FSTAT: 'aof-fstat',
   AOF_FSYNC_ALWAYS: 'aof-fsync-always',
   AOF_STAT: 'aof-stat',
   AOF_REWRITE_DIFF_WRITE: 'aof-rewrite-diff-write',
@@ -15,9 +16,11 @@ export const LATENCY_EVENTS = {
   EXPIRE_CYCLE: 'expire-cycle',
   EVICTION_CYCLE: 'eviction-cycle',
   EVICTION_DEL: 'eviction-del',
+  EVICTION_LAZYFREE: 'eviction-lazyfree',
   FAST_COMMAND: 'fast-command',
   FORK: 'fork',
-  RDB_UNLINK_TEMP_FILE: 'rdb-unlink-temp-file'
+  RDB_UNLINK_TEMP_FILE: 'rdb-unlink-temp-file',
+  WHILE_BLOCKED_CRON: 'while-blocked-cron'
 } as const;
 
 export type LatencyEvent = typeof LATENCY_EVENTS[keyof typeof LATENCY_EVENTS];

--- a/packages/client/lib/commands/LATENCY_HISTORY.ts
+++ b/packages/client/lib/commands/LATENCY_HISTORY.ts
@@ -3,6 +3,7 @@ import { ArrayReply, TuplesReply, NumberReply, Command } from '../RESP/types';
 
 export type LatencyEventType = (
   'active-defrag-cycle' |
+  'aof-fstat' |
   'aof-fsync-always' |
   'aof-stat' |
   'aof-rewrite-diff-write' |
@@ -15,9 +16,11 @@ export type LatencyEventType = (
   'expire-cycle' |
   'eviction-cycle' |
   'eviction-del' |
+  'eviction-lazyfree' |
   'fast-command' |
   'fork' |
-  'rdb-unlink-temp-file'
+  'rdb-unlink-temp-file' |
+  'while-blocked-cron'
 );
 
 export default {

--- a/packages/client/types-tests/latency-events.types-test.ts
+++ b/packages/client/types-tests/latency-events.types-test.ts
@@ -1,0 +1,18 @@
+/**
+ * Compile-time regression: the latency event unions must accept every event
+ * the server samples via latencyAddSampleIfNeeded. aof-fstat (aof.c),
+ * while-blocked-cron (server.c) and eviction-lazyfree (evict.c) are real
+ * event names but were rejected by LATENCY HISTORY/GRAPH/RESET argument types.
+ *
+ * Lives outside `lib/` so it is not picked up by the production build /
+ * typedoc. Checked with `npm run test:types -w @redis/client`.
+ */
+import { createClient } from '../index';
+
+export async function latencyCommandsAcceptSampledEvents(client: ReturnType<typeof createClient>): Promise<void> {
+    console.log(
+        await client.latencyHistory('aof-fstat'),
+        await client.latencyGraph('eviction-lazyfree'),
+        await client.latencyReset('while-blocked-cron')
+    );
+}


### PR DESCRIPTION
## Summary
The latency event unions rejected three event names the server actually samples via latencyAddSampleIfNeeded: aof-fstat (aof.c), while-blocked-cron (server.c) and eviction-lazyfree (evict.c). Passing any of them to latencyHistory, latencyGraph or latencyReset was a compile error although LATENCY HISTORY/GRAPH/RESET accept them server-side. Both LatencyEventType and the shared LATENCY_EVENTS constant now include all three.

## Testing
Compile-time regression test calls all three commands with the previously rejected events: it fails on master with TS2345 and passes after widening. Verified against redis source; type tests, build and lint run locally; Docker-backed integration tests run in CI.

## Checklist
- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only widening of command argument unions; no runtime or security behavior change.
> 
> **Overview**
> Widens `LATENCY HISTORY`/`GRAPH`/`RESET` argument types so they accept three event names Redis actually samples: `aof-fstat`, `eviction-lazyfree`, and `while-blocked-cron`.
> 
> Those names were previously a TypeScript error even though the server accepts them. Adds a compile-time type test covering all three commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 965e14a43d0ac97c5d50c11d9aaed20790e5b7a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->