### PR TITLE
fix(client): accept both string types for verbatim-emitted replies

### DIFF
--- a/packages/client/lib/commands/CLUSTER_INFO.ts
+++ b/packages/client/lib/commands/CLUSTER_INFO.ts
@@ -1,10 +1,10 @@
 import { CommandParser } from '../client/parser';
-import { VerbatimStringReply, Command } from '../RESP/types';
+import { BlobStringReply, VerbatimStringReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
   parseCommand(parser: CommandParser) {
     parser.push('CLUSTER', 'INFO');
   },
-  transformReply: undefined as unknown as () => VerbatimStringReply
+  transformReply: undefined as unknown as () => BlobStringReply | VerbatimStringReply
 } as const satisfies Command;

--- a/packages/client/lib/commands/CLUSTER_NODES.ts
+++ b/packages/client/lib/commands/CLUSTER_NODES.ts
@@ -1,10 +1,10 @@
 import { CommandParser } from '../client/parser';
-import { VerbatimStringReply, Command } from '../RESP/types';
+import { BlobStringReply, VerbatimStringReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
   parseCommand(parser: CommandParser) {
     parser.push('CLUSTER', 'NODES');
   },
-  transformReply: undefined as unknown as () => VerbatimStringReply
+  transformReply: undefined as unknown as () => BlobStringReply | VerbatimStringReply
 } as const satisfies Command;

--- a/packages/client/lib/commands/INFO.ts
+++ b/packages/client/lib/commands/INFO.ts
@@ -1,5 +1,5 @@
 import { CommandParser } from '../client/parser';
-import { RedisArgument, VerbatimStringReply, Command } from '../RESP/types';
+import { RedisArgument, BlobStringReply, VerbatimStringReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
@@ -10,5 +10,5 @@ export default {
       parser.push(section);
     }
   },
-  transformReply: undefined as unknown as () => VerbatimStringReply
+  transformReply: undefined as unknown as () => BlobStringReply | VerbatimStringReply
 } as const satisfies Command;

--- a/packages/client/lib/commands/LATENCY_DOCTOR.ts
+++ b/packages/client/lib/commands/LATENCY_DOCTOR.ts
@@ -1,10 +1,10 @@
 import { CommandParser } from '../client/parser';
-import { BlobStringReply, Command } from '../RESP/types';
+import { BlobStringReply, VerbatimStringReply, Command } from '../RESP/types';
 
 export default {
   IS_READ_ONLY: true,
   parseCommand(parser: CommandParser) {
     parser.push('LATENCY', 'DOCTOR');
   },
-  transformReply: undefined as unknown as () => BlobStringReply
+  transformReply: undefined as unknown as () => BlobStringReply | VerbatimStringReply
 } as const satisfies Command;

--- a/packages/client/lib/commands/LATENCY_GRAPH.ts
+++ b/packages/client/lib/commands/LATENCY_GRAPH.ts
@@ -1,5 +1,5 @@
 import { CommandParser } from '../client/parser';
