### PR TITLE
fix(search): expose dialect_stats and Index Errors in FT.INFO reply

### DIFF
--- a/packages/search/lib/commands/INFO.spec.ts
+++ b/packages/search/lib/commands/INFO.spec.ts
@@ -12,6 +12,34 @@ describe('INFO', () => {
     );
   });
 
+  it('transformReply parses dialect_stats and Index Errors', () => {
+    const ret = INFO.transformReply[2]([
+      'index_name', 'index',
+      'num_docs', 0,
+      'dialect_stats', [
+        'dialect_1', 4,
+        'dialect_2', 1
+      ],
+      'Index Errors', [
+        'indexing failures', 0,
+        'last indexing error', '',
+        'last indexing error key', '',
+        'background indexing status', 'ok'
+      ]
+    ] as unknown as Parameters<typeof INFO.transformReply[2]>[0]);
+
+    assert.deepStrictEqual(ret.dialect_stats, {
+      dialect_1: 4,
+      dialect_2: 1
+    });
+    assert.deepStrictEqual(ret['Index Errors'], {
+      'indexing failures': 0,
+      'last indexing error': '',
+      'last indexing error key': '',
+      'background indexing status': 'ok'
+    });
+  });
+
   testUtils.testWithClientIfVersionWithinRange([[8], 'LATEST'], 'client.ft.info', async client => {
     await client.ft.create('index', {
       field: SCHEMA_FIELD_TYPE.TEXT

--- a/packages/search/lib/commands/INFO.ts
+++ b/packages/search/lib/commands/INFO.ts
@@ -63,6 +63,21 @@ export interface InfoReply {
     index_capacity: NumberReply;
     index_total: NumberReply;
   };
+  /**
+   * Number of queries executed per dialect version, keyed by `dialect_N`
+   */
+  dialect_stats?: {
+    [dialect: string]: NumberReply;
+  };
+  /**
+   * Global index error statistics
+   */
+  'Index Errors'?: {
+    'indexing failures': NumberReply;
+    'last indexing error': BlobStringReply;
+    'last indexing error key': BlobStringReply;
+    'background indexing status': BlobStringReply;
+  };
   stopwords_list?: ArrayReply<BlobStringReply> | TuplesReply<[NullReply]>;
 }
 
@@ -112,6 +127,12 @@ function transformV2Reply(reply: Array<unknown>, preserve?: unknown, typeMapping
         break;
       case 'attributes':
         ret[key] = (reply[i+1] as Array<ArrayReply<SimpleStringReply>>).map(attribute => myTransformFunc(attribute));
+        break;
+      case 'dialect_stats':
+        ret[key] = myTransformFunc(reply[i+1] as ArrayReply<SimpleStringReply>) as never;
+        break;
+      case 'Index Errors':
+        ret[key] = myTransformFunc(reply[i+1] as ArrayReply<SimpleStringReply>) as never;
         break;
       case 'gc_stats': {
         const innerRet = {} as unknown as InfoReply['gc_stats'];


### PR DESCRIPTION
## Summary
FT.INFO silently dropped two top-level reply sections that RediSearch emits (verified in info_command.c across v8.0.0 through master): dialect_stats, a map of per-dialect query counters, and Index Errors, the global index error statistics map from IndexError_Reply. The RESP2 transformer switch had no case for them and InfoReply did not declare them, so the data was unreachable. Both are now typed and parsed like the existing gc_stats section.

## Testing
A captured-reply transform test feeds both sections and asserts their parsed objects; it fails on master (keys dropped) and passes after the change. Verified against RediSearch source; package build and lint run locally, Docker-backed integration tests run in CI.

## Checklist
- bug reproduced before fix
- root cause identified
- bug fixed
- tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side reply typing and RESP2 transform only; no auth, command protocol, or write-path changes.
> 
> **Overview**
> `FT.INFO` RESP2 parsing no longer drops RediSearch’s `dialect_stats` and `Index Errors` sections.
> 
> `InfoReply` now types both maps, and `transformV2Reply` converts the tuple arrays into objects (same pattern as other nested maps). A unit test asserts the parsed shapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7852512ba0bb0d4a22bb5c9a1f103c615463caa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->