### PR TITLE
fix(client): require approximate modifier for XTRIM LIMIT

### DIFF
--- a/packages/client/lib/commands/XTRIM.spec.ts
+++ b/packages/client/lib/commands/XTRIM.spec.ts
@@ -34,12 +34,12 @@ describe('XTRIM', () => {
       );
     });
 
-    it('with LIMIT', () => {
+    it('with LIMIT without strategyModifier ~', () => {
       assert.deepEqual(
         parseArgs(XTRIM, 'key', 'MAXLEN', 1, {
           LIMIT: 1
         }),
-        ['XTRIM', 'key', 'MAXLEN', '1', 'LIMIT', '1']
+        ['XTRIM', 'key', 'MAXLEN', '1']
       );
     });
 

--- a/packages/client/lib/commands/XTRIM.spec.ts
+++ b/packages/client/lib/commands/XTRIM.spec.ts
@@ -53,13 +53,13 @@ describe('XTRIM', () => {
       );
     });
 
-    it('with strategyModifier, LIMIT', () => {
+    it('with strategyModifier ~, LIMIT', () => {
       assert.deepEqual(
-        parseArgs(XTRIM, 'key', 'MAXLEN', 1, {
-          strategyModifier: '=',
-          LIMIT: 1
+        parseArgs(XTRIM, 'key', 'MINID', 5, {
+          strategyModifier: '~',
+          LIMIT: 2
         }),
-        ['XTRIM', 'key', 'MAXLEN', '=', '1', 'LIMIT', '1']
+        ['XTRIM', 'key', 'MINID', '~', '5', 'LIMIT', '2']
       );
     });
 

--- a/packages/client/lib/commands/XTRIM.ts
+++ b/packages/client/lib/commands/XTRIM.ts
@@ -3,19 +3,33 @@ import { NumberReply, Command, RedisArgument } from '../RESP/types';
 import { StreamDeletionPolicy } from './common-stream.types';
 
 /**
- * Options for the XTRIM command
- * 
- * @property strategyModifier - Exact ('=') or approximate ('~') trimming
+ * Options for exact XTRIM trimming
+ *
+ * @property strategyModifier - Exact ('=') trimming
+ * @property policy - Policy to apply when deleting entries (optional, defaults to KEEPREF)
+ */
+export interface XTrimExactOptions {
+  strategyModifier?: '=';
+  /** added in 8.2 */
+  policy?: StreamDeletionPolicy;
+}
+
+/**
+ * Options for approximate XTRIM trimming
+ *
+ * @property strategyModifier - Approximate ('~') trimming, required for LIMIT
  * @property LIMIT - Maximum number of entries to trim in one call (Redis 6.2+)
  * @property policy - Policy to apply when deleting entries (optional, defaults to KEEPREF)
  */
-export interface XTrimOptions {
-  strategyModifier?: '=' | '~';
+export interface XTrimApproximateOptions {
+  strategyModifier: '~';
   /** added in 6.2 */
   LIMIT?: number;
   /** added in 8.2 */
   policy?: StreamDeletionPolicy;
 }
+
+export type XTrimOptions = XTrimExactOptions | XTrimApproximateOptions;
 
 /**
  * Command for trimming a stream to a specified length or minimum ID
@@ -32,13 +46,13 @@ export default {
     parser.pushKey(key);
     parser.push(strategy);
 
-    if (options?.strategyModifier) {
+    if (options?.strategyModifier !== undefined) {
       parser.push(options.strategyModifier);
     }
 
     parser.push(threshold.toString());
 
-    if (options?.LIMIT !== undefined) {
+    if (options?.strategyModifier === '~' && options.LIMIT !== undefined) {
       parser.push('LIMIT', options.LIMIT.toString());
     }
 

--- a/packages/client/types-tests/xtrim-limit.types-test.ts
+++ b/packages/client/types-tests/xtrim-limit.types-test.ts
@@ -1,0 +1,20 @@
+/**
+ * Compile-time regression: XTRIM's LIMIT is only accepted by the server
+ * together with the approximate modifier ("syntax error, LIMIT cannot be used
+ * without the special ~ option", t_stream.c), so the options type must not
+ * allow LIMIT without strategyModifier '~'.
+ *
+ * Lives outside `lib/` so it is not picked up by the production build /
+ * typedoc. Checked with `npm run test:types -w @redis/client`.
+ */
+import { XTrimOptions } from '../lib/commands/XTRIM';
+
+export function xtrimLimitRequiresApproximateModifier(): void {
+    // LIMIT without '~' is rejected by the server.
+    // @ts-expect-error LIMIT requires strategyModifier '~'
+    const invalid: XTrimOptions = { LIMIT: 10 };
+
+    const valid: XTrimOptions = { strategyModifier: '~', LIMIT: 10 };
+
+    console.log(invalid, valid);
+}


### PR DESCRIPTION
## Summary
XTRIM accepted LIMIT without strategyModifier, but the server hard-rejects that combination ("syntax error, LIMIT cannot be used without the special ~ option", t_stream.c), so such calls always failed at runtime. The options are now a discriminated union: LIMIT lives on the approximate branch which requires strategyModifier ~, while exact trimming stays modifier-less or =. Runtime emission for valid inputs is unchanged; one spec case asserted an invalid = + LIMIT command and was corrected.

## Testing
Compile-time regression test rejects {LIMIT} without a modifier (compiled on master, TS2578) and accepts it with ~. Parser assertions, type tests, build and lint run locally; Docker-backed integration tests run in CI.

## Checklist
- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only fix for invalid XTRIM argument combinations; callers who relied on LIMIT without `~` already failed at the server and will now fail at compile time instead.
> 
> **Overview**
> **XTRIM** options are now a discriminated union: exact trimming (`XTrimExactOptions`) allows optional `=` and policy, while approximate trimming (`XTrimApproximateOptions`) requires `strategyModifier: '~'` and is the only branch where **`LIMIT`** is typed.
> 
> The command parser no longer emits **`LIMIT`** unless the approximate modifier is present, matching Redis’s rule that LIMIT without `~` is a syntax error. Spec expectations were updated accordingly (e.g. LIMIT alone no longer appears on the wire), and a compile-time types test asserts that `{ LIMIT: 10 }` without `~` is rejected by TypeScript.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f41a4d83bbd7c473acbb3217e571851b3da8e393. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->