### PR TITLE
fix(client): type COMMAND DOCS set containers as RESP3 sets

### DIFF
--- a/packages/client/lib/commands/COMMAND_DOCS.ts
+++ b/packages/client/lib/commands/COMMAND_DOCS.ts
@@ -1,5 +1,5 @@
 import { CommandParser } from '../client/parser';
-import { ArrayReply, BlobStringReply, Command, MapReply, NumberReply, ReplyUnion, Resp2Reply, TuplesReply, TypeMapping, UnwrapReply } from '../RESP/types';
+import { ArrayReply, BlobStringReply, Command, MapReply, NumberReply, ReplyUnion, Resp2Reply, SetReply, TuplesReply, TypeMapping, UnwrapReply } from '../RESP/types';
 import { RESP_TYPES } from '../RESP/decoder';
 import { RedisVariadicArgument } from './generic-transformers';
 
@@ -12,7 +12,7 @@ export interface CommandDocsArgument {
   summary?: BlobStringReply;
   since?: BlobStringReply;
   deprecated_since?: BlobStringReply;
-  flags?: ArrayReply<BlobStringReply>;
+  flags?: SetReply<BlobStringReply>;
   arguments?: ArrayReply<CommandDocsArgument>;
 }
 
@@ -22,10 +22,10 @@ export interface CommandDoc {
   group?: BlobStringReply;
   complexity?: BlobStringReply;
   module?: BlobStringReply;
-  doc_flags?: ArrayReply<BlobStringReply>;
+  doc_flags?: SetReply<BlobStringReply>;
   deprecated_since?: BlobStringReply;
   replaced_by?: BlobStringReply;
-  history?: ArrayReply<TuplesReply<[BlobStringReply, BlobStringReply]>>;
+  history?: SetReply<TuplesReply<[BlobStringReply, BlobStringReply]>>;
   arguments?: ArrayReply<CommandDocsArgument>;
   subcommands?: CommandDocsReply;
   reply_schema?: ReplyUnion;

--- a/packages/client/types-tests/command-docs.types-test.ts
+++ b/packages/client/types-tests/command-docs.types-test.ts
@@ -1,0 +1,23 @@
+/**
+ * Compile-time regression: COMMAND DOCS containers that the server encodes as
+ * RESP3 sets must be declared as SetReply. addReplyCommandFlags and
+ * addReplyCommandHistory use addReplySetLen for doc_flags, argument flags and
+ * history, so ArrayReply misdescribed the wire type (RESP2 replies stay
+ * arrays either way).
+ *
+ * Lives outside `lib/` so it is not picked up by the production build /
+ * typedoc. Checked with `npm run test:types -w @redis/client`.
+ */
+import { CommandDoc, CommandDocsArgument } from '../lib/commands/COMMAND_DOCS';
+import { BlobStringReply, SetReply, TuplesReply } from '../lib/RESP/types';
+
+export function commandDocSetsAreSets(doc: CommandDoc): void {
+    const docFlags: SetReply<BlobStringReply> | undefined = doc.doc_flags;
+    const history: SetReply<TuplesReply<[BlobStringReply, BlobStringReply]>> | undefined = doc.history;
+    console.log(docFlags, history);
+}
+
+export function commandDocsArgumentFlagsAreSets(arg: CommandDocsArgument): void {
+    const flags: SetReply<BlobStringReply> | undefined = arg.flags;
+    console.log(flags);
+}


### PR DESCRIPTION
## Summary
COMMAND DOCS declared doc_flags, per-argument flags and history as arrays, but the server encodes all three as RESP3 sets: addReplyCommandFlags and addReplyCommandHistory emit addReplySetLen in server.c. The declarations now use SetReply so RESP3 wire types match; RESP2 replies remain arrays either way.

## Testing
Compile-time regression test assigns doc_flags, history and argument flags to their SetReply types: it fails on master with TS2322 and passes after the change. Verified against server.c source; type tests, build and lint run locally; Docker-backed integration tests run in CI.

## Checklist
- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only client reply annotations plus a compile-time test; no runtime or protocol behavior change.
> 
> **Overview**
> Corrects `COMMAND DOCS` TypeScript reply types so `doc_flags`, argument `flags`, and `history` are `SetReply` instead of `ArrayReply`, matching the RESP3 set encoding from the server. RESP2 replies remain arrays.
> 
> Adds a compile-time types test that assigns those fields to `SetReply` so a regression fails with TS2322.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02841d2835dc71552aeafb0dc79b1d55c269d35d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->