### PR TITLE
fix(bloom): include terminating null chunk in BF.SCANDUMP reply type

### DIFF
--- a/packages/bloom/lib/commands/bloom/SCANDUMP.spec.ts
+++ b/packages/bloom/lib/commands/bloom/SCANDUMP.spec.ts
@@ -20,4 +20,20 @@ describe('BF.SCANDUMP', () => {
     assert.equal(typeof dump.iterator, 'number');
     assert.equal(typeof dump.chunk, 'string');
   }, GLOBAL.SERVERS.OPEN);
+
+  testUtils.testWithClient('client.bf.scanDump iterating to the terminating pair', async client => {
+    await client.bf.reserve('scandump-key', 0.01, 100);
+
+    let iterator = 0;
+    while (true) {
+      const reply = await client.bf.scanDump('scandump-key', iterator);
+      if (reply.iterator === 0) {
+        assert.equal(reply.chunk, null);
+        break;
+      }
+
+      assert.equal(typeof reply.chunk, 'string');
+      iterator = reply.iterator;
+    }
+  }, GLOBAL.SERVERS.OPEN);
 });

--- a/packages/bloom/lib/commands/bloom/SCANDUMP.ts
+++ b/packages/bloom/lib/commands/bloom/SCANDUMP.ts
@@ -1,5 +1,5 @@
 import { CommandParser } from '@redis/client/dist/lib/client/parser';
-import { RedisArgument, TuplesReply, NumberReply, BlobStringReply, UnwrapReply, Command } from '@redis/client/dist/lib/RESP/types';
+import { RedisArgument, TuplesReply, NumberReply, BlobStringReply, NullReply, UnwrapReply, Command } from '@redis/client/dist/lib/RESP/types';
 
 export default {
   parseCommand(parser: CommandParser, key: RedisArgument, iterator: number) {
@@ -7,7 +7,7 @@ export default {
     parser.pushKey(key);
     parser.push(iterator.toString());
   },
-  transformReply(reply: UnwrapReply<TuplesReply<[NumberReply, BlobStringReply]>>) {
+  transformReply(reply: UnwrapReply<TuplesReply<[NumberReply, BlobStringReply | NullReply]>>) {
     return {
       iterator: reply[0],
       chunk: reply[1]


### PR DESCRIPTION
## Summary
BF.SCANDUMP was typed as always returning a data chunk, but the command returns successive (iter, data) pairs until the terminating (0, NULL) sentinel documented at bf.scandump, so the final iteration is unrepresentable without a cast. The cuckoo twin CF.SCANDUMP already models this; chunk is now BlobStringReply | NullReply to match.

## Testing
A compile probe against the transformer assigning chunk to NullReply failed on master with TS2322 and passes after the union. Verified against the bf.scandump docs and CF.SCANDUMP precedent; package type check, build and lint run locally; Docker-backed integration tests run in CI.

## Checklist
- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only fix and test coverage in the bloom package; no runtime behavior change beyond correct typings for consumers.
> 
> **Overview**
> **BF.SCANDUMP** reply typing now allows **`chunk`** to be **`null`** on the final **`(iterator: 0, chunk: null)`** pair, matching Redis and the existing **CF.SCANDUMP** command types instead of always **`BlobStringReply`**.
> 
> An integration test walks the scan until **`iterator === 0`** and asserts **`chunk`** is **`null`**, while non-terminal steps still return string chunks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b9a06cda25abd4dd92d48860daae920f0865d99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->