### PR TITLE
fix(client): emit termination event when reconnecting stops

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,7 @@ The Node Redis client class is an Nodejs EventEmitter and it emits an event each
 | `end`                   | Connection has been closed (via `.close()` or `.destroy()`)                        | _No arguments_                                            |
 | `error`                 | An error has occurred—usually a network issue such as "Socket closed unexpectedly" | `(error: Error)`                                          |
 | `reconnecting`          | Client is trying to reconnect to the server                                        | _No arguments_                                            |
+| `terminated`             | Reconnection has stopped because `reconnectStrategy` returned `false` or an `Error` | `(cause: Error)`                                           |
 | `sharded-channel-moved` | See [here](https://github.com/redis/node-redis/blob/master/docs/pub-sub.md#sharded-channel-moved-event)                          | See [here](https://github.com/redis/node-redis/blob/master/docs/pub-sub.md#sharded-channel-moved-event) |
 | `invalidate`            | Client Tracking is on with `emitInvalidate` and a key is invalidated               | `(key: RedisItem \| null)`                                 |
 

--- a/README.md
+++ b/README.md
@@ -388,7 +388,7 @@ The Node Redis client class is an Nodejs EventEmitter and it emits an event each
 | `end`                   | Connection has been closed (via `.close()` or `.destroy()`)                        | _No arguments_                                            |
 | `error`                 | An error has occurred—usually a network issue such as "Socket closed unexpectedly" | `(error: Error)`                                          |
 | `reconnecting`          | Client is trying to reconnect to the server                                        | _No arguments_                                            |
-| `terminated`             | Reconnection has stopped because `reconnectStrategy` returned `false` or an `Error` | `(cause: Error)`                                           |
+| `terminated`             | Reconnection has stopped because `reconnectStrategy` returned `false` or an `Error`; emitted before the companion `error` | `(cause: Error)`                                           |
 | `sharded-channel-moved` | See [here](https://github.com/redis/node-redis/blob/master/docs/pub-sub.md#sharded-channel-moved-event)                          | See [here](https://github.com/redis/node-redis/blob/master/docs/pub-sub.md#sharded-channel-moved-event) |
 | `invalidate`            | Client Tracking is on with `emitInvalidate` and a key is invalidated               | `(key: RedisItem \| null)`                                 |
 

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -67,7 +67,7 @@ An `'error'` event fires on every disconnect, including ones the client is about
 ```javascript
 client.on('terminated', cause => {
   console.error('client will not reconnect:', cause);
-  client.destroy();
+  queueMicrotask(() => client.destroy());
 });
 ```
 

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -62,11 +62,12 @@ createClient({
 });
 ```
 
-An `'error'` event fires on every disconnect, including ones the client is about to retry, so it can't tell you whether reconnection is still in progress. Once `reconnectStrategy` gives up (returns `false` or an `Error`), the client also emits a `'terminated'` event with the reason — that's the signal that reconnection has permanently stopped and the client needs to be recreated:
+An `'error'` event fires on every disconnect, including ones the client is about to retry, so it can't tell you whether reconnection is still in progress. Once `reconnectStrategy` gives up (returns `false` or an `Error`), the client also emits a `'terminated'` event with the reason — that's the signal that reconnection has permanently stopped. Call `destroy()` before replacing the client so its resources are released:
 
 ```javascript
 client.on('terminated', cause => {
   console.error('client will not reconnect:', cause);
+  client.destroy();
 });
 ```
 

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -62,7 +62,7 @@ createClient({
 });
 ```
 
-An `'error'` event fires on every disconnect, including ones the client is about to retry, so it can't tell you whether reconnection is still in progress. Once `reconnectStrategy` gives up (returns `false` or an `Error`), the client emits a `'terminated'` event before the companion `'error'` event. This is the signal that reconnection has permanently stopped. Call `destroy()` before replacing the client so its resources are released:
+An `'error'` event fires on every disconnect, including ones the client is about to retry, so it can't tell you whether reconnection is still in progress. Once `reconnectStrategy` gives up (returns `false` or an `Error`), the client emits a `'terminated'` event before the companion `'error'` event. This ordering lets `await events.once(client, 'terminated')` resolve with the cause before the companion error is emitted, and distinguishes a permanent termination from a transient retry. Call `destroy()` before replacing the client so its resources are released:
 
 ```javascript
 client.on('terminated', cause => {

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -62,6 +62,14 @@ createClient({
 });
 ```
 
+An `'error'` event fires on every disconnect, including ones the client is about to retry, so it can't tell you whether reconnection is still in progress. Once `reconnectStrategy` gives up (returns `false` or an `Error`), the client also emits a `'terminated'` event with the reason — that's the signal that reconnection has permanently stopped and the client needs to be recreated:
+
+```javascript
+client.on('terminated', cause => {
+  console.error('client will not reconnect:', cause);
+});
+```
+
 ## TLS
 
 To enable TLS, set `socket.tls` to `true`. Below are some basic examples.

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -62,7 +62,7 @@ createClient({
 });
 ```
 
-An `'error'` event fires on every disconnect, including ones the client is about to retry, so it can't tell you whether reconnection is still in progress. Once `reconnectStrategy` gives up (returns `false` or an `Error`), the client also emits a `'terminated'` event with the reason — that's the signal that reconnection has permanently stopped. Call `destroy()` before replacing the client so its resources are released:
+An `'error'` event fires on every disconnect, including ones the client is about to retry, so it can't tell you whether reconnection is still in progress. Once `reconnectStrategy` gives up (returns `false` or an `Error`), the client emits a `'terminated'` event before the companion `'error'` event. This is the signal that reconnection has permanently stopped. Call `destroy()` before replacing the client so its resources are released:
 
 ```javascript
 client.on('terminated', cause => {

--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -1551,6 +1551,26 @@ describe('Client', () => {
 
   describe("socket errors during handshake", () => {
 
+    it("should re-emit terminated from the socket", async () => {
+      const client = createClient({
+        socket: {
+          host: "error",
+          connectTimeout: 1,
+          reconnectStrategy: false
+        }
+      });
+      client.on("error", () => {});
+
+      const terminated = new Promise<Error>(resolve => {
+        client.once("terminated", resolve);
+      });
+      await assert.rejects(client.connect());
+
+      const cause = await terminated;
+      assert.ok(cause instanceof Error);
+      client.destroy();
+    });
+
     it("should successfully connect when server accepts connection immediately", async () => {
       const { log, client, teardown } = await setup({}, 0);
       await client.connect();

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -1053,6 +1053,7 @@ export default class RedisClient<
       this.#maybeScheduleWrite();
     })
     .on('reconnecting', () => this.emit('reconnecting'))
+    .on('terminated', cause => this.emit('terminated', cause))
     .on('drain', () => this.#maybeScheduleWrite())
     .on('end', () => this.emit('end'));
   }

--- a/packages/client/lib/client/socket.spec.ts
+++ b/packages/client/lib/client/socket.spec.ts
@@ -201,6 +201,67 @@ describe('Socket', () => {
 
       socket.destroy();
     });
+
+    it('should not reconnect when an error listener destroys the socket', async () => {
+      const connections: net.Socket[] = [];
+      const server = net.createServer(conn => {
+        conn.on('error', () => { /* ignore */ });
+        connections.push(conn);
+      });
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+      const { port } = server.address() as net.AddressInfo;
+      const firstConnection = once(server, 'connection') as Promise<[net.Socket]>;
+
+      try {
+        const socket = createSocket({
+          host: '127.0.0.1',
+          port,
+          reconnectStrategy: 0
+        });
+        socket.on('error', () => socket.destroy());
+
+        await socket.connect();
+        const [conn] = await firstConnection;
+        conn.destroy();
+        await once(socket, 'end');
+        await setTimeout(10);
+
+        assert.equal(connections.length, 1, 'destroyed socket must not reconnect');
+        assert.equal(socket.isOpen, false, 'socket.isOpen');
+      } finally {
+        for (const conn of connections) conn.destroy();
+        await new Promise<void>(resolve => server.close(() => resolve()));
+      }
+    });
+
+    it('should emit `terminated` before `error` when the handshake fails', async () => {
+      const connections: net.Socket[] = [];
+      const server = net.createServer(conn => {
+        conn.on('error', () => { /* ignore */ });
+        connections.push(conn);
+        setImmediate(() => conn.destroy());
+      });
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+      const { port } = server.address() as net.AddressInfo;
+
+      try {
+        const socket = new RedisSocket(() => new Promise(() => { /* wait for socket failure */ }), CLIENT_ID, {
+          host: '127.0.0.1',
+          port,
+          reconnectStrategy: false
+        });
+        const events: string[] = [];
+        socket.on('terminated', () => events.push('terminated'));
+        socket.on('error', () => events.push('error'));
+
+        await assert.rejects(socket.connect());
+
+        assert.deepEqual(events, ['terminated', 'error']);
+      } finally {
+        for (const conn of connections) conn.destroy();
+        await new Promise<void>(resolve => server.close(() => resolve()));
+      }
+    });
   });
 
   describe('initiator interruption (#3346)', () => {

--- a/packages/client/lib/client/socket.spec.ts
+++ b/packages/client/lib/client/socket.spec.ts
@@ -5,6 +5,7 @@ import net from 'node:net';
 import RedisSocket, { RedisSocketOptions } from './socket';
 import testUtils, { GLOBAL } from '../test-utils';
 import { setTimeout } from 'timers/promises';
+import { ReconnectStrategyError } from '../errors';
 
 describe('Socket', () => {
   const CLIENT_ID = 'test-client-id';
@@ -84,6 +85,108 @@ describe('Socket', () => {
       await assert.rejects(socket.connect());
 
       assert.equal(socket.isOpen, false);
+    });
+  });
+
+  describe('terminated event (#2948)', () => {
+    it('should emit `terminated` when reconnectStrategy gives up on the initial connection', async () => {
+      const socket = createSocket({
+        host: 'error',
+        connectTimeout: 1,
+        reconnectStrategy: false
+      });
+
+      // `node:events`' `once()` special-cases `'error'` — it resolves/rejects
+      // as soon as *either* the awaited event or an `'error'` fires, so it
+      // can't be used to await `'terminated'` here without racing the
+      // `'error'` this same give-up also emits. A plain listener sidesteps that.
+      let terminatedCause: Error | undefined;
+      socket.on('terminated', cause => { terminatedCause = cause; });
+
+      await assert.rejects(socket.connect());
+
+      assert.ok(terminatedCause instanceof Error);
+      assert.equal(socket.isOpen, false);
+    });
+
+    it('should emit `terminated` with the wrapped error when a custom reconnectStrategy gives up', async () => {
+      const reconnectStrategy = spy((retries: number) => {
+        if (retries === 1) return new Error('done');
+        return 0;
+      });
+
+      const socket = createSocket({
+        host: 'error',
+        connectTimeout: 1,
+        reconnectStrategy
+      });
+
+      let terminatedCause: Error | undefined;
+      socket.on('terminated', cause => { terminatedCause = cause; });
+
+      await assert.rejects(socket.connect());
+
+      assert.ok(terminatedCause instanceof ReconnectStrategyError, 'terminated cause should be a ReconnectStrategyError');
+    });
+
+    it('should emit `terminated` — not just `error` — when the connection is lost after being ready', async () => {
+      // This is the scenario from #2948: `error` fires on *every* disconnect,
+      // including ones the client is about to retry, so a listener can't tell
+      // "still retrying" apart from "reconnectStrategy gave up, this client
+      // is dead". Before this fix, losing an already-ready connection only
+      // ever emitted `error`, indistinguishable from a transient one.
+      const connections: net.Socket[] = [];
+      const server = net.createServer(conn => {
+        conn.on('error', () => { /* ignore */ });
+        connections.push(conn);
+      });
+      await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+      const { port } = server.address() as net.AddressInfo;
+      const firstConnection = once(server, 'connection') as Promise<[net.Socket]>;
+
+      try {
+        const socket = createSocket({
+          host: '127.0.0.1',
+          port,
+          // Give up as soon as the live connection dies, instead of retrying.
+          reconnectStrategy: false
+        });
+
+        await socket.connect();
+        assert.equal(socket.isReady, true, 'socket.isReady');
+
+        const terminatedCauses: Error[] = [];
+        socket.on('terminated', cause => terminatedCauses.push(cause));
+
+        const [conn] = await firstConnection;
+        conn.destroy();
+        const [errCause] = await once(socket, 'error') as [Error];
+
+        assert.equal(terminatedCauses.length, 1, 'terminated should have fired exactly once');
+        assert.equal(terminatedCauses[0], errCause, 'terminated should carry the same cause as error');
+        assert.equal(socket.isOpen, false, 'socket.isOpen');
+      } finally {
+        for (const conn of connections) conn.destroy();
+        await new Promise<void>(resolve => server.close(() => resolve()));
+      }
+    });
+
+    it('should not emit `terminated` when the reconnectStrategy schedules a retry', async () => {
+      const socket = createSocket({
+        host: 'error',
+        connectTimeout: 1,
+        reconnectStrategy: 0
+      });
+
+      let terminatedCount = 0;
+      socket.on('terminated', () => terminatedCount++);
+
+      socket.connect();
+      await once(socket, 'error');
+      assert.equal(socket.isOpen, true);
+      assert.equal(terminatedCount, 0, 'terminated must not fire while still retrying');
+
+      socket.destroy();
     });
   });
 

--- a/packages/client/lib/client/socket.spec.ts
+++ b/packages/client/lib/client/socket.spec.ts
@@ -163,15 +163,20 @@ describe('Socket', () => {
         await socket.connect();
         assert.equal(socket.isReady, true, 'socket.isReady');
 
-        const terminatedCauses: Error[] = [];
-        socket.on('terminated', cause => terminatedCauses.push(cause));
+        const events: string[] = [];
+        let terminatedCause: Error | undefined;
+        socket.on('terminated', cause => {
+          events.push('terminated');
+          terminatedCause = cause;
+        });
+        socket.on('error', () => events.push('error'));
 
         const [conn] = await firstConnection;
         conn.destroy();
         const [errCause] = await once(socket, 'error') as [Error];
 
-        assert.equal(terminatedCauses.length, 1, 'terminated should have fired exactly once');
-        assert.equal(terminatedCauses[0], errCause, 'terminated should carry the same cause as error');
+        assert.deepEqual(events, ['terminated', 'error']);
+        assert.equal(terminatedCause, errCause, 'terminated should carry the same cause as error');
         assert.equal(socket.isOpen, false, 'socket.isOpen');
       } finally {
         for (const conn of connections) conn.destroy();

--- a/packages/client/lib/client/socket.spec.ts
+++ b/packages/client/lib/client/socket.spec.ts
@@ -96,16 +96,18 @@ describe('Socket', () => {
         reconnectStrategy: false
       });
 
-      // `node:events`' `once()` special-cases `'error'` — it resolves/rejects
-      // as soon as *either* the awaited event or an `'error'` fires, so it
-      // can't be used to await `'terminated'` here without racing the
-      // `'error'` this same give-up also emits. A plain listener sidesteps that.
+      const events: string[] = [];
       let terminatedCause: Error | undefined;
-      socket.on('terminated', cause => { terminatedCause = cause; });
+      socket.on('terminated', cause => {
+        events.push('terminated');
+        terminatedCause = cause;
+      });
+      socket.on('error', () => events.push('error'));
 
       await assert.rejects(socket.connect());
 
       assert.ok(terminatedCause instanceof Error);
+      assert.deepEqual(events.slice(-2), ['terminated', 'error']);
       assert.equal(socket.isOpen, false);
     });
 
@@ -121,12 +123,18 @@ describe('Socket', () => {
         reconnectStrategy
       });
 
+      const events: string[] = [];
       let terminatedCause: Error | undefined;
-      socket.on('terminated', cause => { terminatedCause = cause; });
+      socket.on('terminated', cause => {
+        events.push('terminated');
+        terminatedCause = cause;
+      });
+      socket.on('error', () => events.push('error'));
 
       await assert.rejects(socket.connect());
 
       assert.ok(terminatedCause instanceof ReconnectStrategyError, 'terminated cause should be a ReconnectStrategyError');
+      assert.deepEqual(events.slice(-2), ['terminated', 'error']);
     });
 
     it('should emit `terminated` — not just `error` — when the connection is lost after being ready', async () => {

--- a/packages/client/lib/client/socket.ts
+++ b/packages/client/lib/client/socket.ts
@@ -414,7 +414,20 @@ const retryIn = strategy(retries, cause);
       publish(CHANNELS.CONNECTION_CLOSED, () => ({ clientId: this.#clientId, reason: 'error', wasConnected: true }));
     }
 
-    if (!wasReady || !this.#isOpen) {
+    if (!wasReady) {
+      if (!this.#isOpen) {
+        publish(CHANNELS.ERROR, () => ({
+          error: err,
+          origin: 'client',
+          internal: false,
+          clientId: this.#clientId
+        }));
+        this.emit('error', err);
+      }
+      return;
+    }
+
+    if (!this.#isOpen) {
       publish(CHANNELS.ERROR, () => ({
         error: err,
         origin: 'client',
@@ -435,6 +448,7 @@ const retryIn = strategy(retries, cause);
       clientId: this.#clientId
     }));
     this.emit('error', err);
+    if (!this.#isOpen) return;
 
     this.emit('reconnecting');
     this.#connect().catch(() => {

--- a/packages/client/lib/client/socket.ts
+++ b/packages/client/lib/client/socket.ts
@@ -13,6 +13,10 @@ type NetOptions = {
 };
 
 type ReconnectStrategyFunction = (retries: number, cause: Error) => false | Error | number;
+type ReconnectStrategyResult = {
+  retryIn: false | Error | number;
+  error?: Error;
+};
 
 type RedisSocketOptionsCommon = {
   /**
@@ -111,34 +115,30 @@ export default class RedisSocket extends EventEmitter {
     this.#clientId = clientId;
   }
 
-  #createReconnectStrategy(options?: RedisSocketOptions): ReconnectStrategyFunction {
+  #createReconnectStrategy(options?: RedisSocketOptions): (retries: number, cause: Error) => ReconnectStrategyResult {
     const strategy = options?.reconnectStrategy;
     if (strategy === false || typeof strategy === 'number') {
-      return () => strategy;
+      return () => ({ retryIn: strategy });
     }
 
     if (strategy) {
       return (retries, cause) => {
         try {
-const retryIn = strategy(retries, cause);
+          const retryIn = strategy(retries, cause);
           if (retryIn !== false && !(retryIn instanceof Error) && typeof retryIn !== 'number') {
             throw new TypeError(`Reconnect strategy should return \`false | Error | number\`, got ${retryIn} instead`);
           }
-          return retryIn;
+          return { retryIn };
         } catch (err) {
-          publish(CHANNELS.ERROR, () => ({
-            error: err as Error,
-            origin: 'client',
-            internal: false,
-            clientId: this.#clientId
-          }));
-          this.emit('error', err);
-          return this.defaultReconnectStrategy(retries, err);
+          return {
+            retryIn: this.defaultReconnectStrategy(retries, err),
+            error: err as Error
+          };
         }
       };
     }
 
-    return this.defaultReconnectStrategy;
+    return (retries, cause) => ({ retryIn: this.defaultReconnectStrategy(retries, cause) });
   }
 
   #createSocketFactory(options?: RedisSocketOptions) {
@@ -213,33 +213,31 @@ const retryIn = strategy(retries, cause);
    * has permanently stopped, the client is unusable from here on".
    */
   #shouldReconnect(retries: number, cause: Error) {
-    const retryIn = this.#reconnectStrategy(retries, cause);
+    const { retryIn, error: strategyError } = this.#reconnectStrategy(retries, cause);
     if (retryIn === false) {
       this.#isOpen = false;
-      publish(CHANNELS.ERROR, () => ({
-        error: cause,
-        origin: 'client',
-        internal: false,
-        clientId: this.#clientId
-      }));
       this.emit('terminated', cause);
-      this.emit('error', cause);
-      return cause;
+      this.#emitError(cause);
+      return { retryIn: cause, strategyError };
     } else if (retryIn instanceof Error) {
       this.#isOpen = false;
-      publish(CHANNELS.ERROR, () => ({
-        error: cause,
-        origin: 'client',
-        internal: false,
-        clientId: this.#clientId
-      }));
       const terminatedBy = new ReconnectStrategyError(retryIn, cause);
       this.emit('terminated', terminatedBy);
-      this.emit('error', cause);
-      return terminatedBy;
+      this.#emitError(cause);
+      return { retryIn: terminatedBy, strategyError };
     }
 
-    return retryIn;
+    return { retryIn, strategyError };
+  }
+
+  #emitError(err: Error) {
+    publish(CHANNELS.ERROR, () => ({
+      error: err,
+      origin: 'client',
+      internal: false,
+      clientId: this.#clientId
+    }));
+    this.emit('error', err);
   }
 
   async connect(): Promise<void> {
@@ -264,9 +262,14 @@ const retryIn = strategy(retries, cause);
 
           // Check if socket was closed/destroyed during initiator execution
           if (!this.#socket || this.#socket.destroyed || !this.#socket.readable || !this.#socket.writable) {
-            const retryIn = this.#shouldReconnect(retries++, new SocketClosedUnexpectedlyError());
+            const error = new SocketClosedUnexpectedlyError();
+            const { retryIn, strategyError } = this.#shouldReconnect(retries++, error);
             if (typeof retryIn !== 'number') { throw retryIn; }
+            this.#emitError(error);
+            if (strategyError) this.#emitError(strategyError);
+            if (!this.#isOpen) throw new ClientClosedError();
             await setTimeout(retryIn);
+            if (!this.#isOpen) throw new ClientClosedError();
             this.emit('reconnecting');
             continue;
           }
@@ -292,19 +295,16 @@ const retryIn = strategy(retries, cause);
         // reconnecting or scheduling a retry — the shutdown is intentional.
         if (!this.#isOpen) throw err;
 
-        const retryIn = this.#shouldReconnect(retries++, err as Error);
+        const { retryIn, strategyError } = this.#shouldReconnect(retries++, err as Error);
         if (typeof retryIn !== 'number') {
           throw retryIn;
         }
 
-        publish(CHANNELS.ERROR, () => ({
-          error: err as Error,
-          origin: 'client',
-          internal: false,
-          clientId: this.#clientId
-        }));
-        this.emit('error', err);
+        this.#emitError(err as Error);
+        if (strategyError) this.#emitError(strategyError);
+        if (!this.#isOpen) throw err;
         await setTimeout(retryIn);
+        if (!this.#isOpen) throw err;
         this.emit('reconnecting');
       }
     } while (this.#isOpen && !this.#isReady);
@@ -416,38 +416,21 @@ const retryIn = strategy(retries, cause);
 
     if (!wasReady) {
       if (!this.#isOpen) {
-        publish(CHANNELS.ERROR, () => ({
-          error: err,
-          origin: 'client',
-          internal: false,
-          clientId: this.#clientId
-        }));
-        this.emit('error', err);
+        this.#emitError(err);
       }
       return;
     }
 
     if (!this.#isOpen) {
-      publish(CHANNELS.ERROR, () => ({
-        error: err,
-        origin: 'client',
-        internal: false,
-        clientId: this.#clientId
-      }));
-      this.emit('error', err);
+      this.#emitError(err);
       return;
     }
 
-    const retryIn = this.#shouldReconnect(0, err);
+    const { retryIn, strategyError } = this.#shouldReconnect(0, err);
     if (typeof retryIn !== 'number') return;
 
-    publish(CHANNELS.ERROR, () => ({
-      error: err,
-      origin: 'client',
-      internal: false,
-      clientId: this.#clientId
-    }));
-    this.emit('error', err);
+    this.#emitError(err);
+    if (strategyError) this.#emitError(strategyError);
     if (!this.#isOpen) return;
 
     this.emit('reconnecting');

--- a/packages/client/lib/client/socket.ts
+++ b/packages/client/lib/client/socket.ts
@@ -205,6 +205,13 @@ const retryIn = strategy(retries, cause);
     };
   }
 
+  /**
+   * The single choke point where `reconnectStrategy` giving up (`false` or an
+   * `Error`) is handled: closes the socket for good and emits `'terminated'`
+   * so a caller reacting only to `'error'` — which also fires on every
+   * *retried* disconnect — can tell "still retrying" apart from "reconnection
+   * has permanently stopped, the client is unusable from here on".
+   */
   #shouldReconnect(retries: number, cause: Error) {
     const retryIn = this.#reconnectStrategy(retries, cause);
     if (retryIn === false) {
@@ -216,6 +223,7 @@ const retryIn = strategy(retries, cause);
         clientId: this.#clientId
       }));
       this.emit('error', cause);
+      this.emit('terminated', cause);
       return cause;
     } else if (retryIn instanceof Error) {
       this.#isOpen = false;
@@ -226,7 +234,9 @@ const retryIn = strategy(retries, cause);
         clientId: this.#clientId
       }));
       this.emit('error', cause);
-      return new ReconnectStrategyError(retryIn, cause);
+      const terminatedBy = new ReconnectStrategyError(retryIn, cause);
+      this.emit('terminated', terminatedBy);
+      return terminatedBy;
     }
 
     return retryIn;

--- a/packages/client/lib/client/socket.ts
+++ b/packages/client/lib/client/socket.ts
@@ -407,14 +407,6 @@ const retryIn = strategy(retries, cause);
     this.#isReady = false;
     const socket = this.#socket;
     this.#socket = undefined;
-    publish(CHANNELS.ERROR, () => ({
-      error: err,
-      origin: 'client',
-      internal: false,
-      clientId: this.#clientId
-    }));
-    this.emit('error', err);
-
     socket?.removeAllListeners('data');
     socket?.destroy();
 
@@ -422,7 +414,27 @@ const retryIn = strategy(retries, cause);
       publish(CHANNELS.CONNECTION_CLOSED, () => ({ clientId: this.#clientId, reason: 'error', wasConnected: true }));
     }
 
-    if (!wasReady || !this.#isOpen || typeof this.#shouldReconnect(0, err) !== 'number') return;
+    if (!wasReady || !this.#isOpen) {
+      publish(CHANNELS.ERROR, () => ({
+        error: err,
+        origin: 'client',
+        internal: false,
+        clientId: this.#clientId
+      }));
+      this.emit('error', err);
+      return;
+    }
+
+    const retryIn = this.#shouldReconnect(0, err);
+    if (typeof retryIn !== 'number') return;
+
+    publish(CHANNELS.ERROR, () => ({
+      error: err,
+      origin: 'client',
+      internal: false,
+      clientId: this.#clientId
+    }));
+    this.emit('error', err);
 
     this.emit('reconnecting');
     this.#connect().catch(() => {

--- a/packages/client/lib/client/socket.ts
+++ b/packages/client/lib/client/socket.ts
@@ -222,8 +222,8 @@ const retryIn = strategy(retries, cause);
         internal: false,
         clientId: this.#clientId
       }));
-      this.emit('error', cause);
       this.emit('terminated', cause);
+      this.emit('error', cause);
       return cause;
     } else if (retryIn instanceof Error) {
       this.#isOpen = false;
@@ -233,9 +233,9 @@ const retryIn = strategy(retries, cause);
         internal: false,
         clientId: this.#clientId
       }));
-      this.emit('error', cause);
       const terminatedBy = new ReconnectStrategyError(retryIn, cause);
       this.emit('terminated', terminatedBy);
+      this.emit('error', cause);
       return terminatedBy;
     }
 

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -302,7 +302,7 @@ The Node Redis client class is an Nodejs EventEmitter and it emits an event each
 | `end`                   | Connection has been closed (via `.disconnect()`)                                   | _No arguments_                                            |
 | `error`                 | An error has occurred—usually a network issue such as "Socket closed unexpectedly" | `(error: Error)`                                          |
 | `reconnecting`          | Client is trying to reconnect to the server                                        | _No arguments_                                            |
-| `terminated`             | Reconnection has stopped because `reconnectStrategy` returned `false` or an `Error` | `(cause: Error)`                                           |
+| `terminated`             | Reconnection has stopped because `reconnectStrategy` returned `false` or an `Error`; emitted before the companion `error` | `(cause: Error)`                                           |
 | `sharded-channel-moved` | See [here](https://github.com/redis/node-redis/blob/master/docs/pub-sub.md#sharded-channel-moved-event)                          | See [here](https://github.com/redis/node-redis/blob/master/docs/pub-sub.md#sharded-channel-moved-event) |
 
 > :warning: You **MUST** listen to `error` events. If a client doesn't have at least one `error` listener registered and

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -302,6 +302,7 @@ The Node Redis client class is an Nodejs EventEmitter and it emits an event each
 | `end`                   | Connection has been closed (via `.disconnect()`)                                   | _No arguments_                                            |
 | `error`                 | An error has occurred—usually a network issue such as "Socket closed unexpectedly" | `(error: Error)`                                          |
 | `reconnecting`          | Client is trying to reconnect to the server                                        | _No arguments_                                            |
+| `terminated`             | Reconnection has stopped because `reconnectStrategy` returned `false` or an `Error` | `(cause: Error)`                                           |
 | `sharded-channel-moved` | See [here](https://github.com/redis/node-redis/blob/master/docs/pub-sub.md#sharded-channel-moved-event)                          | See [here](https://github.com/redis/node-redis/blob/master/docs/pub-sub.md#sharded-channel-moved-event) |
 
 > :warning: You **MUST** listen to `error` events. If a client doesn't have at least one `error` listener registered and


### PR DESCRIPTION
Fixes #2948

When reconnecting stops because `reconnectStrategy` returns `false` or an `Error`, the client currently emits `error` but provides no separate signal that it will not retry again.

This adds a `terminated` event to `RedisSocket`, forwards it through `RedisClient`, and documents when it is emitted. Tests cover initial connection failure, terminal reconnect failures, and the retrying case.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core connection/reconnect lifecycle and error emission ordering; behavior change for apps that assumed only `error` on fatal disconnect, but additive event with documented ordering.
> 
> **Overview**
> Adds a **`terminated`** event when `reconnectStrategy` stops retrying (`false` or an `Error`), including after a connection was already **`ready`**—cases that previously only surfaced as **`error`**, same as transient disconnects (#2948).
> 
> **`RedisSocket`** centralizes that path in `#shouldReconnect`: emit **`terminated`** (with cause, often `ReconnectStrategyError`) **before** the companion **`error`**, and refactor reconnect/error handling so retries still emit **`error`** without **`terminated`**. **`RedisClient`** re-emits **`terminated`** from the socket.
> 
> README and **`client-configuration.md`** document the event and a pattern (`await events.once(client, 'terminated')`, then **`destroy()`**). New socket and client tests cover ordering, post-ready loss, and no **`terminated`** while retrying.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f74c465dae7e07fce97cc626128e79eaceb7eb38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->