### PR TITLE
fix(client): destroy pool clients that fail to close

### DIFF
--- a/docs/pool.md
+++ b/docs/pool.md
@@ -46,6 +46,20 @@ await client.withTypeMapping({
 }).ping(); // Buffer
 ```
 
+## Closing a pool
+
+Use `await pool.close()` to wait for in-flight and queued tasks to finish before closing the connections. Once closing starts, new tasks are rejected with `ClientClosedError`.
+
+If a client's `close()` rejects, the pool attempts to destroy that client and still waits for the remaining clients to finish closing. The pool clears its client lists and cache and marks itself closed, then rejects with a client close error. Handle this rejection at the call site:
+
+```javascript
+try {
+  await pool.close();
+} catch (err) {
+  console.error('Failed to close a pooled client', err);
+}
+```
+
 ## Transactions
 
 Things get a little more complex with transactions. Here we are `.watch()`ing some keys. If the keys change during the transaction, a `WatchError` is thrown when `.exec()` is called:

--- a/packages/client/lib/client/pool.spec.ts
+++ b/packages/client/lib/client/pool.spec.ts
@@ -136,6 +136,25 @@ describe('RedisClientPool', () => {
     }
   });
 
+  testUtils.testWithClientPool('close keeps the client close error when cache cleanup also fails', async pool => {
+    pool.clientSideCache!.onPoolClose = () => {
+      throw new Error('cache cleanup failed');
+    };
+
+    await pool.execute(client => client.destroy());
+
+    await assert.rejects(pool.close(), ClientClosedError);
+    assert.equal(pool.totalClients, 0);
+    assert.equal(pool.isOpen, false);
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    poolOptions: {
+      minimum: 1,
+      maximum: 1,
+      clientSideCache: new BasicPooledClientSideCache({})
+    }
+  });
+
   testUtils.testWithClientPool('close waits for the remaining clients after a close rejection', async pool => {
     const clients = await Promise.all([
       pool.execute(async client => client),
@@ -242,6 +261,42 @@ describe('RedisClientPool', () => {
   }, {
     ...GLOBAL.SERVERS.OPEN,
     poolOptions: { minimum: 1, maximum: 1 }
+  });
+
+  testUtils.testWithClientPool('close rejects work started from a client close hook', async pool => {
+    const client = await pool.execute(client => client);
+    const originalClose = client.close.bind(client);
+    let reentrantTask!: Promise<unknown>;
+    client.close = () => {
+      reentrantTask = pool.execute(() => 'reentrant');
+      return originalClose();
+    };
+
+    await pool.close();
+    await assert.rejects(reentrantTask, { message: /closed/i });
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    poolOptions: { minimum: 1, maximum: 1 }
+  });
+
+  testUtils.testWithClientPool('close keeps the pool closing during cache cleanup', async pool => {
+    let reconnect: Promise<unknown> | undefined;
+    pool.clientSideCache!.onPoolClose = () => {
+      reconnect = pool.connect();
+    };
+
+    await pool.close();
+    assert.ok(reconnect);
+    await reconnect;
+    assert.equal(pool.totalClients, 0);
+    assert.equal(pool.isOpen, false);
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    poolOptions: {
+      minimum: 1,
+      maximum: 1,
+      clientSideCache: new BasicPooledClientSideCache({})
+    }
   });
 
   testUtils.testWithClientPool('close waits for in-flight and queued tasks', async pool => {

--- a/packages/client/lib/client/pool.spec.ts
+++ b/packages/client/lib/client/pool.spec.ts
@@ -2,7 +2,8 @@ import { strict as assert } from 'node:assert';
 import testUtils, { GLOBAL } from '../test-utils';
 import { RESP_TYPES } from '../RESP/decoder';
 import { RedisClientPool } from './pool';
-import { TimeoutError } from '../errors';
+import { ClientClosedError, TimeoutError } from '../errors';
+import { BasicPooledClientSideCache } from './cache';
 
 describe('RedisClientPool', () => {
   it('chained withCommandOptions(...).withTypeMapping(...) preserves earlier overrides at dispatch', () => {
@@ -112,6 +113,120 @@ describe('RedisClientPool', () => {
     assert.equal(pool.totalClients, 0, 'totalClients should be 0 after destroy');
     assert.equal(pool.isOpen, false, 'isOpen should be false after destroy');
   }, GLOBAL.SERVERS.OPEN);
+
+  testUtils.testWithClientPool('close rejects and clears the pool when a client is already closed', async pool => {
+    let cacheClosed = false;
+    pool.clientSideCache!.onPoolClose = () => {
+      cacheClosed = true;
+    };
+
+    await pool.execute(client => client.destroy());
+
+    await assert.rejects(pool.close(), ClientClosedError);
+    assert.equal(pool.totalClients, 0);
+    assert.equal(pool.isOpen, false);
+    assert.equal(pool.isClosing, false);
+    assert.equal(cacheClosed, true);
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    poolOptions: {
+      minimum: 1,
+      maximum: 1,
+      clientSideCache: new BasicPooledClientSideCache({})
+    }
+  });
+
+  testUtils.testWithClientPool('close waits for the remaining clients after a close rejection', async pool => {
+    const clients = await Promise.all([
+      pool.execute(async client => client),
+      pool.execute(async client => client)
+    ]);
+    assert.notEqual(clients[0], clients[1]);
+    clients[0].destroy();
+
+    let finishClose!: () => void;
+    const pendingClose = new Promise<void>(resolve => { finishClose = resolve; });
+    const originalClose = clients[1].close.bind(clients[1]);
+    clients[1].close = async () => {
+      await pendingClose;
+      await originalClose();
+    };
+
+    let settled = false;
+    const closeResult = pool.close().then(
+      () => { settled = true; return undefined; },
+      error => { settled = true; return error; }
+    );
+
+    try {
+      await new Promise(resolve => setImmediate(resolve));
+      assert.equal(settled, false);
+      assert.equal(pool.isClosing, true);
+    } finally {
+      finishClose();
+      await closeResult;
+    }
+
+    assert.ok(await closeResult instanceof ClientClosedError);
+    assert.equal(clients[1].isOpen, false);
+    assert.equal(pool.totalClients, 0);
+    assert.equal(pool.isOpen, false);
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    poolOptions: { minimum: 2, maximum: 2 }
+  });
+
+  for (const failDestroy of [false, true]) {
+    testUtils.testWithClientPool(`close destroys failed clients when credential disposal ${failDestroy ? 'always fails' : 'fails once'}`, async pool => {
+      const clients = await Promise.all([
+        pool.execute(async client => client),
+        pool.execute(async client => client)
+      ]);
+      assert.notEqual(clients[0], clients[1]);
+
+      try {
+        await assert.rejects(pool.close(), { message: 'close failed' });
+        for (const client of clients) {
+          assert.equal(client.isReady, false);
+          assert.equal(client.isOpen, false);
+        }
+        assert.equal(pool.totalClients, 0);
+        assert.equal(pool.isOpen, false);
+        assert.equal(pool.isClosing, false);
+      } finally {
+        for (const client of clients) {
+          if (!client.isReady) continue;
+          try {
+            client.destroy();
+          } catch {
+            // The test provider can throw again after destroy tears down the socket.
+          }
+        }
+      }
+    }, {
+      ...GLOBAL.SERVERS.OPEN,
+      clientOptions: {
+        ...GLOBAL.SERVERS.OPEN.clientOptions,
+        credentialsProvider: {
+          type: 'streaming-credentials-provider',
+          subscribe: async () => {
+            let disposed = false;
+            return [{}, {
+              dispose() {
+                if (!disposed) {
+                  disposed = true;
+                  throw new Error('close failed');
+                }
+                if (failDestroy) throw new Error('destroy failed');
+              }
+            }];
+          },
+          onReAuthenticationError: () => {}
+        }
+      },
+      poolOptions: { minimum: 2, maximum: 2 }
+    });
+  }
 
   testUtils.testWithClientPool('close waits for in-flight and queued tasks', async pool => {
     const events: string[] = [];

--- a/packages/client/lib/client/pool.spec.ts
+++ b/packages/client/lib/client/pool.spec.ts
@@ -228,6 +228,22 @@ describe('RedisClientPool', () => {
     });
   }
 
+  testUtils.testWithClientPool('close shares its outcome with a concurrent caller', async pool => {
+    await pool.execute(client => client.destroy());
+
+    const [first, second] = await Promise.allSettled([pool.close(), pool.close()]);
+
+    assert.equal(first.status, 'rejected');
+    assert.equal(second.status, 'rejected');
+    assert.equal((first as PromiseRejectedResult).reason, (second as PromiseRejectedResult).reason);
+    assert.equal(pool.totalClients, 0);
+    assert.equal(pool.isOpen, false);
+    assert.equal(pool.isClosing, false);
+  }, {
+    ...GLOBAL.SERVERS.OPEN,
+    poolOptions: { minimum: 1, maximum: 1 }
+  });
+
   testUtils.testWithClientPool('close waits for in-flight and queued tasks', async pool => {
     const events: string[] = [];
 

--- a/packages/client/lib/client/pool.ts
+++ b/packages/client/lib/client/pool.ts
@@ -632,21 +632,31 @@ export class RedisClientPool<
       // Now all tasks are done, close all clients (which are now idle)
       const promises = [];
       for (const client of this._self.#idleClients) {
-        promises.push(client.close());
+        promises.push(client.close().catch(err => {
+          try {
+            // close() can reject before the socket is destroyed, for example
+            // when disposing a credentials subscription throws.
+            client.destroy();
+          } catch {
+            // Preserve the close error even if forced cleanup also fails.
+          }
+          throw err;
+        }));
       }
 
-      await Promise.all(promises);
-
-      this._self.#clientSideCache?.onPoolClose();
-
+      // A failed close must not let the pool finish closing while other clients
+      // are still draining their pending commands.
+      const results = await Promise.allSettled(promises);
+      for (const result of results) {
+        if (result.status === 'rejected') throw result.reason;
+      }
+    } finally {
       this._self.#idleClients.reset();
       this._self.#clientsInUse.reset();
-    } catch {
-
-    } finally {
       this._self.#drainResolve = undefined;
       this._self.#isClosing = false;
       this._self.#isOpen = false;
+      this._self.#clientSideCache?.onPoolClose();
     }
   }
 

--- a/packages/client/lib/client/pool.ts
+++ b/packages/client/lib/client/pool.ts
@@ -282,6 +282,12 @@ export class RedisClientPool<
    */
   #drainResolve?: () => void;
 
+  /**
+   * The in-flight close() promise, shared with any concurrent caller so they
+   * observe the same outcome instead of an early, unconditional resolve.
+   */
+  #closePromise?: Promise<void>;
+
   #clientSideCache?: PooledClientSideCacheProvider;
   get clientSideCache() {
     return this._self.#clientSideCache;
@@ -615,12 +621,16 @@ export class RedisClientPool<
   multi = this.MULTI;
 
   async close() {
-    if (this._self.#isClosing) return; // TODO: throw err?
+    if (this._self.#isClosing) return this._self.#closePromise; // TODO: throw err?
     if (!this._self.#isOpen) return; // TODO: throw err?
 
     this._self.#isClosing = true;
     clearTimeout(this._self.cleanupTimeout);
+    this._self.#closePromise = this._self.#doClose();
+    return this._self.#closePromise;
+  }
 
+  async #doClose() {
     try {
       // Wait for all in-flight and queued tasks to complete
       if (this._self.#clientsInUse.length > 0) {
@@ -656,6 +666,7 @@ export class RedisClientPool<
       this._self.#drainResolve = undefined;
       this._self.#isClosing = false;
       this._self.#isOpen = false;
+      this._self.#closePromise = undefined;
       this._self.#clientSideCache?.onPoolClose();
     }
   }

--- a/packages/client/lib/client/pool.ts
+++ b/packages/client/lib/client/pool.ts
@@ -267,13 +267,11 @@ export class RedisClientPool<
     return this._self.#isOpen;
   }
 
-  #isClosing = false;
-
   /**
    * Whether the pool is closing (*not* closed).
    */
   get isClosing() {
-    return this._self.#isClosing;
+    return this._self.#closePromise !== undefined;
   }
 
   /**
@@ -457,7 +455,7 @@ export class RedisClientPool<
       this._self.#clientsInUse.remove(node);
       // Closing with no client left: `#returnClient()`, the only other place that signals the
       // drain, will not run again, and nothing can pick up the queued tasks either
