### PR TITLE
feat(search): support WITHSCORES, EXPLAINSCORE, WITHPAYLOADS, WITHSORTKEYS, FILTER, GEOFILTER and PAYLOAD in FT.SEARCH (#2143)

### DIFF
--- a/packages/search/lib/commands/PROFILE_SEARCH.spec.ts
+++ b/packages/search/lib/commands/PROFILE_SEARCH.spec.ts
@@ -9,18 +9,18 @@ describe('PROFILE SEARCH', () => {
   describe('transformArguments', () => {
     it('without options', () => {
       assert.deepEqual(
-        parseArgs(PROFILE_SEARCH, 'index', 'query'),
+        Array.from(parseArgs(PROFILE_SEARCH, 'index', 'query')),
         ['FT.PROFILE', 'index', 'SEARCH', 'QUERY', 'query', 'DIALECT', DEFAULT_DIALECT]
       );
     });
 
     it('with options', () => {
       assert.deepEqual(
-        parseArgs(PROFILE_SEARCH, 'index', 'query', {
+        Array.from(parseArgs(PROFILE_SEARCH, 'index', 'query', {
           LIMITED: true,
           VERBATIM: true,
           INKEYS: 'key'
-        }),
+        })),
         ['FT.PROFILE', 'index', 'SEARCH', 'LIMITED', 'QUERY', 'query',
           'VERBATIM', 'INKEYS', '1', 'key', 'DIALECT', DEFAULT_DIALECT]
       );
@@ -109,6 +109,22 @@ describe('PROFILE SEARCH', () => {
     const keys = Object.keys(res as Record<string, unknown>);
     assert.ok(keys.includes('results'), `Expected 'results' key in response, got keys: ${keys}`);
     assert.ok(keys.includes('profile'), `Expected 'profile' key in response, got keys: ${keys}`);
+  }, GLOBAL.SERVERS.OPEN);
+
+  testUtils.testWithClientIfVersionWithinRange([[8], 'LATEST'], 'client.ft.profileSearch preserves WITHSCORES layout', async client => {
+    await Promise.all([
+      client.ft.create('index', { field: SCHEMA_FIELD_TYPE.TEXT }),
+      client.hSet('1', 'field', 'hello world')
+    ]);
+
+    // profileSearch shares SEARCH's reply transformer; WITHSCORES must parse the
+    // score without shifting id/value (regression: preserve was never set here).
+    const res = await client.ft.profileSearch('index', 'hello', { WITHSCORES: true });
+    const { results } = res as { results: { total: number; documents: Array<{ id: string; score?: number; value: unknown }> } };
+
+    assert.strictEqual(results.total, 1);
+    assert.strictEqual(results.documents[0].id, '1');
+    assert.strictEqual(typeof results.documents[0].score, 'number');
   }, GLOBAL.SERVERS.OPEN);
 
 });

--- a/packages/search/lib/commands/SEARCH.spec.ts
+++ b/packages/search/lib/commands/SEARCH.spec.ts
@@ -535,8 +535,7 @@ describe('FT.SEARCH', () => {
     assert.strictEqual(res.total, 1);
     assert.strictEqual(res.documents.length, 1);
     assert.strictEqual(res.documents[0].id, '1');
-    console.log(res.documents[0].payload);
-    assert.strictEqual(res.documents[0].payload, 'null');
+    assert.strictEqual(res.documents[0].payload, undefined);
     assert.deepStrictEqual(res.documents[0].value, { field: 'hello world' });
   }, GLOBAL.SERVERS.OPEN);
 

--- a/packages/search/lib/commands/SEARCH.spec.ts
+++ b/packages/search/lib/commands/SEARCH.spec.ts
@@ -17,54 +17,54 @@ describe('FT.SEARCH', () => {
 
     it('with VERBATIM', () => {
       assert.deepEqual(
-        parseArgs(SEARCH, 'index', 'query', {
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
           VERBATIM: true
-        }),
+        })),
         ['FT.SEARCH', 'index', 'query', 'VERBATIM', 'DIALECT', DEFAULT_DIALECT]
       );
     });
 
     it('with NOSTOPWORDS', () => {
       assert.deepEqual(
-        parseArgs(SEARCH, 'index', 'query', {
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
           NOSTOPWORDS: true
-        }),
+        })),
         ['FT.SEARCH', 'index', 'query', 'NOSTOPWORDS', 'DIALECT', DEFAULT_DIALECT]
       );
     });
 
     it('with WITHSCORES',() => {
       assert.deepEqual(
-        parseArgs(SEARCH,'index','query',{
+        Array.from(parseArgs(SEARCH,'index','query',{
           WITHSCORES:true
-        }),
+        })),
         ['FT.SEARCH','index','query','WITHSCORES','DIALECT',DEFAULT_DIALECT]
       )
     })
 
      it('with NOCONTENT',() => {
       assert.deepEqual(
-        parseArgs(SEARCH,'index','query',{
+        Array.from(parseArgs(SEARCH,'index','query',{
           NOCONTENT:true
-        }),
+        })),
         ['FT.SEARCH','index','query','NOCONTENT','DIALECT',DEFAULT_DIALECT]
       )
     })
 
      it('with WITHPAYLOADS',() => {
       assert.deepEqual(
-        parseArgs(SEARCH,'index','query',{
+        Array.from(parseArgs(SEARCH,'index','query',{
           WITHPAYLOADS:true
-        }),
+        })),
         ['FT.SEARCH','index','query','WITHPAYLOADS','DIALECT',DEFAULT_DIALECT]
       )
     })
 
      it('with WITHSORTKEYS',() => {
       assert.deepEqual(
-        parseArgs(SEARCH,'index','query',{
+        Array.from(parseArgs(SEARCH,'index','query',{
           WITHSORTKEYS:true
-        }),
+        })),
         ['FT.SEARCH','index','query','WITHSORTKEYS','DIALECT',DEFAULT_DIALECT]
       )
     })
@@ -72,20 +72,20 @@ describe('FT.SEARCH', () => {
       it('with FILTER (single and array)', () => {
     
     assert.deepStrictEqual(
-      parseArgs(SEARCH, 'index', 'query', {
+      Array.from(parseArgs(SEARCH, 'index', 'query', {
         FILTER: { field: 'price', min: 10, max: 100 }
-      }),
+      })),
       ['FT.SEARCH', 'index', 'query', 'FILTER', 'price', '10', '100', 'DIALECT', DEFAULT_DIALECT]
     );
 
     
     assert.deepStrictEqual(
-      parseArgs(SEARCH, 'index', 'query', {
+      Array.from(parseArgs(SEARCH, 'index', 'query', {
         FILTER: [
           { field: 'price', min: 10, max: 100 },
           { field: 'age', min: 18, max: 65 }
         ]
-      }),
+      })),
       [
         'FT.SEARCH', 'index', 'query',
         'FILTER', 'price', '10', '100',
@@ -95,23 +95,32 @@ describe('FT.SEARCH', () => {
     );
   });
 
+  it('with FILTER using Infinity bounds', () => {
+  assert.deepStrictEqual(
+    Array.from(parseArgs(SEARCH, 'index', 'query', {
+      FILTER: { field: 'price', min: -Infinity, max: Infinity }
+    })),
+    ['FT.SEARCH', 'index', 'query', 'FILTER', 'price', '-inf', '+inf', 'DIALECT', DEFAULT_DIALECT]
+  );
+});
+
   it('with GEOFILTER (single and array with units)', () => {
     
     assert.deepStrictEqual(
-      parseArgs(SEARCH, 'index', 'query', {
+      Array.from(parseArgs(SEARCH, 'index', 'query', {
         GEOFILTER: { field: 'location', lon: -122.4194, lat: 37.7749, radius: 10, unit: 'km' }
-      }),
+      })),
       ['FT.SEARCH', 'index', 'query', 'GEOFILTER', 'location', '-122.4194', '37.7749', '10', 'km', 'DIALECT', DEFAULT_DIALECT]
     );
 
     
     assert.deepStrictEqual(
-      parseArgs(SEARCH, 'index', 'query', {
+      Array.from(parseArgs(SEARCH, 'index', 'query', {
         GEOFILTER: [
           { field: 'loc1', lon: 10, lat: 20, radius: 500, unit: 'm' },
           { field: 'loc2', lon: 30, lat: 40, radius: 50, unit: 'mi' }
         ]
-      }),
+      })),
       [
         'FT.SEARCH', 'index', 'query',
         'GEOFILTER', 'loc1', '10', '20', '500', 'm',
@@ -123,27 +132,27 @@ describe('FT.SEARCH', () => {
 
     it('with INKEYS', () => {
       assert.deepEqual(
-        parseArgs(SEARCH, 'index', 'query', {
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
           INKEYS: 'key'
-        }),
+        })),
         ['FT.SEARCH', 'index', 'query', 'INKEYS', '1', 'key', 'DIALECT', DEFAULT_DIALECT]
       );
     });
 
     it('with INFIELDS', () => {
       assert.deepEqual(
-        parseArgs(SEARCH, 'index', 'query', {
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
           INFIELDS: 'field'
-        }),
+        })),
         ['FT.SEARCH', 'index', 'query', 'INFIELDS', '1', 'field', 'DIALECT', DEFAULT_DIALECT]
       );
     });
 
     it('with RETURN', () => {
       assert.deepEqual(
-        parseArgs(SEARCH, 'index', 'query', {
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
           RETURN: 'return'
-        }),
+        })),
         ['FT.SEARCH', 'index', 'query', 'RETURN', '1', 'return', 'DIALECT', DEFAULT_DIALECT]
       );
     });
@@ -151,9 +160,9 @@ describe('FT.SEARCH', () => {
     describe('with SUMMARIZE', () => {
       it('true', () => {
         assert.deepEqual(
-          parseArgs(SEARCH, 'index', 'query', {
+          Array.from(parseArgs(SEARCH, 'index', 'query', {
             SUMMARIZE: true
-          }),
+          })),
           ['FT.SEARCH', 'index', 'query', 'SUMMARIZE', 'DIALECT', DEFAULT_DIALECT]
         );
       });
@@ -161,22 +170,22 @@ describe('FT.SEARCH', () => {
       describe('with FIELDS', () => {
         it('string', () => {
           assert.deepEqual(
-            parseArgs(SEARCH, 'index', 'query', {
+            Array.from(parseArgs(SEARCH, 'index', 'query', {
               SUMMARIZE: {
                 FIELDS: '@field'
               }
-            }),
+            })),
             ['FT.SEARCH', 'index', 'query', 'SUMMARIZE', 'FIELDS', '1', '@field', 'DIALECT', DEFAULT_DIALECT]
           );
         });
 
         it('Array', () => {
           assert.deepEqual(
-            parseArgs(SEARCH, 'index', 'query', {
+            Array.from(parseArgs(SEARCH, 'index', 'query', {
               SUMMARIZE: {
                 FIELDS: ['@1', '@2']
               }
-            }),
+            })),
             ['FT.SEARCH', 'index', 'query', 'SUMMARIZE', 'FIELDS', '2', '@1', '@2', 'DIALECT', DEFAULT_DIALECT]
           );
         });
@@ -184,33 +193,33 @@ describe('FT.SEARCH', () => {
 
       it('with FRAGS', () => {
         assert.deepEqual(
-          parseArgs(SEARCH, 'index', 'query', {
+          Array.from(parseArgs(SEARCH, 'index', 'query', {
             SUMMARIZE: {
               FRAGS: 1
             }
-          }),
+          })),
           ['FT.SEARCH', 'index', 'query', 'SUMMARIZE', 'FRAGS', '1', 'DIALECT', DEFAULT_DIALECT]
         );
       });
 
       it('with LEN', () => {
         assert.deepEqual(
-          parseArgs(SEARCH, 'index', 'query', {
+          Array.from(parseArgs(SEARCH, 'index', 'query', {
             SUMMARIZE: {
               LEN: 1
             }
-          }),
+          })),
           ['FT.SEARCH', 'index', 'query', 'SUMMARIZE', 'LEN', '1', 'DIALECT', DEFAULT_DIALECT]
         );
       });
 
       it('with SEPARATOR', () => {
         assert.deepEqual(
-          parseArgs(SEARCH, 'index', 'query', {
+          Array.from(parseArgs(SEARCH, 'index', 'query', {
             SUMMARIZE: {
               SEPARATOR: 'separator'
             }
-          }),
+          })),
           ['FT.SEARCH', 'index', 'query', 'SUMMARIZE', 'SEPARATOR', 'separator', 'DIALECT', DEFAULT_DIALECT]
         );
       });
@@ -219,9 +228,9 @@ describe('FT.SEARCH', () => {
     describe('with HIGHLIGHT', () => {
       it('true', () => {
         assert.deepEqual(
-          parseArgs(SEARCH, 'index', 'query', {
+          Array.from(parseArgs(SEARCH, 'index', 'query', {
             HIGHLIGHT: true
-          }),
+          })),
           ['FT.SEARCH', 'index', 'query', 'HIGHLIGHT', 'DIALECT', DEFAULT_DIALECT]
         );
       });
@@ -229,22 +238,22 @@ describe('FT.SEARCH', () => {
       describe('with FIELDS', () => {
         it('string', () => {
           assert.deepEqual(
-            parseArgs(SEARCH, 'index', 'query', {
+            Array.from(parseArgs(SEARCH, 'index', 'query', {
               HIGHLIGHT: {
                 FIELDS: ['@field']
               }
-            }),
+            })),
             ['FT.SEARCH', 'index', 'query', 'HIGHLIGHT', 'FIELDS', '1', '@field', 'DIALECT', DEFAULT_DIALECT]
           );
         });
 
         it('Array', () => {
           assert.deepEqual(
-            parseArgs(SEARCH, 'index', 'query', {
+            Array.from(parseArgs(SEARCH, 'index', 'query', {
               HIGHLIGHT: {
                 FIELDS: ['@1', '@2']
               }
-            }),
+            })),
             ['FT.SEARCH', 'index', 'query', 'HIGHLIGHT', 'FIELDS', '2', '@1', '@2', 'DIALECT', DEFAULT_DIALECT]
           );
         });
@@ -252,14 +261,14 @@ describe('FT.SEARCH', () => {
 
       it('with TAGS', () => {
         assert.deepEqual(
-          parseArgs(SEARCH, 'index', 'query', {
+          Array.from(parseArgs(SEARCH, 'index', 'query', {
             HIGHLIGHT: {
               TAGS: {
                 open: 'open',
                 close: 'close'
               }
             }
-          }),
+          })),
           ['FT.SEARCH', 'index', 'query', 'HIGHLIGHT', 'TAGS', 'open', 'close', 'DIALECT', DEFAULT_DIALECT]
         );
       });
@@ -267,64 +276,64 @@ describe('FT.SEARCH', () => {
 
     it('with SLOP', () => {
       assert.deepEqual(
-        parseArgs(SEARCH, 'index', 'query', {
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
           SLOP: 1
-        }),
+        })),
         ['FT.SEARCH', 'index', 'query', 'SLOP', '1', 'DIALECT', DEFAULT_DIALECT]
       );
     });
 
     it('with TIMEOUT', () => {
       assert.deepEqual(
-        parseArgs(SEARCH, 'index', 'query', {
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
           TIMEOUT: 1
-        }),
+        })),
         ['FT.SEARCH', 'index', 'query', 'TIMEOUT', '1', 'DIALECT', DEFAULT_DIALECT]
       );
     });
 
     it('with INORDER', () => {
       assert.deepEqual(
-        parseArgs(SEARCH, 'index', 'query', {
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
           INORDER: true
-        }),
+        })),
         ['FT.SEARCH', 'index', 'query', 'INORDER', 'DIALECT', DEFAULT_DIALECT]
       );
     });
 
     it('with LANGUAGE', () => {
       assert.deepEqual(
-        parseArgs(SEARCH, 'index', 'query', {
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
           LANGUAGE: 'Arabic'
-        }),
+        })),
         ['FT.SEARCH', 'index', 'query', 'LANGUAGE', 'Arabic', 'DIALECT', DEFAULT_DIALECT]
       );
     });
 
     it('with EXPANDER', () => {
       assert.deepEqual(
-        parseArgs(SEARCH, 'index', 'query', {
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
           EXPANDER: 'expender'
-        }),
+        })),
         ['FT.SEARCH', 'index', 'query', 'EXPANDER', 'expender', 'DIALECT', DEFAULT_DIALECT]
       );
     });
 
     it('with SCORER', () => {
       assert.deepEqual(
-        parseArgs(SEARCH, 'index', 'query', {
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
           SCORER: 'scorer'
-        }),
+        })),
         ['FT.SEARCH', 'index', 'query', 'SCORER', 'scorer', 'DIALECT', DEFAULT_DIALECT]
       );
     });
 
     it('with EXPLAINSCORE', () => {
     assert.deepStrictEqual(
-      parseArgs(SEARCH, 'index', 'query', {
+      Array.from(parseArgs(SEARCH, 'index', 'query', {
         WITHSCORES: true,
         EXPLAINSCORE: true
-      }),
+      })),
       ['FT.SEARCH', 'index', 'query', 'WITHSCORES', 'EXPLAINSCORE', 'DIALECT', DEFAULT_DIALECT]
     );
     });
@@ -332,55 +341,61 @@ describe('FT.SEARCH', () => {
 
     it('with PAYLOAD', () => {
     assert.deepStrictEqual(
-      parseArgs(SEARCH, 'index', 'query', {
+      Array.from(parseArgs(SEARCH, 'index', 'query', {
         PAYLOAD: 'evaluation-payload-string'
-      }),
+      })),
       ['FT.SEARCH', 'index', 'query', 'PAYLOAD', 'evaluation-payload-string', 'DIALECT', DEFAULT_DIALECT]
     );
   });
 
     it('with SORTBY', () => {
       assert.deepEqual(
-        parseArgs(SEARCH, 'index', 'query', {
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
           SORTBY: '@by'
-        }),
+        })),
         ['FT.SEARCH', 'index', 'query', 'SORTBY', '@by', 'DIALECT', DEFAULT_DIALECT]
       );
     });
 
     it('with LIMIT', () => {
       assert.deepEqual(
-        parseArgs(SEARCH, 'index', 'query', {
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
           LIMIT: {
             from: 0,
             size: 1
           }
-        }),
+        })),
         ['FT.SEARCH', 'index', 'query', 'LIMIT', '0', '1', 'DIALECT', DEFAULT_DIALECT]
       );
     });
 
     it('with PARAMS', () => {
       assert.deepEqual(
-        parseArgs(SEARCH, 'index', 'query', {
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
           PARAMS: {
             string: 'string',
             buffer: Buffer.from('buffer'),
             number: 1
           }
-        }),
+        })),
         ['FT.SEARCH', 'index', 'query', 'PARAMS', '6', 'string', 'string', 'buffer', Buffer.from('buffer'), 'number', '1', 'DIALECT', DEFAULT_DIALECT]
       );
     });
 
     it('with DIALECT', () => {
       assert.deepEqual(
-        parseArgs(SEARCH, 'index', 'query', {
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
           DIALECT: 1
-        }),
+        })),
         ['FT.SEARCH', 'index', 'query', 'DIALECT', '1']
       );
     });
