### PR TITLE
fix(client): compare scan cursors by string value so iterators terminate under Buffer type mapping

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -1051,6 +1051,41 @@ describe('Client', () => {
     assert.deepEqual(map, results);
   }, GLOBAL.SERVERS.OPEN);
 
+  testUtils.testWithClient('scan iterators terminate under a Blob String type mapping', async client => {
+    // Regression: the iterators compared the reply cursor against the string
+    // '0', which a Buffer cursor never equals, so they scanned the keyspace
+    // forever. The Sentinel scanIterator already guarded against this.
+    const fields: Record<string, string> = {};
+    for (let i = 0; i < 100; i++) {
+      fields[i.toString()] = i.toString();
+    }
+
+    await client.mSet(Object.entries(fields).flat());
+    await client.hSet('hash', fields);
+    await client.sAdd('set', Object.keys(fields));
+    await client.zAdd('zset', Object.keys(fields).map(value => ({ value, score: 1 })));
+
+    const buffers = client.withTypeMapping({
+      [RESP_TYPES.BLOB_STRING]: Buffer
+    });
+
+    // Bound the page count so an unterminated iterator fails the test instead
+    // of hanging it.
+    const MAX_PAGES = 200;
+    async function drain(name: string, iterator: AsyncIterable<unknown>) {
+      let pages = 0;
+      for await (const _page of iterator) {
+        assert.ok(++pages <= MAX_PAGES, `${name} did not terminate within ${MAX_PAGES} pages`);
+      }
+    }
+
+    await drain('scanIterator', buffers.scanIterator({ COUNT: 10 }));
+    await drain('hScanIterator', buffers.hScanIterator('hash', { COUNT: 10 }));
+    await drain('hScanValuesIterator', buffers.hScanValuesIterator('hash', { COUNT: 10 }));
+    await drain('sScanIterator', buffers.sScanIterator('set', { COUNT: 10 }));
+    await drain('zScanIterator', buffers.zScanIterator('zset', { COUNT: 10 }));
+  }, GLOBAL.SERVERS.OPEN);
+
   describe('PubSub', () => {
     testUtils.testWithClient('should be able to publish and subscribe to messages', async publisher => {
       function assertStringListener(message: string, channel: string) {

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -2024,7 +2024,9 @@ export default class RedisClient<
       const reply = await this.scan(cursor, options);
       cursor = reply.cursor;
       yield reply.keys;
-    } while (cursor !== '0');
+      // Cursor may be a Buffer when a Blob String type mapping is in use;
+      // compare by string value so iteration actually terminates.
+    } while (cursor.toString() !== '0');
   }
 
   async* hScanIterator(
@@ -2037,7 +2039,7 @@ export default class RedisClient<
       const reply = await this.hScan(key, cursor, options);
       cursor = reply.cursor;
       yield reply.entries;
-    } while (cursor !== '0');
+    } while (cursor.toString() !== '0');
   }
 
   async* hScanValuesIterator(
@@ -2050,7 +2052,7 @@ export default class RedisClient<
       const reply = await this.hScan(key, cursor, options);
       cursor = reply.cursor;
       yield reply.entries.map(entry => entry.value);
-    } while (cursor !== '0');
+    } while (cursor.toString() !== '0');
   }
 
   async* hScanNoValuesIterator(
@@ -2063,7 +2065,7 @@ export default class RedisClient<
       const reply = await this.hScanNoValues(key, cursor, options);
       cursor = reply.cursor;
       yield reply.fields;
-    } while (cursor !== '0');
+    } while (cursor.toString() !== '0');
   }
 
   async* sScanIterator(
@@ -2076,7 +2078,7 @@ export default class RedisClient<
       const reply = await this.sScan(key, cursor, options);
       cursor = reply.cursor;
       yield reply.members;
-    } while (cursor !== '0');
+    } while (cursor.toString() !== '0');
   }
 
   async* zScanIterator(
@@ -2089,7 +2091,7 @@ export default class RedisClient<
       const reply = await this.zScan(key, cursor, options);
       cursor = reply.cursor;
       yield reply.members;
-    } while (cursor !== '0');
+    } while (cursor.toString() !== '0');
   }
 
   async MONITOR(callback: MonitorCallback<TYPE_MAPPING>) {


### PR DESCRIPTION
## Description

All six scan iterators on `RedisClient` — `scanIterator`, `hScanIterator`,
`hScanValuesIterator`, `hScanNoValuesIterator`, `sScanIterator`, `zScanIterator` —
end their loop with:

```ts
} while (cursor !== '0');
```

`cursor` is the `BlobStringReply` from the reply. Under a Blob String type mapping
(`client.withTypeMapping({ [RESP_TYPES.BLOB_STRING]: Buffer })`, or the equivalent
`withCommandOptions`) it is a `Buffer`, and `Buffer.from('0') !== '0'` is always
true. The loop therefore never exits.

It cannot recover, either: the next call re-issues `SCAN` with a `Buffer('0')`
cursor, which the server reads as a fresh start, so the iteration restarts from
the beginning of the keyspace and spins indefinitely — an unbounded stream of
`SCAN` commands, not just a missing break.

The Sentinel `scanIterator` already guards against exactly this
(`packages/client/lib/sentinel/index.ts:757`):

```ts
// Cursor may be a Buffer when a Blob String type mapping is in use;
// compare by string value so iteration actually terminates.
} while (cursor.toString() !== '0');
```

That guard was simply never applied to the six client iterators. This PR applies
it, keeping the comment wording consistent with the Sentinel one.

## Reproduction

Against `redis@6.2.1` (current release) and a local Redis, with 100 keys and
`COUNT: 10`:

```js
import { createClient, RESP_TYPES } from 'redis';

const base = await createClient().connect();
const client = base.withTypeMapping({ [RESP_TYPES.BLOB_STRING]: Buffer });

let pages = 0;
for await (const keys of client.scanIterator({ COUNT: 10 })) {
  if (++pages > 200) throw new Error('never terminates');
}
```

Before the fix, every one of the six iterators blows past 200 pages over a
100-key keyspace:

```
scanIterator:           INFINITE LOOP (did not terminate within 200 pages)
hScanIterator:          INFINITE LOOP (did not terminate within 200 pages)
hScanValuesIterator:    INFINITE LOOP (did not terminate within 200 pages)
sScanIterator:          INFINITE LOOP (did not terminate within 200 pages)
zScanIterator:          INFINITE LOOP (did not terminate within 200 pages)
hScanNoValuesIterator:  INFINITE LOOP (did not terminate within 200 pages)
```

After:

```
scanIterator:           terminated after 10 pages
hScanIterator:          terminated after 1 pages
hScanValuesIterator:    terminated after 1 pages
sScanIterator:          terminated after 1 pages
zScanIterator:          terminated after 1 pages
hScanNoValuesIterator:  terminated after 1 pages
```

(The hash/set/zset cases finish in one page because those keys are listpack-encoded,
so the very first reply carries cursor `0` — the pre-fix code loops forever *even
when the server says it is done on the first call*.)

The default (string cursor) path is unchanged: `scanIterator` still yields all
103 keys, and `hScan`/`sScan`/`zScan` iterators still yield all 100 elements each.

## Relationship to #2879

Worth being precise, because the mechanism is not the one in the original report.

The issue as filed is against **node-redis 4.7.0**, where `SCAN`'s
`transformReply` coerced the cursor with `Number(cursor)`. On ElastiCache the
reporter received a 64-bit cursor above `Number.MAX_SAFE_INTEGER`, so the coercion
rounded it (the logged `9283678325492940000`, with its tell-tale trailing zeros,
is a float64-rounded value) and the rounded cursor could never reach `0`. **That
specific bug is already fixed on `master`**: the cursor is now a `BlobStringReply`
and is threaded back to the server as an opaque string, so no precision is lost.
This matches the "upgrade to v5" comment on the thread.

While verifying that, the loop above turned up as a *live* infinite-loop in the
same feature on `master`, reachable from a supported public API. It is filed here
as `Related to` rather than `Fixes` #2879 — maintainers may want to close #2879
separately as fixed-in-v5.

## Tests

Adds `scan iterators terminate under a Blob String type mapping` to
`packages/client/lib/client/index.spec.ts`, next to the existing per-iterator
tests. It drives all iterators (except the 7.4-gated `hScanNoValuesIterator`)
through a Buffer type mapping and caps the page count, so a regression fails the
test instead of hanging the suite.

**Verification performed**

- Fail-before / pass-after, both captured against the built `@redis/client` from
  this worktree and a real `redis-server` — the output quoted above.
- `npm run build` (`tsc --build`) — clean.
- `npm run test:types` in `packages/client` — clean.
- `eslint` on both changed files with `--max-warnings=0` — clean.

**Not run locally:** the new mocha test itself. `packages/test-utils` spawns its
Redis container with `--network host`, which Docker Desktop on macOS does not
support (the container starts and reports ready, but publishes no ports, so
`testWithClient`'s before-all hook times out). The test is written to the existing
`testUtils.testWithClient` / `GLOBAL.SERVERS.OPEN` pattern and should run on CI
Linux; the behavior it asserts is the behavior verified directly above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core scan iteration loops used widely, but the change is a narrow termination fix with a regression test; risk is mainly unmapped edge cases in cursor stringification, not auth or data corruption.
> 
> **Overview**
> Fixes an **infinite loop** when using `withTypeMapping({ [RESP_TYPES.BLOB_STRING]: Buffer })` with any of the six `RedisClient` scan iterators (`scanIterator`, `hScanIterator`, `hScanValuesIterator`, `hScanNoValuesIterator`, `sScanIterator`, `zScanIterator`).
> 
> Termination used `cursor !== '0'`, but mapped cursors are `Buffer` instances, so the condition never became false and iteration could spin forever (re-issuing `SCAN` from the start). The loop now uses **`cursor.toString() !== '0'`**, matching the existing Sentinel `scanIterator` behavior. String-cursor usage is unchanged.
> 
> Adds a regression test that drains those iterators through a Blob String → `Buffer` mapping with a **200-page cap** so a hang fails fast instead of blocking CI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e287479a87b5fae5f9bef46e4ce1b3add3b7073e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->