-      if (this._self.#isClosing && this._self.#clientsInUse.length === 0) {
+      if (this._self.isClosing && this._self.#clientsInUse.length === 0) {
         let task;
         while ((task = this._self.#tasksQueue.shift())) {
           clearTimeout(task.timeout);
@@ -473,7 +471,7 @@ export class RedisClientPool<
 
   execute<T>(fn: PoolTask<M, F, S, RESP, TYPE_MAPPING, T>) {
     return new Promise<Awaited<T>>((resolve, reject) => {
-      if (this._self.#isClosing || !this._self.#isOpen) {
+      if (this._self.isClosing || !this._self.#isOpen) {
         return reject(new ClientClosedError());
       }
 
@@ -572,7 +570,7 @@ export class RedisClientPool<
     this.#idleClients.push(node.value);
 
     // If closing and all tasks are done, signal the drain is complete
-    if (this.#isClosing && this.#clientsInUse.length === 0) {
+    if (this.isClosing && this.#clientsInUse.length === 0) {
       this.#drainResolve?.();
       return;
     }
@@ -621,12 +619,11 @@ export class RedisClientPool<
   multi = this.MULTI;
 
   async close() {
-    if (this._self.#isClosing) return this._self.#closePromise; // TODO: throw err?
+    if (this._self.isClosing) return this._self.#closePromise; // TODO: throw err?
     if (!this._self.#isOpen) return; // TODO: throw err?
 
-    this._self.#isClosing = true;
     clearTimeout(this._self.cleanupTimeout);
-    this._self.#closePromise = this._self.#doClose();
+    this._self.#closePromise = Promise.resolve().then(() => this._self.#doClose());
     return this._self.#closePromise;
   }
 
@@ -661,13 +658,19 @@ export class RedisClientPool<
         if (result.status === 'rejected') throw result.reason;
       }
     } finally {
+      try {
+        // A throw here would replace a pending client close error, since a
+        // throw inside `finally` overrides the exception already in flight.
+        this._self.#clientSideCache?.onPoolClose();
+      } catch {
+        // Preserve the client close error even if cache cleanup also fails.
+      }
+
       this._self.#idleClients.reset();
       this._self.#clientsInUse.reset();
       this._self.#drainResolve = undefined;
-      this._self.#isClosing = false;
       this._self.#isOpen = false;
       this._self.#closePromise = undefined;
-      this._self.#clientSideCache?.onPoolClose();
     }
   }
 


### PR DESCRIPTION
close() awaited Promise.all() over each idle client's close() inside a try/catch with an empty catch block. One client failing to close skipped everything after it: #idleClients and #clientsInUse were never reset, and the rejection never reached the caller.

Switched to Promise.allSettled and moved cleanup into a finally block, so every client gets processed and the pool resets regardless of individual failures. A client whose close() rejects is destroyed, and close() rethrows the first rejection instead of discarding it.

Two follow-ups from review: a concurrent close() call while one was already in progress used to resolve immediately regardless of the outcome, so close() now shares its in-flight promise with concurrent callers. And a cache cleanup failure in the finally block could replace a pending client close error (a throw in finally overrides the exception it's handling), so cache cleanup is now wrapped in its own try/catch.

Tests: one client already closed makes close() reject while the pool still resets; a second client's close() is delayed to check it still gets waited on; concurrent close() calls observe the same outcome; a failing cache cleanup doesn't hide the real close error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes lifecycle teardown for pooled connections (close/drain/cache), which can affect shutdown ordering and error propagation in apps using credentials providers or client-side cache.
> 
> **Overview**
> **`pool.close()`** no longer swallows per-client close failures or leaves the pool half-torn-down. Client shutdown uses **`Promise.allSettled`** so every idle client is closed (or cleaned up) before the pool resets; a rejecting **`close()`** triggers **`destroy()`** on that client and the promise **rejects with the first close error** instead of resolving after an empty catch.
> 
> Concurrent **`close()`** calls now **share one in-flight promise** (via **`#closePromise`**, replacing a separate **`#isClosing` flag**) so later callers get the same resolve/reject outcome. Pool teardown (idle/in-use lists, **`isOpen`**, client-side cache **`onPoolClose`**) runs in a **`finally`** block so it always runs; cache cleanup errors are caught so they do not mask the underlying client close error.
> 
> **`docs/pool.md`** documents graceful shutdown, **`ClientClosedError`** for new work while closing, and handling close rejections. **`pool.spec.ts`** adds coverage for partial failures, concurrent close, credential disposal errors, cache cleanup, and reentrant **`execute`** during close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a8f5a8bb9abf974bde527bf81fcfe646ba0d04b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->