### PR TITLE
fix(client): vendor cluster-key-slot to fix empty hash tag slot bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3851,13 +3851,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/cluster-key-slot": {
-      "version": "1.1.2",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "dev": true,
@@ -9456,7 +9449,7 @@
     },
     "packages/bloom": {
       "name": "@redis/bloom",
-      "version": "6.2.0",
+      "version": "6.2.1",
       "license": "MIT",
       "devDependencies": {
         "@redis/test-utils": "*"
@@ -9465,16 +9458,13 @@
         "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "@redis/client": "^6.2.0"
+        "@redis/client": "^6.2.1"
       }
     },
     "packages/client": {
       "name": "@redis/client",
-      "version": "6.2.0",
+      "version": "6.2.1",
       "license": "MIT",
-      "dependencies": {
-        "cluster-key-slot": "1.1.2"
-      },
       "devDependencies": {
         "@node-rs/xxhash": "1.7.6",
         "@opentelemetry/api": "^1.9.0",
@@ -9501,7 +9491,7 @@
     },
     "packages/entraid": {
       "name": "@redis/entraid",
-      "version": "6.2.0",
+      "version": "6.2.1",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.1",
@@ -9521,7 +9511,7 @@
         "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "@redis/client": "^6.2.0"
+        "@redis/client": "^6.2.1"
       }
     },
     "packages/entraid/node_modules/@types/node": {
@@ -9543,7 +9533,7 @@
     },
     "packages/json": {
       "name": "@redis/json",
-      "version": "6.2.0",
+      "version": "6.2.1",
       "license": "MIT",
       "devDependencies": {
         "@redis/test-utils": "*"
@@ -9552,18 +9542,18 @@
         "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "@redis/client": "^6.2.0"
+        "@redis/client": "^6.2.1"
       }
     },
     "packages/redis": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "license": "MIT",
       "dependencies": {
-        "@redis/bloom": "6.2.0",
-        "@redis/client": "6.2.0",
-        "@redis/json": "6.2.0",
-        "@redis/search": "6.2.0",
-        "@redis/time-series": "6.2.0"
+        "@redis/bloom": "6.2.1",
+        "@redis/client": "6.2.1",
+        "@redis/json": "6.2.1",
+        "@redis/search": "6.2.1",
+        "@redis/time-series": "6.2.1"
       },
       "engines": {
         "node": ">= 20.0.0"
@@ -9571,7 +9561,7 @@
     },
     "packages/search": {
       "name": "@redis/search",
-      "version": "6.2.0",
+      "version": "6.2.1",
       "license": "MIT",
       "devDependencies": {
         "@redis/test-utils": "*"
@@ -9580,7 +9570,7 @@
         "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "@redis/client": "^6.2.0"
+        "@redis/client": "^6.2.1"
       }
     },
     "packages/test-utils": {
@@ -9649,7 +9639,7 @@
     },
     "packages/time-series": {
       "name": "@redis/time-series",
-      "version": "6.2.0",
+      "version": "6.2.1",
       "license": "MIT",
       "devDependencies": {
         "@redis/test-utils": "*"
@@ -9658,7 +9648,7 @@
         "node": ">= 20.0.0"
       },
       "peerDependencies": {
-        "@redis/client": "^6.2.0"
+        "@redis/client": "^6.2.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -43,5 +43,8 @@
     "typedoc": "^0.25.7",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.59.0"
+  },
+  "allowScripts": {
+    "esbuild@0.28.1": true
   }
 }

--- a/packages/client/lib/client/pub-sub.ts
+++ b/packages/client/lib/client/pub-sub.ts
@@ -1,6 +1,6 @@
 import { RedisArgument } from '../RESP/types';
 import { CommandToWrite } from './commands-queue';