-import { BlobStringReply, Command } from '../RESP/types';
+import { BlobStringReply, VerbatimStringReply, Command } from '../RESP/types';
 
 export const LATENCY_EVENTS = {
   ACTIVE_DEFRAG_CYCLE: 'active-defrag-cycle',
@@ -27,5 +27,5 @@ export default {
   parseCommand(parser: CommandParser, event: LatencyEvent) {
     parser.push('LATENCY', 'GRAPH', event);
   },
-  transformReply: undefined as unknown as () => BlobStringReply
+  transformReply: undefined as unknown as () => BlobStringReply | VerbatimStringReply
 } as const satisfies Command;

--- a/packages/client/types-tests/verbatim-reply-unions.types-test.ts
+++ b/packages/client/types-tests/verbatim-reply-unions.types-test.ts
@@ -1,0 +1,50 @@
+/**
+ * Compile-time regression: INFO, CLUSTER INFO, CLUSTER NODES, LATENCY DOCTOR
+ * and LATENCY GRAPH are emitted through addReplyVerbatim (networking.c), which
+ * sends a bulk string on RESP2 and a verbatim string on RESP3. Declaring only
+ * one of the two primitives misdescribed the reply on the other protocol.
+ *
+ * Lives outside `lib/` so it is not picked up by the production build /
+ * typedoc. Checked with `npm run test:types -w @redis/client`.
+ */
+import INFO from '../lib/commands/INFO';
+import CLUSTER_INFO from '../lib/commands/CLUSTER_INFO';
+import CLUSTER_NODES from '../lib/commands/CLUSTER_NODES';
+import LATENCY_DOCTOR from '../lib/commands/LATENCY_DOCTOR';
+import LATENCY_GRAPH from '../lib/commands/LATENCY_GRAPH';
+import { BlobStringReply, CommandReply, VerbatimStringReply } from '../lib/RESP/types';
+
+export function infoReplyAcceptsBulkString(blob: BlobStringReply): void {
+    const reply: CommandReply<typeof INFO, 3> = blob;
+    console.log(reply);
+}
+
+export function clusterInfoReplyAcceptsBulkString(blob: BlobStringReply): void {
+    const reply: CommandReply<typeof CLUSTER_INFO, 3> = blob;
+    console.log(reply);
+}
+
+export function clusterNodesReplyAcceptsBulkString(blob: BlobStringReply): void {
+    const reply: CommandReply<typeof CLUSTER_NODES, 3> = blob;
+    console.log(reply);
+}
+
+export function latencyDoctorReplyAcceptsBulkString(blob: BlobStringReply): void {
+    const reply: CommandReply<typeof LATENCY_DOCTOR, 3> = blob;
+    console.log(reply);
+}
+
+export function latencyGraphReplyAcceptsBulkString(blob: BlobStringReply): void {
+    const reply: CommandReply<typeof LATENCY_GRAPH, 3> = blob;
+    console.log(reply);
+}
+
+export function latencyDoctorReplyAcceptsVerbatim(verbatim: VerbatimStringReply): void {
+    const reply: CommandReply<typeof LATENCY_DOCTOR, 3> = verbatim;
+    console.log(reply);
+}
+
+export function latencyGraphReplyAcceptsVerbatim(verbatim: VerbatimStringReply): void {
+    const reply: CommandReply<typeof LATENCY_GRAPH, 3> = verbatim;
+    console.log(reply);
+}


### PR DESCRIPTION
## Summary
INFO, CLUSTER INFO, CLUSTER NODES, LATENCY DOCTOR and LATENCY GRAPH are emitted through addReplyVerbatim (networking.c), which sends a bulk string on RESP2 and a verbatim string on RESP3. Each command declared exactly one of the two primitives, so its type was wrong on the other protocol and rejected valid values under string type mappings. All five now declare BlobStringReply | VerbatimStringReply.

## Testing
Compile-time regression test assigns a bulk-string value into each declared reply (and a verbatim value into the two latency replies): all five assignments fail on master with TS2322 and pass after the union. Verified against networking.c and its callers; type tests, build and lint run locally; Docker-backed integration tests run in CI.

## Checklist
- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only command reply unions plus a compile-time regression test; no runtime or protocol behavior changes.
> 
> **Overview**
> Fixes reply typing for commands Redis emits via `addReplyVerbatim` (bulk string on RESP2, verbatim string on RESP3). `INFO`, `CLUSTER INFO`, `CLUSTER NODES`, `LATENCY DOCTOR`, and `LATENCY GRAPH` now declare `BlobStringReply | VerbatimStringReply` instead of a single primitive, so valid replies are no longer rejected under string type mappings.
> 
> Adds a compile-time types test that assigns both reply kinds into `CommandReply` for those commands.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7c28014a79cff7268c43164ec723bb96b9e9ab2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->