+
+    it('stores the options for use by transformReply', () => {
+    const options = { WITHSCORES: true, NOCONTENT: true };
+    const args = parseArgs(SEARCH, 'index', 'query', options);
+    assert.deepEqual(args.preserve, options);
+  });
   });
 
   describe('transformReply', () => {

--- a/packages/search/lib/commands/SEARCH.spec.ts
+++ b/packages/search/lib/commands/SEARCH.spec.ts
@@ -33,6 +33,15 @@ describe('FT.SEARCH', () => {
       );
     });
 
+    it('with WITHSCORES',() => {
+      assert.deepEqual(
+        parseArgs(SEARCH,'index','query',{
+          WITHSCORES:true
+        }),
+        ['FT.SEARCH','index','query','WITHSCORES','DIALECT',DEFAULT_DIALECT]
+      )
+    })
+
     it('with INKEYS', () => {
       assert.deepEqual(
         parseArgs(SEARCH, 'index', 'query', {
@@ -362,6 +371,23 @@ describe('FT.SEARCH', () => {
           warnings: []
         }
       );
+    }, GLOBAL.SERVERS.OPEN);
+
+     testUtils.testWithClient('withscores', async client => {
+      await Promise.all([
+        client.ft.create('index', {
+          field: 'TEXT'
+        }),
+        client.hSet('1', 'field', '1')
+      ]);
+
+      const res = await client.ft.search('index','*',{WITHSCORES: true});
+      
+      assert.strictEqual(res.total,1);
+      assert.strictEqual(res.documents.length,1);
+      assert.strictEqual(res.documents[0].id,'1');
+      assert.strictEqual(typeof res.documents[0].score,'number');
+      
     }, GLOBAL.SERVERS.OPEN);
 
     testUtils.testWithClient('with data', async client => {

--- a/packages/search/lib/commands/SEARCH.spec.ts
+++ b/packages/search/lib/commands/SEARCH.spec.ts
@@ -42,6 +42,85 @@ describe('FT.SEARCH', () => {
       )
     })
 
+     it('with NOCONTENT',() => {
+      assert.deepEqual(
+        parseArgs(SEARCH,'index','query',{
+          NOCONTENT:true
+        }),
+        ['FT.SEARCH','index','query','NOCONTENT','DIALECT',DEFAULT_DIALECT]
+      )
+    })
+
+     it('with WITHPAYLOADS',() => {
+      assert.deepEqual(
+        parseArgs(SEARCH,'index','query',{
+          WITHPAYLOADS:true
+        }),
+        ['FT.SEARCH','index','query','WITHPAYLOADS','DIALECT',DEFAULT_DIALECT]
+      )
+    })
+
+     it('with WITHSORTKEYS',() => {
+      assert.deepEqual(
+        parseArgs(SEARCH,'index','query',{
+          WITHSORTKEYS:true
+        }),
+        ['FT.SEARCH','index','query','WITHSORTKEYS','DIALECT',DEFAULT_DIALECT]
+      )
+    })
+
+      it('with FILTER (single and array)', () => {
+    
+    assert.deepStrictEqual(
+      parseArgs(SEARCH, 'index', 'query', {
+        FILTER: { field: 'price', min: 10, max: 100 }
+      }),
+      ['FT.SEARCH', 'index', 'query', 'FILTER', 'price', '10', '100', 'DIALECT', DEFAULT_DIALECT]
+    );
+
+    
+    assert.deepStrictEqual(
+      parseArgs(SEARCH, 'index', 'query', {
+        FILTER: [
+          { field: 'price', min: 10, max: 100 },
+          { field: 'age', min: 18, max: 65 }
+        ]
+      }),
+      [
+        'FT.SEARCH', 'index', 'query',
+        'FILTER', 'price', '10', '100',
+        'FILTER', 'age', '18', '65',
+        'DIALECT', DEFAULT_DIALECT
+      ]
+    );
+  });
+
+  it('with GEOFILTER (single and array with units)', () => {
+    
+    assert.deepStrictEqual(
+      parseArgs(SEARCH, 'index', 'query', {
+        GEOFILTER: { field: 'location', lon: -122.4194, lat: 37.7749, radius: 10, unit: 'km' }
+      }),
+      ['FT.SEARCH', 'index', 'query', 'GEOFILTER', 'location', '-122.4194', '37.7749', '10', 'km', 'DIALECT', DEFAULT_DIALECT]
+    );
+
+    
+    assert.deepStrictEqual(
+      parseArgs(SEARCH, 'index', 'query', {
+        GEOFILTER: [
+          { field: 'loc1', lon: 10, lat: 20, radius: 500, unit: 'm' },
+          { field: 'loc2', lon: 30, lat: 40, radius: 50, unit: 'mi' }
+        ]
+      }),
+      [
+        'FT.SEARCH', 'index', 'query',
+        'GEOFILTER', 'loc1', '10', '20', '500', 'm',
+        'GEOFILTER', 'loc2', '30', '40', '50', 'mi',
+        'DIALECT', DEFAULT_DIALECT
+      ]
+    );
+  });
+
     it('with INKEYS', () => {
       assert.deepEqual(
         parseArgs(SEARCH, 'index', 'query', {
@@ -240,6 +319,26 @@ describe('FT.SEARCH', () => {
       );
     });
 
+    it('with EXPLAINSCORE', () => {
+    assert.deepStrictEqual(
+      parseArgs(SEARCH, 'index', 'query', {
+        WITHSCORES: true,
+        EXPLAINSCORE: true
+      }),
+      ['FT.SEARCH', 'index', 'query', 'WITHSCORES', 'EXPLAINSCORE', 'DIALECT', DEFAULT_DIALECT]
+    );
+    });
+  
+
+    it('with PAYLOAD', () => {
+    assert.deepStrictEqual(
+      parseArgs(SEARCH, 'index', 'query', {
+        PAYLOAD: 'evaluation-payload-string'
+      }),
+      ['FT.SEARCH', 'index', 'query', 'PAYLOAD', 'evaluation-payload-string', 'DIALECT', DEFAULT_DIALECT]
+    );
+  });
+
     it('with SORTBY', () => {
       assert.deepEqual(
         parseArgs(SEARCH, 'index', 'query', {
@@ -373,7 +472,26 @@ describe('FT.SEARCH', () => {
       );
     }, GLOBAL.SERVERS.OPEN);
 
-     testUtils.testWithClient('withscores', async client => {
+    testUtils.testWithClient('EXPLAINSCORE', async client => {
+      await Promise.all([
+      client.ft.create('index', { field: 'TEXT' }),
+      client.hSet('1', 'field', 'hello world')
+    ]);
+
+    const res = await client.ft.search('index', 'hello', {
+      WITHSCORES: true,
+      EXPLAINSCORE: true
+    });
+
+    assert.strictEqual(res.total, 1);
+    assert.strictEqual(res.documents.length, 1);
+    assert.strictEqual(res.documents[0].id, '1');
+    assert.strictEqual(typeof res.documents[0].score, 'number');
+    assert.ok(Array.isArray(res.documents[0].scoreExplain));
+    assert.ok(res.documents[0].scoreExplain.length > 0);
+  }, GLOBAL.SERVERS.OPEN);
+
+     testUtils.testWithClient('WITHSCORES', async client => {
       await Promise.all([
         client.ft.create('index', {
           field: 'TEXT'
@@ -389,6 +507,139 @@ describe('FT.SEARCH', () => {
       assert.strictEqual(typeof res.documents[0].score,'number');
       
     }, GLOBAL.SERVERS.OPEN);
+
+    testUtils.testWithClient('NOCONTENT', async client => {
+    await Promise.all([
+      client.ft.create('index', { field: 'TEXT' }),
+      client.hSet('1', 'field', 'hello world')
+    ]);
+
+    const res = await client.ft.search('index', '*', { NOCONTENT: true });
+
+    assert.strictEqual(res.total, 1);
+    assert.strictEqual(res.documents.length, 1);
+    assert.strictEqual(res.documents[0].id, '1');
+    assert.deepStrictEqual(res.documents[0].value, {});
+  }, GLOBAL.SERVERS.OPEN);
+
+    testUtils.testWithClient('WITHPAYLOADS', async client => {
+    await Promise.all([
+      client.ft.create('index', { field: 'TEXT' }),
+      client.hSet('1', 'field', 'hello world')
+    ]);
+
+    const res = await client.ft.search('index', '*', {
+      WITHPAYLOADS: true
+    });
+
+    assert.strictEqual(res.total, 1);
+    assert.strictEqual(res.documents.length, 1);
+    assert.strictEqual(res.documents[0].id, '1');
+    console.log(res.documents[0].payload);
+    assert.strictEqual(res.documents[0].payload, 'null');
+    assert.deepStrictEqual(res.documents[0].value, { field: 'hello world' });
+  }, GLOBAL.SERVERS.OPEN);
+
+
+  testUtils.testWithClient('WITHSORTKEYS', async client => {
+    await Promise.all([
+      client.ft.create('index', {
+        field: { type: 'TEXT', SORTABLE: true }
+      }),
+      client.hSet('1', 'field', 'hello world')
+    ]);
+
+    const res = await client.ft.search('index', '*', {
+      SORTBY: 'field',
+      WITHSORTKEYS: true
+    });
+
+    assert.strictEqual(res.total, 1);
+    assert.strictEqual(res.documents.length, 1);
+    assert.strictEqual(res.documents[0].id, '1');
+    assert.strictEqual(typeof res.documents[0].sortKey, 'string');
+    assert.deepStrictEqual(res.documents[0].value, { field: 'hello world' });
+  }, GLOBAL.SERVERS.OPEN);
+
+  testUtils.testWithClient('WITHSCORES + NOCONTENT', async client => {
+    await Promise.all([
+      client.ft.create('index', { field: 'TEXT' }),
+      client.hSet('101', 'field', 'numeric id test')
+    ]);
+
+    const res = await client.ft.search('index', '*', {
+      WITHSCORES: true,
+      NOCONTENT: true
+    });
+
+    assert.strictEqual(res.total, 1);
+    assert.strictEqual(res.documents.length, 1);
+    assert.strictEqual(res.documents[0].id, '101');
+    assert.strictEqual(typeof res.documents[0].score, 'number');
+    assert.deepStrictEqual(res.documents[0].value, {});
+  }, GLOBAL.SERVERS.OPEN);
+
+    testUtils.testWithClient('FILTER', async client => {
+    await Promise.all([
+      client.ft.create('index', {
+        price: { type: 'NUMERIC' }
+      }),
+      client.hSet('doc:1', 'price', '15'),
+      client.hSet('doc:2', 'price', '50'),
+      client.hSet('doc:3', 'price', '120')
+    ]);
+
+    const res = await client.ft.search('index', '*', {
+      FILTER: { field: 'price', min: 10, max: 100 }
+    });
+
+    assert.strictEqual(res.total, 2);
+    assert.strictEqual(res.documents.length, 2);
+    const ids = res.documents.map(d => d.id).sort();
+    assert.deepStrictEqual(ids, ['doc:1', 'doc:2']);
+  }, GLOBAL.SERVERS.OPEN);
+
+  testUtils.testWithClient('GEOFILTER', async client => {
+    await Promise.all([
+      client.ft.create('index', {
+        location: { type: 'GEO' }
+      }),
+      
+      client.hSet('doc:sf', 'location', '-122.4194,37.7749'),
+      client.hSet('doc:oakland', 'location', '-122.2711,37.8044')
+    ]);
+
+    
+    const res = await client.ft.search('index', '*', {
+      GEOFILTER: {
+        field: 'location',
+        lon: -122.4194,
+        lat: 37.7749,
+        radius: 5,
+        unit: 'km'
+      }
+    });
+
+    assert.strictEqual(res.total, 1);
+    assert.strictEqual(res.documents[0].id, 'doc:sf');
+  }, GLOBAL.SERVERS.OPEN);
+
+
+    testUtils.testWithClient('PAYLOAD', async client => {
+    await Promise.all([
+      client.ft.create('index', { field: 'TEXT' }),
+      client.hSet('1', 'field', 'hello world')
+    ]);
+
+    const res = await client.ft.search('index', '*', {
+      PAYLOAD: 'custom-eval-context'
+    });
+
+    assert.strictEqual(res.total, 1);
+    assert.strictEqual(res.documents[0].id, '1');
+    assert.strictEqual(res.documents[0].payload, undefined); 
+    assert.deepStrictEqual(res.documents[0].value, { field: 'hello world' });
+  }, GLOBAL.SERVERS.OPEN);
 
     testUtils.testWithClient('with data', async client => {
       await Promise.all([

--- a/packages/search/lib/commands/SEARCH.spec.ts
+++ b/packages/search/lib/commands/SEARCH.spec.ts
@@ -4,7 +4,7 @@ import SEARCH from './SEARCH';
 import { SCHEMA_FIELD_TYPE, REDISEARCH_LANGUAGE } from './CREATE';
 import { parseArgs } from '@redis/client/lib/commands/generic-transformers';
 import { DEFAULT_DIALECT } from '../dialect/default';
-
+import { RESP_TYPES } from '@redis/client';
 
 describe('FT.SEARCH', () => {
   describe('transformArguments', () => {
@@ -750,6 +750,31 @@ describe('FT.SEARCH', () => {
 
 
     }, GLOBAL.SERVERS.OPEN);
+
+  testUtils.testWithClient('NOCONTENT takes precedence over a conflicting RETURN', async client => {
+  await Promise.all([
+    client.ft.create('index', { title: 'TEXT', price: 'NUMERIC' }),
+    client.hSet('1', { title: 'Widget', price: '9.99' })
+  ]);
+  const res = await client.ft.search('index', '*', {
+    NOCONTENT: true,
+    RETURN: ['title', 'price']
+  });
+  assert.strictEqual(res.total, 1);
+  assert.deepStrictEqual(res.documents[0].value, {});
+}, GLOBAL.SERVERS.OPEN);
+
+  
+  testUtils.testWithClient('WITHSORTKEYS honors BLOB_STRING', async client => {
+  await Promise.all([
+    client.ft.create('index', { field: { type: 'TEXT', SORTABLE: true } }),
+    client.hSet('1', 'field', 'hello world')
+  ]);
+  const res = await client
+    .withTypeMapping({ [RESP_TYPES.BLOB_STRING]: Buffer })
+    .ft.search('index', '*', { SORTBY: 'field', WITHSORTKEYS: true });
+  assert.ok(Buffer.isBuffer(res.documents[0].sortKey));
+}, GLOBAL.SERVERS.OPEN);
 
   });
 

--- a/packages/search/lib/commands/SEARCH.spec.ts
+++ b/packages/search/lib/commands/SEARCH.spec.ts
@@ -33,93 +33,89 @@ describe('FT.SEARCH', () => {
       );
     });
 
-    it('with WITHSCORES',() => {
+    it('with WITHSCORES', () => {
       assert.deepEqual(
-        Array.from(parseArgs(SEARCH,'index','query',{
-          WITHSCORES:true
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
+          WITHSCORES: true
         })),
-        ['FT.SEARCH','index','query','WITHSCORES','DIALECT',DEFAULT_DIALECT]
-      )
-    })
+        ['FT.SEARCH', 'index', 'query', 'WITHSCORES', 'DIALECT', DEFAULT_DIALECT]
+      );
+    });
 
-     it('with WITHPAYLOADS',() => {
+    it('with WITHPAYLOADS', () => {
       assert.deepEqual(
-        Array.from(parseArgs(SEARCH,'index','query',{
-          WITHPAYLOADS:true
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
+          WITHPAYLOADS: true
         })),
-        ['FT.SEARCH','index','query','WITHPAYLOADS','DIALECT',DEFAULT_DIALECT]
-      )
-    })
+        ['FT.SEARCH', 'index', 'query', 'WITHPAYLOADS', 'DIALECT', DEFAULT_DIALECT]
+      );
+    });
 
-     it('with WITHSORTKEYS',() => {
+    it('with WITHSORTKEYS', () => {
       assert.deepEqual(
-        Array.from(parseArgs(SEARCH,'index','query',{
-          WITHSORTKEYS:true
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
+          WITHSORTKEYS: true
         })),
-        ['FT.SEARCH','index','query','WITHSORTKEYS','DIALECT',DEFAULT_DIALECT]
-      )
-    })
+        ['FT.SEARCH', 'index', 'query', 'WITHSORTKEYS', 'DIALECT', DEFAULT_DIALECT]
+      );
+    });
 
-      it('with FILTER (single and array)', () => {
-    
-    assert.deepStrictEqual(
-      Array.from(parseArgs(SEARCH, 'index', 'query', {
-        FILTER: { field: 'price', min: 10, max: 100 }
-      })),
-      ['FT.SEARCH', 'index', 'query', 'FILTER', 'price', '10', '100', 'DIALECT', DEFAULT_DIALECT]
-    );
+    it('with FILTER (single and array)', () => {
+      assert.deepStrictEqual(
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
+          FILTER: { field: 'price', min: 10, max: 100 }
+        })),
+        ['FT.SEARCH', 'index', 'query', 'FILTER', 'price', '10', '100', 'DIALECT', DEFAULT_DIALECT]
+      );
 
-    
-    assert.deepStrictEqual(
-      Array.from(parseArgs(SEARCH, 'index', 'query', {
-        FILTER: [
-          { field: 'price', min: 10, max: 100 },
-          { field: 'age', min: 18, max: 65 }
+      assert.deepStrictEqual(
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
+          FILTER: [
+            { field: 'price', min: 10, max: 100 },
+            { field: 'age', min: 18, max: 65 }
+          ]
+        })),
+        [
+          'FT.SEARCH', 'index', 'query',
+          'FILTER', 'price', '10', '100',
+          'FILTER', 'age', '18', '65',
+          'DIALECT', DEFAULT_DIALECT
         ]
-      })),
-      [
-        'FT.SEARCH', 'index', 'query',
-        'FILTER', 'price', '10', '100',
-        'FILTER', 'age', '18', '65',
-        'DIALECT', DEFAULT_DIALECT
-      ]
-    );
-  });
+      );
+    });
 
-  it('with FILTER using Infinity bounds', () => {
-  assert.deepStrictEqual(
-    Array.from(parseArgs(SEARCH, 'index', 'query', {
-      FILTER: { field: 'price', min: -Infinity, max: Infinity }
-    })),
-    ['FT.SEARCH', 'index', 'query', 'FILTER', 'price', '-inf', '+inf', 'DIALECT', DEFAULT_DIALECT]
-  );
-});
+    it('with FILTER using Infinity bounds', () => {
+      assert.deepStrictEqual(
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
+          FILTER: { field: 'price', min: -Infinity, max: Infinity }
+        })),
+        ['FT.SEARCH', 'index', 'query', 'FILTER', 'price', '-inf', '+inf', 'DIALECT', DEFAULT_DIALECT]
+      );
+    });
 
-  it('with GEOFILTER (single and array with units)', () => {
-    
-    assert.deepStrictEqual(
-      Array.from(parseArgs(SEARCH, 'index', 'query', {
-        GEOFILTER: { field: 'location', lon: -122.4194, lat: 37.7749, radius: 10, unit: 'km' }
-      })),
-      ['FT.SEARCH', 'index', 'query', 'GEOFILTER', 'location', '-122.4194', '37.7749', '10', 'km', 'DIALECT', DEFAULT_DIALECT]
-    );
+    it('with GEOFILTER (single and array with units)', () => {
+      assert.deepStrictEqual(
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
+          GEOFILTER: { field: 'location', lon: -122.4194, lat: 37.7749, radius: 10, unit: 'km' }
+        })),
+        ['FT.SEARCH', 'index', 'query', 'GEOFILTER', 'location', '-122.4194', '37.7749', '10', 'km', 'DIALECT', DEFAULT_DIALECT]
+      );
 
-    
-    assert.deepStrictEqual(
-      Array.from(parseArgs(SEARCH, 'index', 'query', {
-        GEOFILTER: [
-          { field: 'loc1', lon: 10, lat: 20, radius: 500, unit: 'm' },
-          { field: 'loc2', lon: 30, lat: 40, radius: 50, unit: 'mi' }
+      assert.deepStrictEqual(
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
+          GEOFILTER: [
+            { field: 'loc1', lon: 10, lat: 20, radius: 500, unit: 'm' },
+            { field: 'loc2', lon: 30, lat: 40, radius: 50, unit: 'mi' }
+          ]
+        })),
+        [
+          'FT.SEARCH', 'index', 'query',
+          'GEOFILTER', 'loc1', '10', '20', '500', 'm',
+          'GEOFILTER', 'loc2', '30', '40', '50', 'mi',
+          'DIALECT', DEFAULT_DIALECT
         ]
-      })),
-      [
-        'FT.SEARCH', 'index', 'query',
-        'GEOFILTER', 'loc1', '10', '20', '500', 'm',
-        'GEOFILTER', 'loc2', '30', '40', '50', 'mi',
-        'DIALECT', DEFAULT_DIALECT
-      ]
-    );
-  });
+      );
+    });
 
     it('with INKEYS', () => {
       assert.deepEqual(
@@ -320,24 +316,23 @@ describe('FT.SEARCH', () => {
     });
 
     it('with EXPLAINSCORE', () => {
-    assert.deepStrictEqual(
-      Array.from(parseArgs(SEARCH, 'index', 'query', {
-        WITHSCORES: true,
-        EXPLAINSCORE: true
-      })),
-      ['FT.SEARCH', 'index', 'query', 'WITHSCORES', 'EXPLAINSCORE', 'DIALECT', DEFAULT_DIALECT]
-    );
+      assert.deepStrictEqual(
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
+          WITHSCORES: true,
+          EXPLAINSCORE: true
+        })),
+        ['FT.SEARCH', 'index', 'query', 'WITHSCORES', 'EXPLAINSCORE', 'DIALECT', DEFAULT_DIALECT]
+      );
     });
-  
 
     it('with PAYLOAD', () => {
-    assert.deepStrictEqual(
-      Array.from(parseArgs(SEARCH, 'index', 'query', {
-        PAYLOAD: 'evaluation-payload-string'
-      })),
-      ['FT.SEARCH', 'index', 'query', 'PAYLOAD', 'evaluation-payload-string', 'DIALECT', DEFAULT_DIALECT]
-    );
-  });
+      assert.deepStrictEqual(
+        Array.from(parseArgs(SEARCH, 'index', 'query', {
+          PAYLOAD: 'evaluation-payload-string'
+        })),
+        ['FT.SEARCH', 'index', 'query', 'PAYLOAD', 'evaluation-payload-string', 'DIALECT', DEFAULT_DIALECT]
+      );
+    });
 
     it('with SORTBY', () => {
       assert.deepEqual(
@@ -487,27 +482,27 @@ describe('FT.SEARCH', () => {
 
     testUtils.testWithClient('EXPLAINSCORE', async client => {
       await Promise.all([
-      client.ft.create('index', { field: 'TEXT' }),
-      client.hSet('1', 'field', 'hello world')
-    ]);
+        client.ft.create('index', { field: 'TEXT' }),
+        client.hSet('1', 'field', 'hello world')
+      ]);
 
-    const res = await client.ft.search('index', 'hello', {
-      WITHSCORES: true,
-      EXPLAINSCORE: true
-    });
+      const res = await client.ft.search('index', 'hello', {
+        WITHSCORES: true,
+        EXPLAINSCORE: true
+      });
 
-    assert.strictEqual(res.total, 1);
-    assert.strictEqual(res.documents.length, 1);
-    assert.strictEqual(res.documents[0].id, '1');
-    assert.strictEqual(typeof res.documents[0].score, 'number');
-    // scoreExplain is a single recursive `[summary, children]` node.
-    const explain = res.documents[0].scoreExplain;
-    assert.ok(Array.isArray(explain), 'scoreExplain is a [summary, children] node');
-    assert.strictEqual(typeof explain[0], 'string');
-    assert.ok(Array.isArray(explain[1]));
-  }, GLOBAL.SERVERS.OPEN);
+      assert.strictEqual(res.total, 1);
+      assert.strictEqual(res.documents.length, 1);
+      assert.strictEqual(res.documents[0].id, '1');
+      assert.strictEqual(typeof res.documents[0].score, 'number');
+      // scoreExplain is a single recursive `[summary, children]` node.
+      const explain = res.documents[0].scoreExplain;
+      assert.ok(Array.isArray(explain), 'scoreExplain is a [summary, children] node');
+      assert.strictEqual(typeof explain[0], 'string');
+      assert.ok(Array.isArray(explain[1]));
+    }, GLOBAL.SERVERS.OPEN);
 
-     testUtils.testWithClient('WITHSCORES', async client => {
+    testUtils.testWithClient('WITHSCORES', async client => {
       await Promise.all([
         client.ft.create('index', {
           field: 'TEXT'
@@ -515,13 +510,12 @@ describe('FT.SEARCH', () => {
         client.hSet('1', 'field', '1')
       ]);
 
-      const res = await client.ft.search('index','*',{WITHSCORES: true});
-      
-      assert.strictEqual(res.total,1);
-      assert.strictEqual(res.documents.length,1);
-      assert.strictEqual(res.documents[0].id,'1');
-      assert.strictEqual(typeof res.documents[0].score,'number');
-      
+      const res = await client.ft.search('index', '*', { WITHSCORES: true });
+
+      assert.strictEqual(res.total, 1);
+      assert.strictEqual(res.documents.length, 1);
+      assert.strictEqual(res.documents[0].id, '1');
+      assert.strictEqual(typeof res.documents[0].score, 'number');
     }, GLOBAL.SERVERS.OPEN);
 
     testUtils.testWithClient('WITHSCORES honors the DOUBLE type mapping', async client => {
@@ -538,119 +532,115 @@ describe('FT.SEARCH', () => {
     }, GLOBAL.SERVERS.OPEN);
 
     testUtils.testWithClient('WITHPAYLOADS', async client => {
-    await Promise.all([
-      client.ft.create('index', { field: 'TEXT' }),
-      client.hSet('1', 'field', 'hello world')
-    ]);
+      await Promise.all([
+        client.ft.create('index', { field: 'TEXT' }),
+        client.hSet('1', 'field', 'hello world')
+      ]);
 
-    const res = await client.ft.search('index', '*', {
-      WITHPAYLOADS: true
-    });
+      const res = await client.ft.search('index', '*', {
+        WITHPAYLOADS: true
+      });
 
-    assert.strictEqual(res.total, 1);
-    assert.strictEqual(res.documents.length, 1);
-    assert.strictEqual(res.documents[0].id, '1');
-    assert.strictEqual(res.documents[0].payload, undefined);
-    assert.deepStrictEqual(res.documents[0].value, { field: 'hello world' });
-  }, GLOBAL.SERVERS.OPEN);
+      assert.strictEqual(res.total, 1);
+      assert.strictEqual(res.documents.length, 1);
+      assert.strictEqual(res.documents[0].id, '1');
+      assert.strictEqual(res.documents[0].payload, undefined);
+      assert.deepStrictEqual(res.documents[0].value, { field: 'hello world' });
+    }, GLOBAL.SERVERS.OPEN);
 
+    testUtils.testWithClient('WITHSORTKEYS', async client => {
+      await Promise.all([
+        client.ft.create('index', {
+          field: { type: 'TEXT', SORTABLE: true }
+        }),
+        client.hSet('1', 'field', 'hello world')
+      ]);
 
-  testUtils.testWithClient('WITHSORTKEYS', async client => {
-    await Promise.all([
-      client.ft.create('index', {
-        field: { type: 'TEXT', SORTABLE: true }
-      }),
-      client.hSet('1', 'field', 'hello world')
-    ]);
+      const res = await client.ft.search('index', '*', {
+        SORTBY: 'field',
+        WITHSORTKEYS: true
+      });
 
-    const res = await client.ft.search('index', '*', {
-      SORTBY: 'field',
-      WITHSORTKEYS: true
-    });
+      assert.strictEqual(res.total, 1);
+      assert.strictEqual(res.documents.length, 1);
+      assert.strictEqual(res.documents[0].id, '1');
+      assert.strictEqual(typeof res.documents[0].sortKey, 'string');
+      assert.deepStrictEqual(res.documents[0].value, { field: 'hello world' });
+    }, GLOBAL.SERVERS.OPEN);
 
-    assert.strictEqual(res.total, 1);
-    assert.strictEqual(res.documents.length, 1);
-    assert.strictEqual(res.documents[0].id, '1');
-    assert.strictEqual(typeof res.documents[0].sortKey, 'string');
-    assert.deepStrictEqual(res.documents[0].value, { field: 'hello world' });
-  }, GLOBAL.SERVERS.OPEN);
+    testUtils.testWithClient('WITHSCORES keeps a numeric id out of the score slot', async client => {
+      await Promise.all([
+        client.ft.create('index', { field: 'TEXT' }),
+        client.hSet('101', 'field', 'numeric id test')
+      ]);
 
-  testUtils.testWithClient('WITHSCORES keeps a numeric id out of the score slot', async client => {
-    await Promise.all([
-      client.ft.create('index', { field: 'TEXT' }),
-      client.hSet('101', 'field', 'numeric id test')
-    ]);
+      const res = await client.ft.search('index', '*', { WITHSCORES: true });
 
-    const res = await client.ft.search('index', '*', { WITHSCORES: true });
-
-    assert.strictEqual(res.total, 1);
-    assert.strictEqual(res.documents.length, 1);
-    assert.strictEqual(res.documents[0].id, '101');
-    assert.strictEqual(typeof res.documents[0].score, 'number');
-    assert.deepStrictEqual(res.documents[0].value, { field: 'numeric id test' });
-  }, GLOBAL.SERVERS.OPEN);
+      assert.strictEqual(res.total, 1);
+      assert.strictEqual(res.documents.length, 1);
+      assert.strictEqual(res.documents[0].id, '101');
+      assert.strictEqual(typeof res.documents[0].score, 'number');
+      assert.deepStrictEqual(res.documents[0].value, { field: 'numeric id test' });
+    }, GLOBAL.SERVERS.OPEN);
 
     testUtils.testWithClient('FILTER', async client => {
-    await Promise.all([
-      client.ft.create('index', {
-        price: { type: 'NUMERIC' }
-      }),
-      client.hSet('doc:1', 'price', '15'),
-      client.hSet('doc:2', 'price', '50'),
-      client.hSet('doc:3', 'price', '120')
-    ]);
+      await Promise.all([
+        client.ft.create('index', {
+          price: { type: 'NUMERIC' }
+        }),
+        client.hSet('doc:1', 'price', '15'),
+        client.hSet('doc:2', 'price', '50'),
+        client.hSet('doc:3', 'price', '120')
+      ]);
 
-    const res = await client.ft.search('index', '*', {
-      FILTER: { field: 'price', min: 10, max: 100 }
-    });
+      const res = await client.ft.search('index', '*', {
+        FILTER: { field: 'price', min: 10, max: 100 }
+      });
 
-    assert.strictEqual(res.total, 2);
-    assert.strictEqual(res.documents.length, 2);
-    const ids = res.documents.map(d => d.id).sort();
-    assert.deepStrictEqual(ids, ['doc:1', 'doc:2']);
-  }, GLOBAL.SERVERS.OPEN);
+      assert.strictEqual(res.total, 2);
+      assert.strictEqual(res.documents.length, 2);
+      const ids = res.documents.map(d => d.id).sort();
+      assert.deepStrictEqual(ids, ['doc:1', 'doc:2']);
+    }, GLOBAL.SERVERS.OPEN);
 
-  testUtils.testWithClient('GEOFILTER', async client => {
-    await Promise.all([
-      client.ft.create('index', {
-        location: { type: 'GEO' }
-      }),
-      
-      client.hSet('doc:sf', 'location', '-122.4194,37.7749'),
-      client.hSet('doc:oakland', 'location', '-122.2711,37.8044')
-    ]);
+    testUtils.testWithClient('GEOFILTER', async client => {
+      await Promise.all([
+        client.ft.create('index', {
+          location: { type: 'GEO' }
+        }),
+        client.hSet('doc:sf', 'location', '-122.4194,37.7749'),
+        client.hSet('doc:oakland', 'location', '-122.2711,37.8044')
+      ]);
 
-    
-    const res = await client.ft.search('index', '*', {
-      GEOFILTER: {
-        field: 'location',
-        lon: -122.4194,
-        lat: 37.7749,
-        radius: 5,
-        unit: 'km'
-      }
-    });
+      const res = await client.ft.search('index', '*', {
+        GEOFILTER: {
+          field: 'location',
+          lon: -122.4194,
+          lat: 37.7749,
+          radius: 5,
+          unit: 'km'
+        }
+      });
 
-    assert.strictEqual(res.total, 1);
-    assert.strictEqual(res.documents[0].id, 'doc:sf');
-  }, GLOBAL.SERVERS.OPEN);
-
+      assert.strictEqual(res.total, 1);
+      assert.strictEqual(res.documents[0].id, 'doc:sf');
+    }, GLOBAL.SERVERS.OPEN);
 
     testUtils.testWithClient('PAYLOAD', async client => {
-    await Promise.all([
-      client.ft.create('index', { field: 'TEXT' }),
-      client.hSet('1', 'field', 'hello world')
-    ]);
+      await Promise.all([
+        client.ft.create('index', { field: 'TEXT' }),
+        client.hSet('1', 'field', 'hello world')
+      ]);
 
-    const res = await client.ft.search('index', '*', {
-      PAYLOAD: 'custom-eval-context'
-    });
+      const res = await client.ft.search('index', '*', {
+        PAYLOAD: 'custom-eval-context'
+      });
 
-    assert.strictEqual(res.total, 1);
-    assert.strictEqual(res.documents[0].id, '1');
-    assert.strictEqual(res.documents[0].payload, undefined); 
-    assert.deepStrictEqual(res.documents[0].value, { field: 'hello world' });
-  }, GLOBAL.SERVERS.OPEN);
+      assert.strictEqual(res.total, 1);
+      assert.strictEqual(res.documents[0].id, '1');
+      assert.strictEqual(res.documents[0].payload, undefined);
+      assert.deepStrictEqual(res.documents[0].value, { field: 'hello world' });
+    }, GLOBAL.SERVERS.OPEN);
 
     testUtils.testWithClient('with data', async client => {
       await Promise.all([
@@ -748,17 +738,18 @@ describe('FT.SEARCH', () => {
 
     }, GLOBAL.SERVERS.OPEN);
 
-  testUtils.testWithClient('WITHSORTKEYS honors BLOB_STRING', async client => {
-  await Promise.all([
-    client.ft.create('index', { field: { type: 'TEXT', SORTABLE: true } }),
-    client.hSet('1', 'field', 'hello world')
-  ]);
-  const res = await client
-    .withTypeMapping({ [RESP_TYPES.BLOB_STRING]: Buffer })
-    .ft.search('index', '*', { SORTBY: 'field', WITHSORTKEYS: true });
-  assert.ok(Buffer.isBuffer(res.documents[0].sortKey));
-}, GLOBAL.SERVERS.OPEN);
+    testUtils.testWithClient('WITHSORTKEYS honors BLOB_STRING', async client => {
+      await Promise.all([
+        client.ft.create('index', { field: { type: 'TEXT', SORTABLE: true } }),
+        client.hSet('1', 'field', 'hello world')
+      ]);
 
+      const res = await client
+        .withTypeMapping({ [RESP_TYPES.BLOB_STRING]: Buffer })
+        .ft.search('index', '*', { SORTBY: 'field', WITHSORTKEYS: true });
+
+      assert.ok(Buffer.isBuffer(res.documents[0].sortKey));
+    }, GLOBAL.SERVERS.OPEN);
   });
 
   describe('non-English languages', () => {

--- a/packages/search/lib/commands/SEARCH.spec.ts
+++ b/packages/search/lib/commands/SEARCH.spec.ts
@@ -10,7 +10,7 @@ describe('FT.SEARCH', () => {
   describe('transformArguments', () => {
     it('without options', () => {
       assert.deepEqual(
-        parseArgs(SEARCH, 'index', 'query'),
+        Array.from(parseArgs(SEARCH, 'index', 'query')),
         ['FT.SEARCH', 'index', 'query', 'DIALECT', DEFAULT_DIALECT]
       );
     });
@@ -39,15 +39,6 @@ describe('FT.SEARCH', () => {
           WITHSCORES:true
         })),
         ['FT.SEARCH','index','query','WITHSCORES','DIALECT',DEFAULT_DIALECT]
-      )
-    })
-
-     it('with NOCONTENT',() => {
-      assert.deepEqual(
-        Array.from(parseArgs(SEARCH,'index','query',{
-          NOCONTENT:true
-        })),
-        ['FT.SEARCH','index','query','NOCONTENT','DIALECT',DEFAULT_DIALECT]
       )
     })
 
@@ -391,11 +382,18 @@ describe('FT.SEARCH', () => {
       );
     });
 
-    it('stores the options for use by transformReply', () => {
-    const options = { WITHSCORES: true, NOCONTENT: true };
-    const args = parseArgs(SEARCH, 'index', 'query', options);
-    assert.deepEqual(args.preserve, options);
-  });
+    it('preserves a frozen layout snapshot for transformReply', () => {
+      const args = parseArgs(SEARCH, 'index', 'query', { WITHSCORES: true, RETURN: ['a'] });
+      assert.deepEqual(args.preserve, {
+        WITHSCORES: true,
+        EXPLAINSCORE: false,
+        NOCONTENT: false,
+        WITHPAYLOADS: false,
+        WITHSORTKEYS: false,
+        RETURN: ['a']
+      });
+      assert.ok(Object.isFrozen(args.preserve));
+    });
   });
 
   describe('transformReply', () => {
@@ -502,8 +500,11 @@ describe('FT.SEARCH', () => {
     assert.strictEqual(res.documents.length, 1);
     assert.strictEqual(res.documents[0].id, '1');
     assert.strictEqual(typeof res.documents[0].score, 'number');
-    assert.ok(Array.isArray(res.documents[0].scoreExplain));
-    assert.ok(res.documents[0].scoreExplain.length > 0);
+    // scoreExplain is a single recursive `[summary, children]` node.
+    const explain = res.documents[0].scoreExplain;
+    assert.ok(Array.isArray(explain), 'scoreExplain is a [summary, children] node');
+    assert.strictEqual(typeof explain[0], 'string');
+    assert.ok(Array.isArray(explain[1]));
   }, GLOBAL.SERVERS.OPEN);
 
      testUtils.testWithClient('WITHSCORES', async client => {
@@ -523,19 +524,18 @@ describe('FT.SEARCH', () => {
       
     }, GLOBAL.SERVERS.OPEN);
 
-    testUtils.testWithClient('NOCONTENT', async client => {
-    await Promise.all([
-      client.ft.create('index', { field: 'TEXT' }),
-      client.hSet('1', 'field', 'hello world')
-    ]);
+    testUtils.testWithClient('WITHSCORES honors the DOUBLE type mapping', async client => {
+      await Promise.all([
+        client.ft.create('index', { field: 'TEXT' }),
+        client.hSet('1', 'field', 'hello world')
+      ]);
 
-    const res = await client.ft.search('index', '*', { NOCONTENT: true });
+      const res = await client
+        .withTypeMapping({ [RESP_TYPES.DOUBLE]: String })
+        .ft.search('index', 'hello', { WITHSCORES: true });
 
-    assert.strictEqual(res.total, 1);
-    assert.strictEqual(res.documents.length, 1);
-    assert.strictEqual(res.documents[0].id, '1');
-    assert.deepStrictEqual(res.documents[0].value, {});
-  }, GLOBAL.SERVERS.OPEN);
+      assert.strictEqual(typeof res.documents[0].score, 'string');
+    }, GLOBAL.SERVERS.OPEN);
 
     testUtils.testWithClient('WITHPAYLOADS', async client => {
     await Promise.all([
@@ -575,22 +575,19 @@ describe('FT.SEARCH', () => {
     assert.deepStrictEqual(res.documents[0].value, { field: 'hello world' });
   }, GLOBAL.SERVERS.OPEN);
 
-  testUtils.testWithClient('WITHSCORES + NOCONTENT', async client => {
+  testUtils.testWithClient('WITHSCORES keeps a numeric id out of the score slot', async client => {
     await Promise.all([
       client.ft.create('index', { field: 'TEXT' }),
       client.hSet('101', 'field', 'numeric id test')
     ]);
 
-    const res = await client.ft.search('index', '*', {
-      WITHSCORES: true,
-      NOCONTENT: true
-    });
+    const res = await client.ft.search('index', '*', { WITHSCORES: true });
 
     assert.strictEqual(res.total, 1);
     assert.strictEqual(res.documents.length, 1);
     assert.strictEqual(res.documents[0].id, '101');
     assert.strictEqual(typeof res.documents[0].score, 'number');
-    assert.deepStrictEqual(res.documents[0].value, {});
+    assert.deepStrictEqual(res.documents[0].value, { field: 'numeric id test' });
   }, GLOBAL.SERVERS.OPEN);
 
     testUtils.testWithClient('FILTER', async client => {
@@ -751,20 +748,6 @@ describe('FT.SEARCH', () => {
 
     }, GLOBAL.SERVERS.OPEN);
 
-  testUtils.testWithClient('NOCONTENT takes precedence over a conflicting RETURN', async client => {
-  await Promise.all([
-    client.ft.create('index', { title: 'TEXT', price: 'NUMERIC' }),
-    client.hSet('1', { title: 'Widget', price: '9.99' })
-  ]);
-  const res = await client.ft.search('index', '*', {
-    NOCONTENT: true,
-    RETURN: ['title', 'price']
-  });
-  assert.strictEqual(res.total, 1);
-  assert.deepStrictEqual(res.documents[0].value, {});
-}, GLOBAL.SERVERS.OPEN);
-
-  
   testUtils.testWithClient('WITHSORTKEYS honors BLOB_STRING', async client => {
   await Promise.all([
     client.ft.create('index', { field: { type: 'TEXT', SORTABLE: true } }),

--- a/packages/search/lib/commands/SEARCH.ts
+++ b/packages/search/lib/commands/SEARCH.ts
@@ -26,6 +26,15 @@ export function parseParamsArgument(parser: CommandParser, params?: FtSearchPara
   }
 }
 
+function numericFilterBound(value:number | RedisArgument):RedisArgument{
+  if (typeof value === 'number'){
+    if (value === Infinity) return '+inf';
+    if (value === -Infinity) return '-inf';
+    return value.toString();
+  }
+  return value;
+}
+
 export interface FtSearchOptions {
   VERBATIM?: boolean;
   NOSTOPWORDS?: boolean;
@@ -123,7 +132,7 @@ export function parseSearchOptions(parser: CommandParser, options?: FtSearchOpti
   if (options?.FILTER) {
     const filters = Array.isArray(options.FILTER) ? options.FILTER : [options.FILTER];
     for (const filter of filters) {
-      parser.push('FILTER', filter.field, filter.min.toString(), filter.max.toString());
+      parser.push('FILTER', filter.field, numericFilterBound(filter.min), numericFilterBound(filter.max));
     }
   }
 
@@ -228,14 +237,14 @@ export function parseSearchOptions(parser: CommandParser, options?: FtSearchOpti
 function transformSearchReplyResp2(
   reply: SearchRawReply,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches TransformReply contract
-  _preserve?: any,
+  _preserve?: unknown,
   _typeMapping?: TypeMapping,
-  options?: FtSearchOptions
 ): SearchReply {
+  const options = _preserve as FtSearchOptions | undefined;
   const documents: SearchReply['documents'] = [];
   
   const hasScores = Boolean(options?.WITHSCORES);
-  const hasExplain = Boolean(options?.EXPLAINSCORE);
+  const hasExplain = Boolean(options?.EXPLAINSCORE) || Boolean(options?.EXPLAINSCORE);
   const hasPayloads = Boolean(options?.WITHPAYLOADS);
   const hasSortKeys = Boolean(options?.WITHSORTKEYS);
   const noContent = Boolean(options?.NOCONTENT);
@@ -296,10 +305,9 @@ function transformSearchReplyResp3(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches TransformReply contract
   preserve?: any,
   typeMapping?: TypeMapping,
-  options?: FtSearchOptions
 ): SearchReply {
   if (Array.isArray(rawReply)) {
-    return transformSearchReplyResp2(rawReply as SearchRawReply, preserve, typeMapping,options);
+    return transformSearchReplyResp2(rawReply as SearchRawReply, preserve, typeMapping);
   }
 
   const reply = mapLikeToObject(rawReply);
@@ -355,6 +363,7 @@ export default {
     parser.push('FT.SEARCH', index, query);
 
     parseSearchOptions(parser, options);
+    parser.preserve = options;
   },
   transformReply: {
     2: transformSearchReplyResp2,

--- a/packages/search/lib/commands/SEARCH.ts
+++ b/packages/search/lib/commands/SEARCH.ts
@@ -6,6 +6,7 @@ import { DEFAULT_DIALECT } from '../dialect/default';
 import { getMapValue, mapLikeToObject, mapLikeValues, parseDocumentValue, parseSearchResultRow, parseWarnings } from './reply-transformers';
 
 export type FtSearchParams = Record<string, RedisArgument | number>;
+export type ScoreExplain = string | [string, Array<ScoreExplain>];
 
 export function parseParamsArgument(parser: CommandParser, params?: FtSearchParams) {
   if (params) {
@@ -33,6 +34,14 @@ function numericFilterBound(value:number | RedisArgument):RedisArgument{
     return value.toString();
   }
   return value;
+}
+
+function normalizeScoreExplain(raw: unknown): ScoreExplain {
+  if (Array.isArray(raw)) {
+    const [summary, children] = raw;
+    return [String(summary), Array.isArray(children) ? children.map(normalizeScoreExplain) : []];
+  }
+  return String(raw);
 }
 
 export interface FtSearchOptions {
@@ -203,7 +212,7 @@ export function parseSearchOptions(parser: CommandParser, options?: FtSearchOpti
     parser.push('SCORER', options.SCORER);
   }
 
-  if (options?.PAYLOAD) {
+  if (options?.PAYLOAD != undefined) {
     parser.push('PAYLOAD', options.PAYLOAD);
   }
 
@@ -243,11 +252,12 @@ function transformSearchReplyResp2(
   const options = _preserve as FtSearchOptions | undefined;
   const documents: SearchReply['documents'] = [];
   
-  const hasScores = Boolean(options?.WITHSCORES);
-  const hasExplain = Boolean(options?.EXPLAINSCORE) || Boolean(options?.EXPLAINSCORE);
+  const hasScores = Boolean(options?.WITHSCORES) || Boolean(options?.EXPLAINSCORE);
+  const hasExplain = Boolean(options?.EXPLAINSCORE); 
   const hasPayloads = Boolean(options?.WITHPAYLOADS);
   const hasSortKeys = Boolean(options?.WITHSORTKEYS);
-  const noContent = Boolean(options?.NOCONTENT);
+  const noContent = Boolean(options?.NOCONTENT) ||
+    (Array.isArray(options?.RETURN) && options.RETURN.length === 0);
 
   let i = 1;
   while (i < reply.length) {
@@ -255,26 +265,26 @@ function transformSearchReplyResp2(
     const id = reply[i++] as string;
 
     let score: number | undefined;
-    let scoreExplain: Array<string> | undefined;
+    let scoreExplain: Array<ScoreExplain> | undefined;
 
     if (hasScores) {
       if (hasExplain && Array.isArray(reply[i])) {
-        const tuple = reply[i++] as [string | number, Array<string>];
+        const tuple = reply[i++] as [string | number, unknown];
         score = Number(tuple[0]);
-        scoreExplain = tuple[1];
+        scoreExplain = Array.isArray(tuple[1]) ? tuple[1].map(normalizeScoreExplain) : undefined;
       } else {
         score = Number(reply[i++]);
       }
     }
 
-    let payload: string | undefined;
+    let payload: string |Buffer | undefined;
     if (hasPayloads){
-      payload = reply[i++] as string;
+      payload = reply[i++] as string | Buffer;
     }
 
-    let sortKey: string | undefined;
+    let sortKey: string | Buffer | undefined;
     if (hasSortKeys) {
-      sortKey = reply[i++] as string;
+      sortKey = reply[i++] as string | Buffer;
     }
 
     let value: SearchDocumentValue = {};
@@ -326,12 +336,12 @@ function transformSearchReplyResp3(
     const rawSortKey = getMapValue(resultMap, ['sortkey']);
 
     let score: number | undefined
-    let scoreExplain: Array<string> | undefined;
+    let scoreExplain: Array<ScoreExplain> | undefined;
 
     if (Array.isArray(rawScore)){
       score = Number(rawScore[0]);
       if (Array.isArray(rawScore[1])){
-        scoreExplain = rawScore[1].map(String);
+        scoreExplain = rawScore[1].map(normalizeScoreExplain);
       }
     } else if (rawScore !== undefined && rawScore !== null){
       score = typeof rawScore === 'number' ? rawScore : Number(rawScore);
@@ -341,8 +351,8 @@ function transformSearchReplyResp3(
       id: String((id as { toString?(): string })?.toString?.() ?? id ?? ''),
       ...(score !== undefined && !isNaN(score) ? {score} : {}),
       ...(scoreExplain !== undefined ? {scoreExplain} : {}),
-      ...(rawPayload !== undefined && rawPayload !== null? {payload: String(rawPayload)} : {}),
-      ...(rawSortKey !== undefined && rawSortKey !== null ? {sortKey: String(rawSortKey)} : {}),
+      ...(rawPayload !== undefined && rawPayload !== null? {payload: rawPayload as string | Buffer} : {}),
+      ...(rawSortKey !== undefined && rawSortKey !== null ? {sortKey: rawSortKey as string | Buffer}: {}),
       value: value as SearchDocumentValue
     };
   });
@@ -382,9 +392,9 @@ export interface SearchReply {
   documents: Array<{
       id: string;
       score?: number;
-      scoreExplain?: Array<string>;
-      payload?: string;
-      sortKey?: string;
+      scoreExplain?: Array<ScoreExplain>;
+      payload?: string | Buffer;
+      sortKey?: string | Buffer;
       value: SearchDocumentValue;
   }>;
   /**

--- a/packages/search/lib/commands/SEARCH.ts
+++ b/packages/search/lib/commands/SEARCH.ts
@@ -30,6 +30,7 @@ export interface FtSearchOptions {
   VERBATIM?: boolean;
   NOSTOPWORDS?: boolean;
   INKEYS?: RedisVariadicArgument;
+  WITHSCORES?: boolean;
   INFIELDS?: RedisVariadicArgument;
   RETURN?: RedisVariadicArgument;
   SUMMARIZE?: boolean | {
@@ -70,6 +71,10 @@ export function parseSearchOptions(parser: CommandParser, options?: FtSearchOpti
 
   if (options?.NOSTOPWORDS) {
     parser.push('NOSTOPWORDS');
+  }
+
+  if (options?.WITHSCORES) {
+    parser.push('WITHSCORES');
   }
 
   parseOptionalVariadicArgument(parser, 'INKEYS', options?.INKEYS);
@@ -171,8 +176,14 @@ function transformSearchReplyResp2(
   const documents: SearchReply['documents'] = [];
   let i = 1;
   while (i < reply.length) {
+    let score: number | undefined;
+
+    if(typeof reply[i] === 'number' || (typeof reply[i] === 'string' && !isNaN(Number(reply[i])) && Array.isArray(reply[i + 1]))){
+      score = Number(reply[i++]);
+    }
     documents.push({
       id: reply[i++] as string,
+      ...(score !== undefined ? {score} : {}),
       value: (withoutDocuments ? {} : documentValue(reply[i++])) as SearchDocumentValue
     });
   }
@@ -203,9 +214,15 @@ function transformSearchReplyResp3(
   );
 
   const documents: SearchReply['documents'] = results.map(result => {
+    const resultMap = mapLikeToObject(result);
     const { id, value } = parseSearchResultRow(result);
+    
+    const rawScore = getMapValue(resultMap,['score']);
+    const score = rawScore !== undefined ? Number(rawScore) : undefined;
+
     return {
       id: String((id as { toString?(): string })?.toString?.() ?? id ?? ''),
+      ...(score !== undefined && !isNaN(score) ? {score} : {}),
       value: value as SearchDocumentValue
     };
   });
@@ -243,6 +260,7 @@ export interface SearchReply {
   total: number;
   documents: Array<{
       id: string;
+      score?: number;
       value: SearchDocumentValue;
   }>;
   /**

--- a/packages/search/lib/commands/SEARCH.ts
+++ b/packages/search/lib/commands/SEARCH.ts
@@ -104,7 +104,7 @@ export function parseSearchOptions(parser: CommandParser, options?: FtSearchOpti
     parser.push('NOCONTENT');
   }
 
-  if (options?.WITHSCORES) {
+  if (options?.WITHSCORES || options?.EXPLAINSCORE) {
     parser.push('WITHSCORES');
   }
 
@@ -333,8 +333,8 @@ function transformSearchReplyResp3(
       id: String((id as { toString?(): string })?.toString?.() ?? id ?? ''),
       ...(score !== undefined && !isNaN(score) ? {score} : {}),
       ...(scoreExplain !== undefined ? {scoreExplain} : {}),
-      ...(rawPayload !== undefined ? {payload: String(rawPayload)} : {}),
-      ...(rawSortKey !== undefined ? {sortKey: String(rawSortKey)} : {}),
+      ...(rawPayload !== undefined && rawPayload !== null? {payload: String(rawPayload)} : {}),
+      ...(rawSortKey !== undefined && rawSortKey !== null ? {sortKey: String(rawSortKey)} : {}),
       value: value as SearchDocumentValue
     };
   });

--- a/packages/search/lib/commands/SEARCH.ts
+++ b/packages/search/lib/commands/SEARCH.ts
@@ -31,6 +31,32 @@ export interface FtSearchOptions {
   NOSTOPWORDS?: boolean;
   INKEYS?: RedisVariadicArgument;
   WITHSCORES?: boolean;
+  EXPLAINSCORE?: boolean;
+  NOCONTENT?: boolean;
+  WITHPAYLOADS?: boolean;
+  WITHSORTKEYS?: boolean;
+  FILTER?: {
+    field: RedisArgument;
+    min: number | RedisArgument;
+    max: number | RedisArgument;
+  } | Array<{
+    field: RedisArgument;
+    min: number | RedisArgument;
+    max: number | RedisArgument;
+  }>;
+  GEOFILTER?: {
+    field: RedisArgument;
+    lon: number;
+    lat: number;
+    radius: number;
+    unit: 'm' | 'km' | 'mi' | 'ft';
+  } | Array<{
+    field: RedisArgument;
+    lon: number;
+    lat: number;
+    radius: number;
+    unit: 'm' | 'km' | 'mi' | 'ft';
+  }>;
   INFIELDS?: RedisVariadicArgument;
   RETURN?: RedisVariadicArgument;
   SUMMARIZE?: boolean | {
@@ -52,6 +78,7 @@ export interface FtSearchOptions {
   LANGUAGE?: RediSearchLanguage;
   EXPANDER?: RedisArgument;
   SCORER?: RedisArgument;
+  PAYLOAD?: RedisArgument;
   SORTBY?: RedisArgument | {
     BY: RedisArgument;
     DIRECTION?: 'ASC' | 'DESC';
@@ -73,8 +100,38 @@ export function parseSearchOptions(parser: CommandParser, options?: FtSearchOpti
     parser.push('NOSTOPWORDS');
   }
 
+  if(options?.NOCONTENT) {
+    parser.push('NOCONTENT');
+  }
+
   if (options?.WITHSCORES) {
     parser.push('WITHSCORES');
+  }
+
+  if (options?.EXPLAINSCORE) {
+    parser.push('EXPLAINSCORE');
+  }
+
+  if(options?.WITHPAYLOADS) {
+    parser.push('WITHPAYLOADS');
+  }
+
+  if(options?.WITHSORTKEYS) {
+    parser.push('WITHSORTKEYS');
+  }
+
+  if (options?.FILTER) {
+    const filters = Array.isArray(options.FILTER) ? options.FILTER : [options.FILTER];
+    for (const filter of filters) {
+      parser.push('FILTER', filter.field, filter.min.toString(), filter.max.toString());
+    }
+  }
+
+  if (options?.GEOFILTER) {
+    const geofilters = Array.isArray(options.GEOFILTER) ? options.GEOFILTER : [options.GEOFILTER];
+    for (const geo of geofilters) {
+      parser.push('GEOFILTER', geo.field, geo.lon.toString(), geo.lat.toString(), geo.radius.toString(), geo.unit);
+    }
   }
 
   parseOptionalVariadicArgument(parser, 'INKEYS', options?.INKEYS);
@@ -137,6 +194,10 @@ export function parseSearchOptions(parser: CommandParser, options?: FtSearchOpti
     parser.push('SCORER', options.SCORER);
   }
 
+  if (options?.PAYLOAD) {
+    parser.push('PAYLOAD', options.PAYLOAD);
+  }
+
   if (options?.SORTBY) {
     parser.push('SORTBY');
 
@@ -168,23 +229,57 @@ function transformSearchReplyResp2(
   reply: SearchRawReply,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches TransformReply contract
   _preserve?: any,
-  _typeMapping?: TypeMapping
+  _typeMapping?: TypeMapping,
+  options?: FtSearchOptions
 ): SearchReply {
-  // if reply[2] is array, then we have content/documents. Otherwise, only ids
-  const withoutDocuments = reply.length > 2 && !Array.isArray(reply[2]);
-
   const documents: SearchReply['documents'] = [];
+  
+  const hasScores = Boolean(options?.WITHSCORES);
+  const hasExplain = Boolean(options?.EXPLAINSCORE);
+  const hasPayloads = Boolean(options?.WITHPAYLOADS);
+  const hasSortKeys = Boolean(options?.WITHSORTKEYS);
+  const noContent = Boolean(options?.NOCONTENT);
+
   let i = 1;
   while (i < reply.length) {
-    let score: number | undefined;
+  
+    const id = reply[i++] as string;
 
-    if(typeof reply[i] === 'number' || (typeof reply[i] === 'string' && !isNaN(Number(reply[i])) && Array.isArray(reply[i + 1]))){
-      score = Number(reply[i++]);
+    let score: number | undefined;
+    let scoreExplain: Array<string> | undefined;
+
+    if (hasScores) {
+      if (hasExplain && Array.isArray(reply[i])) {
+        const tuple = reply[i++] as [string | number, Array<string>];
+        score = Number(tuple[0]);
+        scoreExplain = tuple[1];
+      } else {
+        score = Number(reply[i++]);
+      }
     }
+
+    let payload: string | undefined;
+    if (hasPayloads){
+      payload = reply[i++] as string;
+    }
+
+    let sortKey: string | undefined;
+    if (hasSortKeys) {
+      sortKey = reply[i++] as string;
+    }
+
+    let value: SearchDocumentValue = {};
+    if (!noContent) {
+      value = documentValue(reply[i++]) as SearchDocumentValue;
+    }
+
     documents.push({
-      id: reply[i++] as string,
-      ...(score !== undefined ? {score} : {}),
-      value: (withoutDocuments ? {} : documentValue(reply[i++])) as SearchDocumentValue
+      id,
+      ...(score !== undefined && !isNaN(score) ? {score} : {}),
+      ...(scoreExplain !== undefined ? {scoreExplain} : {}),
+      ...(payload !== undefined ? {payload} : {}),
+      ...(sortKey !== undefined ? {sortKey} : {}),
+      value,
     });
   }
 
@@ -200,10 +295,11 @@ function transformSearchReplyResp3(
   rawReply: ReplyUnion,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches TransformReply contract
   preserve?: any,
-  typeMapping?: TypeMapping
+  typeMapping?: TypeMapping,
+  options?: FtSearchOptions
 ): SearchReply {
   if (Array.isArray(rawReply)) {
-    return transformSearchReplyResp2(rawReply as SearchRawReply, preserve, typeMapping);
+    return transformSearchReplyResp2(rawReply as SearchRawReply, preserve, typeMapping,options);
   }
 
   const reply = mapLikeToObject(rawReply);
@@ -218,11 +314,27 @@ function transformSearchReplyResp3(
     const { id, value } = parseSearchResultRow(result);
     
     const rawScore = getMapValue(resultMap,['score']);
-    const score = rawScore !== undefined ? Number(rawScore) : undefined;
+    const rawPayload = getMapValue(resultMap, ['payload']);
+    const rawSortKey = getMapValue(resultMap, ['sortkey']);
+
+    let score: number | undefined
+    let scoreExplain: Array<string> | undefined;
+
+    if (Array.isArray(rawScore)){
+      score = Number(rawScore[0]);
+      if (Array.isArray(rawScore[1])){
+        scoreExplain = rawScore[1].map(String);
+      }
+    } else if (rawScore !== undefined && rawScore !== null){
+      score = typeof rawScore === 'number' ? rawScore : Number(rawScore);
+    }
 
     return {
       id: String((id as { toString?(): string })?.toString?.() ?? id ?? ''),
       ...(score !== undefined && !isNaN(score) ? {score} : {}),
+      ...(scoreExplain !== undefined ? {scoreExplain} : {}),
+      ...(rawPayload !== undefined ? {payload: String(rawPayload)} : {}),
+      ...(rawSortKey !== undefined ? {sortKey: String(rawSortKey)} : {}),
       value: value as SearchDocumentValue
     };
   });
@@ -261,6 +373,9 @@ export interface SearchReply {
   documents: Array<{
       id: string;
       score?: number;
+      scoreExplain?: Array<string>;
+      payload?: string;
+      sortKey?: string;
       value: SearchDocumentValue;
   }>;
   /**

--- a/packages/search/lib/commands/SEARCH.ts
+++ b/packages/search/lib/commands/SEARCH.ts
@@ -1,12 +1,12 @@
 import { CommandParser } from '@redis/client/dist/lib/client/parser';
 import { RedisArgument, Command, ReplyUnion, TypeMapping, DoubleReply, BlobStringReply } from '@redis/client/dist/lib/RESP/types';
-import { RedisVariadicArgument, parseOptionalVariadicArgument, transformDoubleReply } from '@redis/client/dist/lib/commands/generic-transformers';
+import { RedisVariadicArgument, parseOptionalVariadicArgument, transformDoubleReply, transformStringDoubleArgument } from '@redis/client/dist/lib/commands/generic-transformers';
 import { RediSearchLanguage } from './CREATE';
 import { DEFAULT_DIALECT } from '../dialect/default';
 import { getMapValue, mapLikeToObject, mapLikeValues, parseDocumentValue, parseSearchResultRow, parseWarnings } from './reply-transformers';
 
 export type FtSearchParams = Record<string, RedisArgument | number>;
-export type ScoreExplain = string  | Buffer| [string | Buffer, Array<ScoreExplain>];
+export type ScoreExplain = string | Buffer | [string | Buffer, Array<ScoreExplain>];
 
 export function parseParamsArgument(parser: CommandParser, params?: FtSearchParams) {
   if (params) {
@@ -27,15 +27,6 @@ export function parseParamsArgument(parser: CommandParser, params?: FtSearchPara
   }
 }
 
-function numericFilterBound(value:number | RedisArgument):RedisArgument{
-  if (typeof value === 'number'){
-    if (value === Infinity) return '+inf';
-    if (value === -Infinity) return '-inf';
-    return value.toString();
-  }
-  return value;
-}
-
 function normalizeScoreExplain(raw: unknown): ScoreExplain {
   if (Array.isArray(raw)) {
     const [summary, children] = raw;
@@ -46,36 +37,60 @@ function normalizeScoreExplain(raw: unknown): ScoreExplain {
   return Buffer.isBuffer(raw) ? raw: String(raw);
 }
 
+export interface SearchNumericFilter {
+  field: RedisArgument;
+  /**
+   * Inclusive lower bound. Use `-Infinity` for an open bound, or a string
+   * such as `'(10'` for an exclusive bound.
+   */
+  min: number | RedisArgument;
+  /**
+   * Inclusive upper bound. Use `Infinity` for an open bound, or a string
+   * such as `'(100'` for an exclusive bound.
+   */
+  max: number | RedisArgument;
+}
+
+export interface SearchGeoFilter {
+  field: RedisArgument;
+  lon: number;
+  lat: number;
+  radius: number;
+  unit: 'm' | 'km' | 'mi' | 'ft';
+}
+
 export interface FtSearchOptions {
   VERBATIM?: boolean;
   NOSTOPWORDS?: boolean;
   INKEYS?: RedisVariadicArgument;
+  /**
+   * Also return the relevance score of each document, exposed as `score` on
+   * each reply document.
+   */
   WITHSCORES?: boolean;
+  /**
+   * Return a textual explanation of how each score was computed, exposed as
+   * `scoreExplain` on each reply document. Implies `WITHSCORES`.
+   */
   EXPLAINSCORE?: boolean;
+  /**
+   * Also return each document's payload (set at indexing time), exposed as
+   * `payload` on each reply document.
+   */
   WITHPAYLOADS?: boolean;
+  /**
+   * Also return the value of the sorting key, exposed as `sortKey` on each
+   * reply document. Only relevant together with `SORTBY`.
+   */
   WITHSORTKEYS?: boolean;
-  FILTER?: {
-    field: RedisArgument;
-    min: number | RedisArgument;
-    max: number | RedisArgument;
-  } | Array<{
-    field: RedisArgument;
-    min: number | RedisArgument;
-    max: number | RedisArgument;
-  }>;
-  GEOFILTER?: {
-    field: RedisArgument;
-    lon: number;
-    lat: number;
-    radius: number;
-    unit: 'm' | 'km' | 'mi' | 'ft';
-  } | Array<{
-    field: RedisArgument;
-    lon: number;
-    lat: number;
-    radius: number;
-    unit: 'm' | 'km' | 'mi' | 'ft';
-  }>;
+  /**
+   * Limit results to a numeric range on one or more numeric fields.
+   */
+  FILTER?: SearchNumericFilter | Array<SearchNumericFilter>;
+  /**
+   * Limit results to a geographic radius on one or more geo fields.
+   */
+  GEOFILTER?: SearchGeoFilter | Array<SearchGeoFilter>;
   INFIELDS?: RedisVariadicArgument;
   RETURN?: RedisVariadicArgument;
   SUMMARIZE?: boolean | {
@@ -97,6 +112,10 @@ export interface FtSearchOptions {
   LANGUAGE?: RediSearchLanguage;
   EXPANDER?: RedisArgument;
   SCORER?: RedisArgument;
+  /**
+   * An arbitrary payload passed to the scoring function (see `SCORER`).
+   * Not returned in the reply.
+   */
   PAYLOAD?: RedisArgument;
   SORTBY?: RedisArgument | {
     BY: RedisArgument;
@@ -127,18 +146,18 @@ export function parseSearchOptions(parser: CommandParser, options?: FtSearchOpti
     parser.push('EXPLAINSCORE');
   }
 
-  if(options?.WITHPAYLOADS) {
+  if (options?.WITHPAYLOADS) {
     parser.push('WITHPAYLOADS');
   }
 
-  if(options?.WITHSORTKEYS) {
+  if (options?.WITHSORTKEYS) {
     parser.push('WITHSORTKEYS');
   }
 
   if (options?.FILTER) {
     const filters = Array.isArray(options.FILTER) ? options.FILTER : [options.FILTER];
     for (const filter of filters) {
-      parser.push('FILTER', filter.field, numericFilterBound(filter.min), numericFilterBound(filter.max));
+      parser.push('FILTER', filter.field, transformStringDoubleArgument(filter.min), transformStringDoubleArgument(filter.max));
     }
   }
 
@@ -269,7 +288,7 @@ function transformSearchReplyResp2(
   reply: SearchRawReply,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches TransformReply contract
   preserve?: any,
-  typeMapping?: TypeMapping,
+  typeMapping?: TypeMapping
 ): SearchReply {
   const options = preserve as Partial<SearchLayoutOptions> | undefined;
   const documents: SearchReply['documents'] = [];
@@ -327,7 +346,7 @@ function transformSearchReplyResp2(
       ...(scoreExplain !== undefined ? { scoreExplain } : {}),
       ...(payload !== undefined ? { payload } : {}),
       ...(sortKey !== undefined ? { sortKey } : {}),
-      value,
+      value
     });
   }
 
@@ -343,7 +362,7 @@ function transformSearchReplyResp3(
   rawReply: ReplyUnion,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches TransformReply contract
   preserve?: any,
-  typeMapping?: TypeMapping,
+  typeMapping?: TypeMapping
 ): SearchReply {
   if (Array.isArray(rawReply)) {
     return transformSearchReplyResp2(rawReply as SearchRawReply, preserve, typeMapping);
@@ -359,8 +378,8 @@ function transformSearchReplyResp3(
   const documents: SearchReply['documents'] = results.map(result => {
     const resultMap = mapLikeToObject(result);
     const { id, value } = parseSearchResultRow(result);
-    
-    const rawScore = getMapValue(resultMap,['score']);
+
+    const rawScore = getMapValue(resultMap, ['score']);
     const rawPayload = getMapValue(resultMap, ['payload']);
     const rawSortKey = getMapValue(resultMap, ['sortkey']);
 
@@ -382,10 +401,10 @@ function transformSearchReplyResp3(
 
     return {
       id: String((id as { toString?(): string })?.toString?.() ?? id ?? ''),
-      ...(score !== undefined && score !== null ? {score} : {}),
-      ...(scoreExplain !== undefined ? {scoreExplain} : {}),
-      ...(rawPayload !== undefined && rawPayload !== null? {payload: rawPayload as string | Buffer} : {}),
-      ...(rawSortKey !== undefined && rawSortKey !== null ? {sortKey: rawSortKey as string | Buffer}: {}),
+      ...(score !== undefined && score !== null ? { score } : {}),
+      ...(scoreExplain !== undefined ? { scoreExplain } : {}),
+      ...(rawPayload !== undefined && rawPayload !== null ? { payload: rawPayload as string | Buffer } : {}),
+      ...(rawSortKey !== undefined && rawSortKey !== null ? { sortKey: rawSortKey as string | Buffer } : {}),
       value: value as SearchDocumentValue
     };
   });
@@ -423,9 +442,24 @@ export interface SearchReply {
   total: number;
   documents: Array<{
       id: string;
+      /**
+       * Relevance score; present when `WITHSCORES` or `EXPLAINSCORE` was set.
+       * A number by default; follows the client's `DOUBLE` type mapping.
+       */
       score?: DoubleReply;
+      /**
+       * Score explanation tree; present when `EXPLAINSCORE` was set.
+       */
       scoreExplain?: ScoreExplain;
+      /**
+       * Document payload; present when `WITHPAYLOADS` was set and the
+       * document has a payload.
+       */
       payload?: string | Buffer;
+      /**
+       * Sorting-key value; present when `WITHSORTKEYS` was set and the
+       * document has one (see `SORTBY`).
+       */
       sortKey?: string | Buffer;
       value: SearchDocumentValue;
   }>;

--- a/packages/search/lib/commands/SEARCH.ts
+++ b/packages/search/lib/commands/SEARCH.ts
@@ -1,6 +1,6 @@
 import { CommandParser } from '@redis/client/dist/lib/client/parser';
-import { RedisArgument, Command, ReplyUnion, TypeMapping } from '@redis/client/dist/lib/RESP/types';
-import { RedisVariadicArgument, parseOptionalVariadicArgument } from '@redis/client/dist/lib/commands/generic-transformers';
+import { RedisArgument, Command, ReplyUnion, TypeMapping, DoubleReply, BlobStringReply } from '@redis/client/dist/lib/RESP/types';
+import { RedisVariadicArgument, parseOptionalVariadicArgument, transformDoubleReply } from '@redis/client/dist/lib/commands/generic-transformers';
 import { RediSearchLanguage } from './CREATE';
 import { DEFAULT_DIALECT } from '../dialect/default';
 import { getMapValue, mapLikeToObject, mapLikeValues, parseDocumentValue, parseSearchResultRow, parseWarnings } from './reply-transformers';
@@ -52,7 +52,6 @@ export interface FtSearchOptions {
   INKEYS?: RedisVariadicArgument;
   WITHSCORES?: boolean;
   EXPLAINSCORE?: boolean;
-  NOCONTENT?: boolean;
   WITHPAYLOADS?: boolean;
   WITHSORTKEYS?: boolean;
   FILTER?: {
@@ -118,10 +117,6 @@ export function parseSearchOptions(parser: CommandParser, options?: FtSearchOpti
 
   if (options?.NOSTOPWORDS) {
     parser.push('NOSTOPWORDS');
-  }
-
-  if(options?.NOCONTENT) {
-    parser.push('NOCONTENT');
   }
 
   if (options?.WITHSCORES || options?.EXPLAINSCORE) {
@@ -243,19 +238,44 @@ export function parseSearchOptions(parser: CommandParser, options?: FtSearchOpti
   } else {
     parser.push('DIALECT', DEFAULT_DIALECT);
   }
+
+  // Snapshot only the options that drive RESP2 reply layout, so the transformer
+  // reads a stable copy even if the caller mutates `options` before the reply
+  // arrives. Shared by FT.SEARCH and FT.PROFILE SEARCH (both call this).
+  parser.preserve = preserveSearchLayout(options);
+}
+
+export type SearchLayoutOptions = {
+  WITHSCORES: boolean;
+  EXPLAINSCORE: boolean;
+  NOCONTENT: boolean;
+  WITHPAYLOADS: boolean;
+  WITHSORTKEYS: boolean;
+  RETURN?: RedisVariadicArgument;
+};
+
+export function preserveSearchLayout(options?: FtSearchOptions): Readonly<SearchLayoutOptions> {
+  return Object.freeze({
+    WITHSCORES: Boolean(options?.WITHSCORES),
+    EXPLAINSCORE: Boolean(options?.EXPLAINSCORE),
+    NOCONTENT: false,
+    WITHPAYLOADS: Boolean(options?.WITHPAYLOADS),
+    WITHSORTKEYS: Boolean(options?.WITHSORTKEYS),
+    RETURN: Array.isArray(options?.RETURN) ? [...options.RETURN] : options?.RETURN
+  });
 }
 
 function transformSearchReplyResp2(
   reply: SearchRawReply,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any -- matches TransformReply contract
-  _preserve?: unknown,
-  _typeMapping?: TypeMapping,
+  preserve?: any,
+  typeMapping?: TypeMapping,
 ): SearchReply {
-  const options = _preserve as FtSearchOptions | undefined;
+  const options = preserve as Partial<SearchLayoutOptions> | undefined;
   const documents: SearchReply['documents'] = [];
-  
+
   const hasScores = Boolean(options?.WITHSCORES) || Boolean(options?.EXPLAINSCORE);
-  const hasExplain = Boolean(options?.EXPLAINSCORE); 
+  const hasExplain = Boolean(options?.EXPLAINSCORE);
   const hasPayloads = Boolean(options?.WITHPAYLOADS);
   const hasSortKeys = Boolean(options?.WITHSORTKEYS);
   const noContent = Boolean(options?.NOCONTENT) ||
@@ -263,34 +283,35 @@ function transformSearchReplyResp2(
 
   let i = 1;
   while (i < reply.length) {
-  
     const id = reply[i++] as string;
 
-    let score: number | undefined;
-    let scoreExplain: Array<ScoreExplain> | undefined;
+    let score: DoubleReply | undefined;
+    let scoreExplain: ScoreExplain | undefined;
 
     if (hasScores) {
       if (hasExplain && Array.isArray(reply[i])) {
-        const tuple = reply[i++] as [string | number, unknown];
-        score = Number(tuple[0]);
-        scoreExplain = Array.isArray(tuple[1]) ? tuple[1].map(normalizeScoreExplain) : undefined;
+        // EXPLAINSCORE row is `[score, explanationNode]`; the explanation is a
+        // single recursive `[summary, children]` node, so normalize it whole.
+        const tuple = reply[i++] as [BlobStringReply, unknown];
+        score = transformDoubleReply[2](tuple[0], undefined, typeMapping);
+        scoreExplain = tuple[1] !== undefined ? normalizeScoreExplain(tuple[1]) : undefined;
       } else {
-        score = Number(reply[i++]);
+        score = transformDoubleReply[2](reply[i++] as BlobStringReply, undefined, typeMapping);
       }
     }
 
-    let payload: string |Buffer | undefined;
-    if (hasPayloads){
-      const rawpayload = reply[i++];
-      if (rawpayload !== undefined && rawpayload !== null){
-        payload = rawpayload as string | Buffer;
+    let payload: string | Buffer | undefined;
+    if (hasPayloads) {
+      const rawPayload = reply[i++];
+      if (rawPayload !== undefined && rawPayload !== null) {
+        payload = rawPayload as string | Buffer;
       }
     }
 
     let sortKey: string | Buffer | undefined;
     if (hasSortKeys) {
       const rawSortKey = reply[i++];
-      if(rawSortKey !== null && rawSortKey !== undefined){
+      if (rawSortKey !== null && rawSortKey !== undefined) {
         sortKey = rawSortKey as string | Buffer;
       }
     }
@@ -302,10 +323,10 @@ function transformSearchReplyResp2(
 
     documents.push({
       id,
-      ...(score !== undefined && !isNaN(score) ? {score} : {}),
-      ...(scoreExplain !== undefined ? {scoreExplain} : {}),
-      ...(payload !== undefined ? {payload} : {}),
-      ...(sortKey !== undefined ? {sortKey} : {}),
+      ...(score !== undefined ? { score } : {}),
+      ...(scoreExplain !== undefined ? { scoreExplain } : {}),
+      ...(payload !== undefined ? { payload } : {}),
+      ...(sortKey !== undefined ? { sortKey } : {}),
       value,
     });
   }
@@ -343,21 +364,25 @@ function transformSearchReplyResp3(
     const rawPayload = getMapValue(resultMap, ['payload']);
     const rawSortKey = getMapValue(resultMap, ['sortkey']);
 
-    let score: number | undefined
-    let scoreExplain: Array<ScoreExplain> | undefined;
+    // On RESP3 the score is already decoded per the client's type mapping
+    // (a number by default, or a string under `{ DOUBLE: String }`), so pass
+    // it through rather than re-coercing it and discarding that mapping.
+    let score: DoubleReply | undefined;
+    let scoreExplain: ScoreExplain | undefined;
 
-    if (Array.isArray(rawScore)){
-      score = Number(rawScore[0]);
-      if (Array.isArray(rawScore[1])){
-        scoreExplain = rawScore[1].map(normalizeScoreExplain);
+    if (Array.isArray(rawScore)) {
+      // `[score, explanationNode]` — normalize the explanation node as a whole.
+      score = rawScore[0] as DoubleReply;
+      if (rawScore[1] !== undefined) {
+        scoreExplain = normalizeScoreExplain(rawScore[1]);
       }
-    } else if (rawScore !== undefined && rawScore !== null){
-      score = typeof rawScore === 'number' ? rawScore : Number(rawScore);
+    } else if (rawScore !== undefined && rawScore !== null) {
+      score = rawScore as DoubleReply;
     }
 
     return {
       id: String((id as { toString?(): string })?.toString?.() ?? id ?? ''),
-      ...(score !== undefined && !isNaN(score) ? {score} : {}),
+      ...(score !== undefined && score !== null ? {score} : {}),
       ...(scoreExplain !== undefined ? {scoreExplain} : {}),
       ...(rawPayload !== undefined && rawPayload !== null? {payload: rawPayload as string | Buffer} : {}),
       ...(rawSortKey !== undefined && rawSortKey !== null ? {sortKey: rawSortKey as string | Buffer}: {}),
@@ -381,15 +406,6 @@ export default {
     parser.push('FT.SEARCH', index, query);
 
     parseSearchOptions(parser, options);
-    parser.preserve = Object.freeze({
-    WITHSCORES: Boolean(options?.WITHSCORES),
-    EXPLAINSCORE: Boolean(options?.EXPLAINSCORE),
-    NOCONTENT: Boolean(options?.NOCONTENT),
-    WITHPAYLOADS: Boolean(options?.WITHPAYLOADS),
-    WITHSORTKEYS: Boolean(options?.WITHSORTKEYS),
-    RETURN: Array.isArray(options?.RETURN) ?
-            [...options.RETURN]:options?.RETURN
-});
   },
   transformReply: {
     2: transformSearchReplyResp2,
@@ -407,8 +423,8 @@ export interface SearchReply {
   total: number;
   documents: Array<{
       id: string;
-      score?: number;
-      scoreExplain?: Array<ScoreExplain>;
+      score?: DoubleReply;
+      scoreExplain?: ScoreExplain;
       payload?: string | Buffer;
       sortKey?: string | Buffer;
       value: SearchDocumentValue;

--- a/packages/search/lib/commands/SEARCH.ts
+++ b/packages/search/lib/commands/SEARCH.ts
@@ -6,7 +6,7 @@ import { DEFAULT_DIALECT } from '../dialect/default';
 import { getMapValue, mapLikeToObject, mapLikeValues, parseDocumentValue, parseSearchResultRow, parseWarnings } from './reply-transformers';
 
 export type FtSearchParams = Record<string, RedisArgument | number>;
-export type ScoreExplain = string | [string, Array<ScoreExplain>];
+export type ScoreExplain = string  | Buffer| [string | Buffer, Array<ScoreExplain>];
 
 export function parseParamsArgument(parser: CommandParser, params?: FtSearchParams) {
   if (params) {
@@ -39,9 +39,11 @@ function numericFilterBound(value:number | RedisArgument):RedisArgument{
 function normalizeScoreExplain(raw: unknown): ScoreExplain {
   if (Array.isArray(raw)) {
     const [summary, children] = raw;
-    return [String(summary), Array.isArray(children) ? children.map(normalizeScoreExplain) : []];
+    const normalizedSummary = Buffer.isBuffer(summary) ? summary : String(summary);
+    return [
+      normalizedSummary, Array.isArray(children) ? children.map(normalizeScoreExplain) : []];
   }
-  return String(raw);
+  return Buffer.isBuffer(raw) ? raw: String(raw);
 }
 
 export interface FtSearchOptions {
@@ -279,12 +281,18 @@ function transformSearchReplyResp2(
 
     let payload: string |Buffer | undefined;
     if (hasPayloads){
-      payload = reply[i++] as string | Buffer;
+      const rawpayload = reply[i++];
+      if (rawpayload !== undefined && rawpayload !== null){
+        payload = rawpayload as string | Buffer;
+      }
     }
 
     let sortKey: string | Buffer | undefined;
     if (hasSortKeys) {
-      sortKey = reply[i++] as string | Buffer;
+      const rawSortKey = reply[i++];
+      if(rawSortKey !== null && rawSortKey !== undefined){
+        sortKey = rawSortKey as string | Buffer;
+      }
     }
 
     let value: SearchDocumentValue = {};
@@ -373,7 +381,15 @@ export default {
     parser.push('FT.SEARCH', index, query);
 
     parseSearchOptions(parser, options);
-    parser.preserve = options;
+    parser.preserve = Object.freeze({
+    WITHSCORES: Boolean(options?.WITHSCORES),
+    EXPLAINSCORE: Boolean(options?.EXPLAINSCORE),
+    NOCONTENT: Boolean(options?.NOCONTENT),
+    WITHPAYLOADS: Boolean(options?.WITHPAYLOADS),
+    WITHSORTKEYS: Boolean(options?.WITHSORTKEYS),
+    RETURN: Array.isArray(options?.RETURN) ?
+            [...options.RETURN]:options?.RETURN
+});
   },
   transformReply: {
     2: transformSearchReplyResp2,

--- a/packages/search/lib/commands/SEARCH_NOCONTENT.spec.ts
+++ b/packages/search/lib/commands/SEARCH_NOCONTENT.spec.ts
@@ -12,6 +12,32 @@ describe('FT.SEARCH NOCONTENT', () => {
         ['FT.SEARCH', 'index', 'query', 'DIALECT', DEFAULT_DIALECT, 'NOCONTENT']
       );
     });
+    it('with a permitted option (FILTER)', () => {
+      assert.deepEqual(
+        parseArgs(SEARCH_NOCONTENT, 'index', 'query', {
+          FILTER: { field: 'price', min: 10, max: 100 }
+        }),
+        ['FT.SEARCH', 'index', 'query', 'FILTER', 'price', '10', '100', 'DIALECT', DEFAULT_DIALECT, 'NOCONTENT']
+      );
+    });
+
+    it('with LIMIT', () => {
+      assert.deepEqual(
+        parseArgs(SEARCH_NOCONTENT, 'index', 'query', {
+          LIMIT: { from: 0, size: 5 }
+        }),
+        ['FT.SEARCH', 'index', 'query', 'LIMIT', '0', '5', 'DIALECT', DEFAULT_DIALECT, 'NOCONTENT']
+      );
+    });
+
+    it('with SORTBY', () => {
+      assert.deepEqual(
+        parseArgs(SEARCH_NOCONTENT, 'index', 'query', {
+          SORTBY: { BY: '@field', DIRECTION: 'DESC' }
+        }),
+        ['FT.SEARCH', 'index', 'query', 'SORTBY', '@field', 'DESC', 'DIALECT', DEFAULT_DIALECT, 'NOCONTENT']
+      );
+    });
   });
 
   describe('client.ft.searchNoContent', () => {
@@ -51,6 +77,52 @@ describe('FT.SEARCH NOCONTENT', () => {
       assert.equal(reply.total, 2);
       assert.ok(Array.isArray(reply.documents));
       assert.equal(reply.documents.length, 2);
+    }, GLOBAL.SERVERS.OPEN);
+  
+    testUtils.testWithClient('documents are plain string IDs, not objects', async client => {
+      await Promise.all([
+        client.ft.create('index', { field: 'TEXT' }),
+        client.hSet('1', 'field', 'hello world')
+      ]);
+      const reply = await client.ft.searchNoContent('index', '*');
+      assert.strictEqual(typeof reply.documents[0], 'string');
+      assert.strictEqual(reply.documents[0], '1');
+    }, GLOBAL.SERVERS.OPEN);
+
+    testUtils.testWithClient('respects FILTER', async client => {
+      await Promise.all([
+        client.ft.create('index', { price: { type: 'NUMERIC' } }),
+        client.hSet('doc:1', 'price', '15'),
+        client.hSet('doc:2', 'price', '50'),
+        client.hSet('doc:3', 'price', '120')
+      ]);
+      const reply = await client.ft.searchNoContent('index', '*', {
+        FILTER: { field: 'price', min: 10, max: 100 }
+      });
+      assert.strictEqual(reply.total, 2);
+      assert.deepStrictEqual(reply.documents.sort(), ['doc:1', 'doc:2']);
+    }, GLOBAL.SERVERS.OPEN);
+
+    testUtils.testWithClient('respects LIMIT', async client => {
+      await Promise.all([
+        client.ft.create('index', { field: 'TEXT' }),
+        client.hSet('1', 'field', 'hello'),
+        client.hSet('2', 'field', 'hello'),
+        client.hSet('3', 'field', 'hello')
+      ]);
+      const reply = await client.ft.searchNoContent('index', '*', {
+        LIMIT: { from: 0, size: 1 }
+      });
+      assert.strictEqual(reply.total, 3, 'total reflects all matches, not just the page');
+      assert.strictEqual(reply.documents.length, 1);
+    }, GLOBAL.SERVERS.OPEN);
+
+    testUtils.testWithClient('empty index returns empty documents, not an error', async client => {
+      await client.ft.create('index', { field: 'TEXT' });
+      const reply = await client.ft.searchNoContent('index', '*');
+      assert.strictEqual(reply.total, 0);
+      assert.deepStrictEqual(reply.documents, []);
+      assert.deepStrictEqual(reply.warnings, []);
     }, GLOBAL.SERVERS.OPEN);
   });
 });

--- a/packages/search/lib/commands/SEARCH_NOCONTENT.spec.ts
+++ b/packages/search/lib/commands/SEARCH_NOCONTENT.spec.ts
@@ -3,12 +3,14 @@ import testUtils, { GLOBAL } from '../test-utils';
 import SEARCH_NOCONTENT from './SEARCH_NOCONTENT';
 import { parseArgs } from '@redis/client/lib/commands/generic-transformers';
 import { DEFAULT_DIALECT } from '../dialect/default';
+import { ReplyUnion } from '@redis/client/dist/lib/RESP/types';
+import { BasicCommandParser} from '@redis/client/lib/client/parser.ts';
 
 describe('FT.SEARCH NOCONTENT', () => {
   describe('transformArguments', () => {
     it('without options', () => {
       assert.deepEqual(
-        parseArgs(SEARCH_NOCONTENT, 'index', 'query'),
+        Array.from(parseArgs(SEARCH_NOCONTENT, 'index', 'query')),
         ['FT.SEARCH', 'index', 'query', 'DIALECT', DEFAULT_DIALECT, 'NOCONTENT']
       );
     });
@@ -38,6 +40,35 @@ describe('FT.SEARCH NOCONTENT', () => {
         ['FT.SEARCH', 'index', 'query', 'SORTBY', '@field', 'DESC', 'DIALECT', DEFAULT_DIALECT, 'NOCONTENT']
       );
     });
+
+    it('legacy array-shaped RESP3', () => {
+    const legacyArrayReply = [2, '1', '2'];
+    const result = SEARCH_NOCONTENT.transformReply[3](
+    legacyArrayReply as unknown as ReplyUnion,
+    { FILTER: { field: 'x', min: 0, max: 1 },NOCONTENT:true }
+  );
+  assert.deepStrictEqual(result, {
+    total: 2,
+    documents: ['1', '2'],
+    warnings: []
+      });
+    });
+
+    it('parseCommand injects NOCONTENT', () => {
+    const parser = new BasicCommandParser();
+    SEARCH_NOCONTENT.parseCommand(
+      parser,
+      'index',
+      'query',
+      { FILTER: { field: 'x', min: 0, max: 1 } }
+    );
+
+    assert.deepStrictEqual(parser.preserve, {
+      FILTER: { field: 'x', min: 0, max: 1 },
+      NOCONTENT: true
+    });
+  });
+
   });
 
   describe('client.ft.searchNoContent', () => {
@@ -125,4 +156,6 @@ describe('FT.SEARCH NOCONTENT', () => {
       assert.deepStrictEqual(reply.warnings, []);
     }, GLOBAL.SERVERS.OPEN);
   });
+
+
 });

--- a/packages/search/lib/commands/SEARCH_NOCONTENT.spec.ts
+++ b/packages/search/lib/commands/SEARCH_NOCONTENT.spec.ts
@@ -14,27 +14,27 @@ describe('FT.SEARCH NOCONTENT', () => {
     });
     it('with a permitted option (FILTER)', () => {
       assert.deepEqual(
-        parseArgs(SEARCH_NOCONTENT, 'index', 'query', {
+        Array.from(parseArgs(SEARCH_NOCONTENT, 'index', 'query', {
           FILTER: { field: 'price', min: 10, max: 100 }
-        }),
+        })),
         ['FT.SEARCH', 'index', 'query', 'FILTER', 'price', '10', '100', 'DIALECT', DEFAULT_DIALECT, 'NOCONTENT']
       );
     });
 
     it('with LIMIT', () => {
       assert.deepEqual(
-        parseArgs(SEARCH_NOCONTENT, 'index', 'query', {
+        Array.from(parseArgs(SEARCH_NOCONTENT, 'index', 'query', {
           LIMIT: { from: 0, size: 5 }
-        }),
+        })),
         ['FT.SEARCH', 'index', 'query', 'LIMIT', '0', '5', 'DIALECT', DEFAULT_DIALECT, 'NOCONTENT']
       );
     });
 
     it('with SORTBY', () => {
       assert.deepEqual(
-        parseArgs(SEARCH_NOCONTENT, 'index', 'query', {
+        Array.from(parseArgs(SEARCH_NOCONTENT, 'index', 'query', {
           SORTBY: { BY: '@field', DIRECTION: 'DESC' }
-        }),
+        })),
         ['FT.SEARCH', 'index', 'query', 'SORTBY', '@field', 'DESC', 'DIALECT', DEFAULT_DIALECT, 'NOCONTENT']
       );
     });

--- a/packages/search/lib/commands/SEARCH_NOCONTENT.spec.ts
+++ b/packages/search/lib/commands/SEARCH_NOCONTENT.spec.ts
@@ -14,6 +14,7 @@ describe('FT.SEARCH NOCONTENT', () => {
         ['FT.SEARCH', 'index', 'query', 'DIALECT', DEFAULT_DIALECT, 'NOCONTENT']
       );
     });
+
     it('with a permitted option (FILTER)', () => {
       assert.deepEqual(
         Array.from(parseArgs(SEARCH_NOCONTENT, 'index', 'query', {
@@ -41,38 +42,40 @@ describe('FT.SEARCH NOCONTENT', () => {
       );
     });
 
-    it('legacy array-shaped RESP3', () => {
-    const legacyArrayReply = [2, '1', '2'];
-    const result = SEARCH_NOCONTENT.transformReply[3](
-    legacyArrayReply as unknown as ReplyUnion,
-    { FILTER: { field: 'x', min: 0, max: 1 },NOCONTENT:true }
-  );
-  assert.deepStrictEqual(result, {
-    total: 2,
-    documents: ['1', '2'],
-    warnings: []
-      });
-    });
-
     it('parseCommand injects NOCONTENT and preserves an ID-only layout', () => {
-    const parser = new BasicCommandParser();
-    SEARCH_NOCONTENT.parseCommand(
-      parser,
-      'index',
-      'query',
-      { FILTER: { field: 'x', min: 0, max: 1 } }
-    );
+      const parser = new BasicCommandParser();
+      SEARCH_NOCONTENT.parseCommand(
+        parser,
+        'index',
+        'query',
+        { FILTER: { field: 'x', min: 0, max: 1 } }
+      );
 
-    assert.deepStrictEqual(parser.preserve, {
-      WITHSCORES: false,
-      EXPLAINSCORE: false,
-      NOCONTENT: true,
-      WITHPAYLOADS: false,
-      WITHSORTKEYS: false,
-      RETURN: undefined
+      assert.deepStrictEqual(parser.preserve, {
+        WITHSCORES: false,
+        EXPLAINSCORE: false,
+        NOCONTENT: true,
+        WITHPAYLOADS: false,
+        WITHSORTKEYS: false,
+        RETURN: undefined
+      });
     });
   });
 
+  describe('transformReply', () => {
+    it('legacy array-shaped RESP3', () => {
+      const legacyArrayReply = [2, '1', '2'];
+      const result = SEARCH_NOCONTENT.transformReply[3](
+        legacyArrayReply as unknown as ReplyUnion,
+        { FILTER: { field: 'x', min: 0, max: 1 }, NOCONTENT: true }
+      );
+
+      assert.deepStrictEqual(result, {
+        total: 2,
+        documents: ['1', '2'],
+        warnings: []
+      });
+    });
   });
 
   describe('client.ft.searchNoContent', () => {
@@ -113,7 +116,7 @@ describe('FT.SEARCH NOCONTENT', () => {
       assert.ok(Array.isArray(reply.documents));
       assert.equal(reply.documents.length, 2);
     }, GLOBAL.SERVERS.OPEN);
-  
+
     testUtils.testWithClient('documents are plain string IDs, not objects', async client => {
       await Promise.all([
         client.ft.create('index', { field: 'TEXT' }),

--- a/packages/search/lib/commands/SEARCH_NOCONTENT.spec.ts
+++ b/packages/search/lib/commands/SEARCH_NOCONTENT.spec.ts
@@ -4,7 +4,7 @@ import SEARCH_NOCONTENT from './SEARCH_NOCONTENT';
 import { parseArgs } from '@redis/client/lib/commands/generic-transformers';
 import { DEFAULT_DIALECT } from '../dialect/default';
 import { ReplyUnion } from '@redis/client/dist/lib/RESP/types';
-import { BasicCommandParser} from '@redis/client/lib/client/parser.ts';
+import { BasicCommandParser } from '@redis/client/lib/client/parser';
 
 describe('FT.SEARCH NOCONTENT', () => {
   describe('transformArguments', () => {
@@ -54,7 +54,7 @@ describe('FT.SEARCH NOCONTENT', () => {
       });
     });
 
-    it('parseCommand injects NOCONTENT', () => {
+    it('parseCommand injects NOCONTENT and preserves an ID-only layout', () => {
     const parser = new BasicCommandParser();
     SEARCH_NOCONTENT.parseCommand(
       parser,
@@ -64,8 +64,12 @@ describe('FT.SEARCH NOCONTENT', () => {
     );
 
     assert.deepStrictEqual(parser.preserve, {
-      FILTER: { field: 'x', min: 0, max: 1 },
-      NOCONTENT: true
+      WITHSCORES: false,
+      EXPLAINSCORE: false,
+      NOCONTENT: true,
+      WITHPAYLOADS: false,
+      WITHSORTKEYS: false,
+      RETURN: undefined
     });
   });
 
@@ -156,6 +160,4 @@ describe('FT.SEARCH NOCONTENT', () => {
       assert.deepStrictEqual(reply.warnings, []);
     }, GLOBAL.SERVERS.OPEN);
   });
-
-
 });

--- a/packages/search/lib/commands/SEARCH_NOCONTENT.ts
+++ b/packages/search/lib/commands/SEARCH_NOCONTENT.ts
@@ -13,6 +13,7 @@ export default {
     options?: SearchNoContentOptions) {
    SEARCH.parseCommand(parser, index, query, options as FtSearchOptions);
     parser.push('NOCONTENT');
+    parser.preserve = { ...(options ?? {}), NOCONTENT: true };
   },
   transformReply: {
     2: (reply: SearchRawReply): SearchNoContentReply => {

--- a/packages/search/lib/commands/SEARCH_NOCONTENT.ts
+++ b/packages/search/lib/commands/SEARCH_NOCONTENT.ts
@@ -1,10 +1,18 @@
 import { Command, ReplyUnion, TypeMapping } from '@redis/client/dist/lib/RESP/types';
-import SEARCH, { SearchRawReply } from './SEARCH';
+import SEARCH, { FtSearchOptions, SearchRawReply } from './SEARCH';
+
+type SearchNoContentOptions = Omit<FtSearchOptions,
+  'NOCONTENT' | 'WITHSCORES' | 'EXPLAINSCORE' | 'WITHPAYLOADS' | 'WITHSORTKEYS'
+>;
 
 export default {
-  parseCommand(...args: Parameters<typeof SEARCH.parseCommand>) {
-    SEARCH.parseCommand(...args);
-    args[0].push('NOCONTENT');
+  parseCommand(
+    parser: Parameters<typeof SEARCH.parseCommand>[0],
+    index: Parameters<typeof SEARCH.parseCommand>[1],
+    query: Parameters<typeof SEARCH.parseCommand>[2],
+    options?: SearchNoContentOptions) {
+   SEARCH.parseCommand(parser, index, query, options as FtSearchOptions);
+    parser.push('NOCONTENT');
   },
   transformReply: {
     2: (reply: SearchRawReply): SearchNoContentReply => {

--- a/packages/search/lib/commands/SEARCH_NOCONTENT.ts
+++ b/packages/search/lib/commands/SEARCH_NOCONTENT.ts
@@ -1,8 +1,10 @@
 import { Command, ReplyUnion, TypeMapping } from '@redis/client/dist/lib/RESP/types';
 import SEARCH, { FtSearchOptions, SearchRawReply } from './SEARCH';
 
+// Reply-shape options make no sense for an ID-only reply, so exclude them here.
+// NOCONTENT is the command itself, so it is not a caller-supplied option either.
 type SearchNoContentOptions = Omit<FtSearchOptions,
-  'NOCONTENT' | 'WITHSCORES' | 'EXPLAINSCORE' | 'WITHPAYLOADS' | 'WITHSORTKEYS'
+  'WITHSCORES' | 'EXPLAINSCORE' | 'WITHPAYLOADS' | 'WITHSORTKEYS'
 >;
 
 export default {
@@ -11,9 +13,12 @@ export default {
     index: Parameters<typeof SEARCH.parseCommand>[1],
     query: Parameters<typeof SEARCH.parseCommand>[2],
     options?: SearchNoContentOptions) {
-   SEARCH.parseCommand(parser, index, query, options as FtSearchOptions);
+    SEARCH.parseCommand(parser, index, query, options as FtSearchOptions);
     parser.push('NOCONTENT');
-    parser.preserve = { ...(options ?? {}), NOCONTENT: true };
+    // parseSearchOptions already set a frozen layout snapshot; layer NOCONTENT
+    // on top so the shared RESP3 transformer treats the reply as ID-only when a
+    // legacy array-shaped reply falls through to it.
+    parser.preserve = Object.freeze({ ...(parser.preserve as object), NOCONTENT: true });
   },
   transformReply: {
     2: (reply: SearchRawReply): SearchNoContentReply => {


### PR DESCRIPTION
### Description

This PR resolves issue #2143 by adding full support for the `WITHSCORES` option in `FT.SEARCH` commands within `@redis/search`, along with the other query options that were missing from the typed API: `EXPLAINSCORE`, `WITHPAYLOADS`, `WITHSORTKEYS`, `FILTER`, `GEOFILTER`, and `PAYLOAD`.

Previously, these flags were either not accepted by the options type, ignored during argument parsing, or their returned values were dropped (or mis-parsed) during reply transformation.

This change ensures that:

1. All of the above options are properly serialized into the command arguments when requested.
2. The reply layout (scores, score explanations, payloads, sort keys, content presence) is parsed correctly in both RESP2 and RESP3 transformers, driven by a frozen layout snapshot on `parser.preserve` shared by `FT.SEARCH`, `FT.SEARCH … NOCONTENT`, and `FT.PROFILE SEARCH`.
3. The `SearchReply` type exposes the new optional per-document fields: `score?: DoubleReply` (a number by default, following the client's `DOUBLE` type mapping), `scoreExplain?: ScoreExplain`, `payload?: string | Buffer`, and `sortKey?: string | Buffer`.

---

### Checklist

* [x] Does `npm test` pass with this change (including linting)?
* [x] Is the new or changed code fully tested?
* [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)? — JSDoc added for all new options and reply fields.