-import calculateSlot from 'cluster-key-slot';
+import calculateSlot from '../utils/calculate-slot';
 import { publish, CHANNELS } from './tracing';
 
 export const PUBSUB_TYPE = {

--- a/packages/client/lib/cluster/batch-routing.spec.ts
+++ b/packages/client/lib/cluster/batch-routing.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert';
-import calculateSlot from 'cluster-key-slot';
+import calculateSlot from '../utils/calculate-slot';
 import RedisCluster from '.';
 import { ErrorReply } from '../errors';
 

--- a/packages/client/lib/cluster/cluster-slots.ts
+++ b/packages/client/lib/cluster/cluster-slots.ts
@@ -5,7 +5,7 @@ import type { CommandToWrite } from '../client/commands-queue';
 import { EventEmitter } from 'node:stream';
 import { ChannelListeners, PUBSUB_TYPE, PubSubListeners, PubSubTypeListeners } from '../client/pub-sub';
 import { RedisArgument, RedisFunctions, RedisModules, RedisScripts, RespVersions, TypeMapping, DEFAULT_RESP } from '../RESP/types';
-import calculateSlot from 'cluster-key-slot';
+import calculateSlot from '../utils/calculate-slot';
 import { RedisSocketOptions } from '../client/socket';
 import { BasicPooledClientSideCache, PooledClientSideCacheProvider } from '../client/cache';
 import { SMIGRATED_EVENT, SMigratedEvent, dbgMaintenance } from '../client/enterprise-maintenance-manager';

--- a/packages/client/lib/cluster/index.spec.ts
+++ b/packages/client/lib/cluster/index.spec.ts
@@ -7,7 +7,7 @@ import { ClientClosedError, ClientOfflineError, RootNodesUnavailableError, MaxCo
 import { spy } from 'sinon';
 import RedisClient from '../client';
 import { RESP_TYPES } from '../RESP/decoder';
-import calculateSlot from 'cluster-key-slot';
+import calculateSlot from '../utils/calculate-slot';
 import { CommandParser } from '../client/parser';
 
 describe('Cluster command lifecycle', () => {

--- a/packages/client/lib/cluster/index.ts
+++ b/packages/client/lib/cluster/index.ts
@@ -19,7 +19,7 @@ import { DEFAULT_COMMAND_TIMEOUT } from '../defaults';
 import { FieldsetRegistry } from '../himport/registry';
 import { defaultCommandMetadata, defaultCommandPolicies, isReplicaSafe, PolicyResolver, REQUEST_POLICIES_WITH_DEFAULTS, RESPONSE_POLICIES_WITH_DEFAULTS, type CommandMetadata } from '../command-metadata';
 import { REQUEST_ROUTERS, RESPONSE_REDUCERS, NUMERIC_AGG_POLICIES, remapAggregateReply } from './request-response-policies/dispatch';
-import calculateSlot from 'cluster-key-slot';
+import calculateSlot from '../utils/calculate-slot';
 import { finalizeFtCursor } from './request-response-policies/ft-cursor';
 import { finalizeScanCursor } from './request-response-policies/scan-cursor';
 

--- a/packages/client/lib/cluster/multi-redirect.spec.ts
+++ b/packages/client/lib/cluster/multi-redirect.spec.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert';
 import { setTimeout } from 'node:timers/promises';
-import calculateSlot from 'cluster-key-slot';
+import calculateSlot from '../utils/calculate-slot';
 import testUtils from '../test-utils';
 import { ErrorReply } from '../errors';
 

--- a/packages/client/lib/cluster/request-response-policies/multi-shard-splitter.spec.ts
+++ b/packages/client/lib/cluster/request-response-policies/multi-shard-splitter.spec.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'node:assert';
-import calculateSlot from 'cluster-key-slot';
+import calculateSlot from '../../utils/calculate-slot';
 import type { KeySpec } from '../../commands/generic-transformers';
 import { splitMultiShardCommand } from './multi-shard-splitter';
 

--- a/packages/client/lib/cluster/request-response-policies/multi-shard-splitter.ts
+++ b/packages/client/lib/cluster/request-response-policies/multi-shard-splitter.ts
@@ -1,4 +1,4 @@
-import calculateSlot from 'cluster-key-slot';
+import calculateSlot from '../../utils/calculate-slot';
 import type { RedisArgument } from '../../RESP/types';
 import type { KeySpec } from '../../commands/generic-transformers';
 

--- a/packages/client/lib/utils/calculate-slot.spec.ts
+++ b/packages/client/lib/utils/calculate-slot.spec.ts
@@ -1,0 +1,106 @@
+import { strict as assert } from 'node:assert';
+import calculateSlot from './calculate-slot';
+
+describe('calculateSlot', () => {
+  describe('empty hash tag handling', () => {
+    // Redis treats an empty hash tag ("{}") as no tag at all: it hashes the
+    // whole key and stops searching for a tag. The unpatched upstream
+    // scanner instead falls through on an empty tag without clearing its
+    // "in a tag" state, so it keeps scanning and latches onto the next "}"
+    // in the key, hashing whatever sits between them instead of the whole
+    // key. These values were measured against a live Redis 8.0.6 cluster
+    // with `CLUSTER KEYSLOT` and confirm the vendored fix matches it.
+    it('hashes the whole key when it contains only an empty tag', () => {
+      assert.equal(calculateSlot('a{}b}c'), 2041);
+      assert.equal(calculateSlot('{}a}b'), 5168);
+      assert.equal(calculateSlot('x{}}y'), 2083);
+      assert.equal(calculateSlot('{}{a}'), 13650);
+    });
+
+    it('does not resume tag scanning after an empty tag', () => {
+      // Regression guard: an empty tag with no later '}' was already correct
+      // before the fix, since the scanner falls off the end of the string.
+      assert.equal(calculateSlot('user:{}:1'), 8272);
+    });
+
+    it('behaves the same for Buffer input as for string input', () => {
+      assert.equal(calculateSlot(Buffer.from('a{}b}c')), 2041);
+      assert.equal(calculateSlot(Buffer.from('x{}}y')), 2083);
+    });
+  });
+
+  describe('regression guards for ordinary tags', () => {
+    it('still hashes the contents of a normal, non-empty tag', () => {
+      assert.equal(calculateSlot('a{b}c'), 3300);
+    });
+
+    it("still stops at the first '}' after the first '{'", () => {
+      assert.equal(calculateSlot('a{b{c}d'), 15725);
+    });
+
+    it('still hashes the whole key when there are no braces', () => {
+      assert.equal(calculateSlot('foo'), 12182);
+    });
+  });
+
+  describe('generateMulti()', () => {
+    it('returns the shared slot when all keys hash to the same slot', () => {
+      // "a{}b}c" and "42703" both land on slot 2041 under the corrected
+      // whole-key hashing behaviour.
+      assert.equal(calculateSlot.generateMulti(['a{}b}c', '42703']), 2041);
+    });
+
+    it('returns -1 when keys hash to different slots', () => {
+      assert.equal(calculateSlot.generateMulti(['x{}}y', 'z{}}w']), -1);
+    });
+  });
+
+  describe('parity with upstream cluster-key-slot', () => {
+    // Ported from cluster-key-slot's own test suite (test/hash.spec.js) at
+    // https://github.com/invertase/cluster-key-slot/blob/master/test/hash.spec.js
+    // to guard against regressions in the vendored implementation. None of
+    // these keys trigger the empty-hash-tag bug, so every expected value is
+    // unchanged from upstream.
+    const tests: Array<[string | Buffer, number]> = [
+      ['123465', 1492],
+      ['foobar', 12325],
+      ['abcdefghijklmnopqrstuvwxyz', 9132],
+      ['gsdfhan$%^&*(sdgsdnhshcs', 15532],
+      ['abc{foobar}', 12325],
+      ['{foobar}', 12325],
+      ['h8a9sd{foobar}}{asd}}', 12325],
+      ['{foobar', 16235],
+      ['foobar{}', 4435],
+      ['{{foobar}', 16235],
+      ['éêe', 13690],
+      ['àâa', 3872],
+      ['漢字', 14191],
+      ['汉字', 16196],
+      ['호텔', 4350],
+      ['💀', 9284],
+      ['𐀀', 11620], // surrogate pair
+      ['{}foobar', 14573],
+      [Buffer.from([0x7b, 0x7d, 0x2a, 0x2]), 3932],
+      [Buffer.from([0x7b, 0x2a, 0x7d, 0x2]), 1320],
+      [Buffer.from('汉字'), 16196]
+    ];
+
+    it('generates the same hash as upstream for each key', () => {
+      for (const [key, expectedSlot] of tests) {
+        assert.equal(calculateSlot(key), expectedSlot, String(key));
+      }
+    });
+
+    it('generates the same multi-key hash as upstream', () => {
+      const testsMulti = Array(8).fill('abcdefghijklmnopqrstuvwxyz');
+      assert.equal(calculateSlot.generateMulti(testsMulti), 9132);
+    });
+
+    it("returns -1 for upstream's mixed-slot key set", () => {
+      assert.equal(
+        calculateSlot.generateMulti(tests.map(([key]) => key)),
+        -1
+      );
+    });
+  });
+});

--- a/packages/client/lib/utils/calculate-slot.ts
+++ b/packages/client/lib/utils/calculate-slot.ts
@@ -1,0 +1,193 @@
+import { RedisArgument } from '../RESP/types';
+
+/*
+ * Vendored from `cluster-key-slot@1.1.2`
+ * (https://github.com/invertase/cluster-key-slot), patched to fix a
+ * disagreement with real Redis servers over how an empty hash tag ("{}") is
+ * handled.
+ *
+ * Redis treats an empty hash tag as no tag at all: given `{}` it hashes the
+ * whole key and stops searching (see `keyHashSlot()` in Redis's
+ * `src/cluster.c`). The upstream single-pass scanner instead falls through
+ * and keeps scanning for the next `}`, hashing whatever sits between --
+ * which can silently misroute commands and sharded pub/sub subscriptions to
+ * the wrong node. Vendoring was necessary because the upstream repository
+ * has been archived and is no longer maintained.
+ *
+ * `lib/index.js` in `cluster-key-slot` is byte-identical between 1.1.1 and
+ * 1.1.2 (1.1.2 was a license metadata fix only), so this same fix applies
+ * to the version node-redis previously depended on.
+ *
+ * The fix, marked below, latches the whole-key fallback once the empty-tag
+ * case is seen: one extra boolean, no extra pass, no change to the hot path
+ * for keys without braces.
+ *
+ * Original copyright notices, preserved from upstream:
+ *
+ * Copyright 2001-2010 Georges Menie (www.menie.org)
+ * Copyright 2010 Salvatore Sanfilippo (adapted to Redis coding style)
+ * Copyright 2015 Zihua Li (http://zihua.li) (ported to JavaScript)
+ * Copyright 2016 Mike Diarmid (http://github.com/salakar) (re-write for
+ * performance, ~700% perf inc)
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* CRC16 implementation according to CCITT standards.
+ *
+ * Note by @antirez: this is actually the XMODEM CRC 16 algorithm, using the
+ * following parameters:
+ *
+ * Name                       : "XMODEM", also known as "ZMODEM", "CRC-16/ACORN"
+ * Width                      : 16 bit
+ * Poly                       : 1021 (That is actually x^16 + x^12 + x^5 + 1)
+ * Initialization             : 0000
+ * Reflect Input byte         : False
+ * Reflect Output CRC         : False
+ * Xor constant to output CRC : 0000
+ * Output for "123456789"     : 31C3
+ */
+const lookup = [
+  0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7, 0x8108,
+  0x9129, 0xa14a, 0xb16b, 0xc18c, 0xd1ad, 0xe1ce, 0xf1ef, 0x1231, 0x0210,
+  0x3273, 0x2252, 0x52b5, 0x4294, 0x72f7, 0x62d6, 0x9339, 0x8318, 0xb37b,
+  0xa35a, 0xd3bd, 0xc39c, 0xf3ff, 0xe3de, 0x2462, 0x3443, 0x0420, 0x1401,
+  0x64e6, 0x74c7, 0x44a4, 0x5485, 0xa56a, 0xb54b, 0x8528, 0x9509, 0xe5ee,
+  0xf5cf, 0xc5ac, 0xd58d, 0x3653, 0x2672, 0x1611, 0x0630, 0x76d7, 0x66f6,
+  0x5695, 0x46b4, 0xb75b, 0xa77a, 0x9719, 0x8738, 0xf7df, 0xe7fe, 0xd79d,
+  0xc7bc, 0x48c4, 0x58e5, 0x6886, 0x78a7, 0x0840, 0x1861, 0x2802, 0x3823,
+  0xc9cc, 0xd9ed, 0xe98e, 0xf9af, 0x8948, 0x9969, 0xa90a, 0xb92b, 0x5af5,
+  0x4ad4, 0x7ab7, 0x6a96, 0x1a71, 0x0a50, 0x3a33, 0x2a12, 0xdbfd, 0xcbdc,
+  0xfbbf, 0xeb9e, 0x9b79, 0x8b58, 0xbb3b, 0xab1a, 0x6ca6, 0x7c87, 0x4ce4,
+  0x5cc5, 0x2c22, 0x3c03, 0x0c60, 0x1c41, 0xedae, 0xfd8f, 0xcdec, 0xddcd,
+  0xad2a, 0xbd0b, 0x8d68, 0x9d49, 0x7e97, 0x6eb6, 0x5ed5, 0x4ef4, 0x3e13,
+  0x2e32, 0x1e51, 0x0e70, 0xff9f, 0xefbe, 0xdfdd, 0xcffc, 0xbf1b, 0xaf3a,
+  0x9f59, 0x8f78, 0x9188, 0x81a9, 0xb1ca, 0xa1eb, 0xd10c, 0xc12d, 0xf14e,
+  0xe16f, 0x1080, 0x00a1, 0x30c2, 0x20e3, 0x5004, 0x4025, 0x7046, 0x6067,
+  0x83b9, 0x9398, 0xa3fb, 0xb3da, 0xc33d, 0xd31c, 0xe37f, 0xf35e, 0x02b1,
+  0x1290, 0x22f3, 0x32d2, 0x4235, 0x5214, 0x6277, 0x7256, 0xb5ea, 0xa5cb,
+  0x95a8, 0x8589, 0xf56e, 0xe54f, 0xd52c, 0xc50d, 0x34e2, 0x24c3, 0x14a0,
+  0x0481, 0x7466, 0x6447, 0x5424, 0x4405, 0xa7db, 0xb7fa, 0x8799, 0x97b8,
+  0xe75f, 0xf77e, 0xc71d, 0xd73c, 0x26d3, 0x36f2, 0x0691, 0x16b0, 0x6657,
+  0x7676, 0x4615, 0x5634, 0xd94c, 0xc96d, 0xf90e, 0xe92f, 0x99c8, 0x89e9,
+  0xb98a, 0xa9ab, 0x5844, 0x4865, 0x7806, 0x6827, 0x18c0, 0x08e1, 0x3882,
+  0x28a3, 0xcb7d, 0xdb5c, 0xeb3f, 0xfb1e, 0x8bf9, 0x9bd8, 0xabbb, 0xbb9a,
+  0x4a75, 0x5a54, 0x6a37, 0x7a16, 0x0af1, 0x1ad0, 0x2ab3, 0x3a92, 0xfd2e,
+  0xed0f, 0xdd6c, 0xcd4d, 0xbdaa, 0xad8b, 0x9de8, 0x8dc9, 0x7c26, 0x6c07,
+  0x5c64, 0x4c45, 0x3ca2, 0x2c83, 0x1ce0, 0x0cc1, 0xef1f, 0xff3e, 0xcf5d,
+  0xdf7c, 0xaf9b, 0xbfba, 0x8fd9, 0x9ff8, 0x6e17, 0x7e36, 0x4e55, 0x5e74,
+  0x2e93, 0x3eb2, 0x0ed1, 0x1ef0
+];
+
+/**
+ * Convert a string to a UTF8 array - faster than via buffer
+ */
+function toUTF8Array(str: string): number[] {
+  let char: number;
+  let i = 0;
+  let p = 0;
+  const utf8: number[] = [];
+  const len = str.length;
+
+  for (; i < len; i++) {
+    char = str.charCodeAt(i);
+    if (char < 128) {
+      utf8[p++] = char;
+    } else if (char < 2048) {
+      utf8[p++] = (char >> 6) | 192;
+      utf8[p++] = (char & 63) | 128;
+    } else if (
+      (char & 0xfc00) === 0xd800 &&
+      i + 1 < str.length &&
+      (str.charCodeAt(i + 1) & 0xfc00) === 0xdc00
+    ) {
+      char = 0x10000 + ((char & 0x03ff) << 10) + (str.charCodeAt(++i) & 0x03ff);
+      utf8[p++] = (char >> 18) | 240;
+      utf8[p++] = ((char >> 12) & 63) | 128;
+      utf8[p++] = ((char >> 6) & 63) | 128;
+      utf8[p++] = (char & 63) | 128;
+    } else {
+      utf8[p++] = (char >> 12) | 224;
+      utf8[p++] = ((char >> 6) & 63) | 128;
+      utf8[p++] = (char & 63) | 128;
+    }
+  }
+
+  return utf8;
+}
+
+/**
+ * Convert a string or Buffer into a redis slot hash.
+ */
+function generate(value: RedisArgument): number {
+  let char: number;
+  let i = 0;
+  let start = -1;
+  // Latched once an empty hash tag ("{}") is seen: Redis hashes the whole
+  // key and stops looking for a tag in that case, so once `done` is set we
+  // must stop treating any later "{" as the start of a new tag.
+  let done = false;
+  let result = 0;
+  let resultHash = 0;
+  const utf8: ArrayLike<number> =
+    typeof value === 'string' ? toUTF8Array(value) : value;
+  const len = utf8.length;
+
+  while (i < len) {
+    char = utf8[i++];
+    if (done || start === -1) {
+      if (!done && char === 0x7b) {
+        start = i;
+      }
+    } else if (char !== 0x7d) {
+      resultHash = lookup[(char ^ (resultHash >> 8)) & 0xff] ^ (resultHash << 8);
+    } else if (i - 1 !== start) {
+      return resultHash & 0x3fff;
+    } else {
+      // Empty hash tag ("{}"): Redis falls back to hashing the whole key.
+      done = true;
+    }
+
+    result = lookup[(char ^ (result >> 8)) & 0xff] ^ (result << 8);
+  }
+
+  return result & 0x3fff;
+}
+
+interface CalculateSlot {
+  (value: RedisArgument): number;
+  /**
+   * Convert an array of multiple strings or Buffers into a redis slot hash.
+   * Returns -1 if one of the keys is not for the same slot as the others
+   */
+  generateMulti(values: Array<RedisArgument>): number;
+}
+
+const calculateSlot = generate as CalculateSlot;
+
+calculateSlot.generateMulti = function generateMulti(
+  values: Array<RedisArgument>
+): number {
+  let i = 1;
+  const len = values.length;
+  const base = generate(values[0]);
+
+  while (i < len) {
+    if (generate(values[i++]) !== base) return -1;
+  }
+
+  return base;
+};
+
+export default calculateSlot;

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -14,9 +14,7 @@
     "generate:metadata": "tsx ./scripts/generate-command-metadata-data.ts",
     "release": "release-it"
   },
-  "dependencies": {
-    "cluster-key-slot": "1.1.2"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@node-rs/xxhash": "1.7.6",
     "@opentelemetry/api": "^1.9.0",


### PR DESCRIPTION
Redis treats an empty hash tag ("{}") as no tag at all: it hashes the whole key and stops searching. cluster-key-slot's single-pass scanner instead falls through and keeps scanning for the next "}", hashing whatever sits between - silently misrouting commands and, for sharded pub/sub, resolving a channel to the wrong master so subscribed messages are never delivered. Measured against a live Redis 8.0.6 cluster, this diverges from real slot assignment 460 times across an 8016-key corpus.

Upstream (invertase/cluster-key-slot) was archived in March 2026 and had been unmaintained for years before that, and @redis/client pins the exact version "1.1.2" rather than a range, so no upstream fix would reach users regardless. The function is ~40 lines plus a lookup table with no dependencies, well within vendoring range.

Vendor the implementation into packages/client/lib/utils/calculate-slot.ts with the fix applied: latch the whole-key fallback once an empty tag is seen, so a later "}" elsewhere in the key can no longer be mistaken for a tag close. lib/index.js in cluster-key-slot is byte-identical between 1.1.1 and 1.1.2, so this is the same fix applied to ioredis. Repoint cluster/index.ts, cluster-slots.ts, client/pub-sub.ts, and multi-shard-splitter.ts (plus the specs that computed expected slots) at the vendored module, drop the npm dependency, and add unit tests covering the empty-tag cases plus parity with upstream's own test suite.

A detailed write up of this bug can be found at https://github.com/mishan/intraslot/blob/main/contrib/empty-hashtag-slot-bug/README.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core cluster slot hashing used for all keyed routing and sharded pub/sub; behavior shifts only for keys with empty `{}` tags, but that path was previously wrong versus Redis.
> 
> **Overview**
> Replaces the archived **`cluster-key-slot`** dependency with an in-tree **`calculate-slot`** helper and patches how **empty hash tags (`{}`)** are hashed so slot assignment matches Redis (whole-key hash, no further tag scanning). That bug could misroute cluster commands and **sharded pub/sub** channels to the wrong shard.
> 
> Cluster routing (`cluster/index.ts`, `cluster-slots.ts`), **multi-shard** splitting, and **pub/sub** slot logic now import the vendored module; **`cluster-key-slot`** is removed from `@redis/client` dependencies. New unit tests cover empty-tag cases, **`generateMulti`**, and parity with upstream’s hash suite. The lockfile drops **`cluster-key-slot`** and bumps workspace **`@redis/client`** to **6.2.1**; root **`package.json`** adds an **`allowScripts`** entry for esbuild.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8107e494280cd7ff090d3d1dfb4ccda70cd99cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->