### PR TITLE
fix(cluster): emit node-connect/node-ready on every reconnection

### DIFF
--- a/docs/clustering.md
+++ b/docs/clustering.md
@@ -152,10 +152,10 @@ The Node Redis Cluster class extends Node.js’s EventEmitter and emits the foll
 | `connect`               | The cluster has successfully connected and is ready to us                          | _No arguments_                                            |
 | `disconnect`            | The cluster has disconnected                                                       | _No arguments_                                            |
 | `error`                 | The cluster has errored                                                            | `(error: Error)`                                          |
-| `node-ready`            | A cluster node is ready to establish a connection                                  | `(node: { host: string, port: number })`                  |
-| `node-connect`          | A cluster node has connected                                                       | `(node: { host: string, port: number })`                  |
+| `node-ready`            | A cluster node is ready to use, on its first connection and on every reconnection  | `(node: { host: string, port: number })`                  |
+| `node-connect`          | A cluster node's socket has connected, before its handshake — on the first connection and on every reconnection | `(node: { host: string, port: number })` |
 | `node-reconnecting`     | A cluster node is attempting to reconnect after an error                           | `(node: { host: string, port: number })`                  |
-| `node-disconnect`       | A cluster node has disconnected                                                    | `(node: { host: string, port: number })`                  |
+| `node-disconnect`       | A cluster node has disconnected (via `close()` or `destroy()`)                      | `(node: { host: string, port: number })`                  |
 | `node-error`            | A cluster node has has errored (usually during TCP connection)                     | `(error: Error, node: { host: string, port: number })`    |
 
 > :warning: You **MUST** listen to `error` events. If a cluster doesn't have at least one `error` listener registered and

--- a/packages/client/lib/cluster/cluster-slots.ts
+++ b/packages/client/lib/cluster/cluster-slots.ts
@@ -789,8 +789,8 @@ export default class RedisClusterSlots<
         wasReady = true;
         this.#reconnectionTracker.removeClient(client._clientId);
       })
-      .once('ready', () => emit('node-ready', clientInfo))
-      .once('connect', () => emit('node-connect', clientInfo))
+      .on('ready', () => emit('node-ready', clientInfo))
+      .on('connect', () => emit('node-connect', clientInfo))
       .once('end', () => {
         this.#reconnectionTracker.removeClient(client._clientId);
         emit('node-disconnect', clientInfo);

--- a/packages/client/lib/cluster/index.spec.ts
+++ b/packages/client/lib/cluster/index.spec.ts
@@ -878,6 +878,54 @@ describe('Cluster', () => {
         minimizeConnections: false
       }
     });
+
+    testUtils.testWithCluster('should fire node-connect and node-ready again after a node reconnects', async cluster => {
+      const master = cluster.masters[0],
+        log: Array<string> = [];
+
+      cluster
+        .on('node-reconnecting', () => log.push('node-reconnecting'))
+        .on('node-connect', () => log.push('node-connect'))
+        .on('node-ready', () => log.push('node-ready'));
+
+      // Drop the server side of exactly the cluster's own connection to this
+      // node: ask that node client for its CLIENT ID, then kill that id from a
+      // separate connection so nothing else on the node is affected.
+      const nodeClientId = await master.client!.sendCommand(['CLIENT', 'ID']),
+        killer = RedisClient.create({
+          socket: { host: master.host, port: master.port }
+        });
+
+      await killer.connect();
+      try {
+        await killer.sendCommand(['CLIENT', 'KILL', 'ID', String(nodeClientId)]);
+      } finally {
+        killer.destroy();
+      }
+
+      // The node client reconnects on its own; wait for the events rather than
+      // for a fixed delay. The budget here (5s) must stay well inside
+      // `testTimeout` below, which has to be raised because Mocha's default is
+      // 2s. Without the fix `node-reconnecting` is the only one that ever
+      // arrives and the loop exhausts -> assertion fails.
+      for (let i = 0; i < 100 && !log.includes('node-ready'); i++) {
+        await setTimeout(50);
+      }
+
+      assert.deepEqual(log, [
+        'node-reconnecting',
+        'node-connect',
+        'node-ready'
+      ]);
+    }, {
+      ...GLOBAL.CLUSTERS.OPEN,
+      numberOfMasters: 2,
+      numberOfReplicas: 0,
+      testTimeout: 30000,
+      clusterConfiguration: {
+        minimizeConnections: false
+      }
+    });
   });
 
 });


### PR DESCRIPTION
### Description

`RedisCluster` wires `node-reconnecting` with `.on`, but its counterparts `node-ready` and `node-connect` with `.once`:

https://github.com/redis/node-redis/blob/d33e4af/packages/client/lib/cluster/cluster-slots.ts#L781-L793

So those two are spent on a node client's first connection. When that same client later reconnects, the standalone client underneath re-emits `connect` and `ready` (`socket.ts` emits them inside its connect path, `client/index.ts` forwards them) — the cluster swallows both, while `node-reconnecting` keeps arriving on every attempt.

A consumer tracking node health from these events is therefore told the node went away and never told it came back. It stays latched for the lifetime of that client, and the only way out on the application side is polling `isReady` across `nodeByAddress` on a timer, which is what these events exist to avoid.

### Scope

The defect is confined to a node client reconnecting to the **same address** — a transient network blip, a server restart, a killed connection.

It does *not* affect a node being replaced at a new address: the topology refresh creates a brand-new client there, and that client's first `ready` still satisfies `.once`. I verified that separately so as not to overstate the fix — killing a master outright and letting a replica be promoted produces `node-connect`/`node-ready` for the promoted address even on unpatched `master`.

### Reproduction

Against a real six-node cluster on `master` (d33e4af), dropping the server side of exactly the cluster's own connection to one node (`CLIENT ID` on the node client, then `CLIENT KILL ID` from a separate connection):

```
killed cluster node client id=19 on master 30000
events after the reconnection: ["node-reconnecting 30000"]
node-reconnecting=1 node-connect=0 node-ready=0 isReady=true
```

The node client is `isReady` again, and the consumer was never told. With this change:

```
killed cluster node client id=20 on master 30000
events after the reconnection: ["node-reconnecting 30000","node-connect 30000","node-ready 30000"]
node-reconnecting=1 node-connect=1 node-ready=1 isReady=true
```

### The change

Emit both with `.on`, matching `node-reconnecting` and the standalone client.

`node-disconnect` deliberately stays on `.once('end')`: `end` is emitted from `destroySocket()`, which is reached only through `quit()`/`destroy()` and never from the reconnect path, so it cannot repeat for a single client.

Startup behaviour is unchanged — one `node-connect` and one `node-ready` per node, in the same order the existing `clusterEvents` test asserts. `#createClient` is also used for the pub/sub node client and for sharded pub/sub clients, so those become observable across reconnections too.

#### Cost

- `connect` and `ready` are emitted only from the socket's connect path (`socket.ts` L258, L291); neither is on a command path, so nothing is added per command.
- Listener registrations per node client are unchanged (9 before, 9 after) — this swaps two registrations rather than adding any.
- The new emissions are strictly rarer than an existing one: `node-reconnecting` fires per reconnection *attempt*, while `node-ready` fires per *successful* connection.
- `.on` also avoids the `onceWrapper` allocation and the `removeListener` call that `.once` performs.

### Docs

`docs/clustering.md` described `node-ready` as "ready to establish a connection" and said nothing about repetition. The three affected rows now state the actual contract.

### Why it was not caught

The existing `clusterEvents` test only covers `connect()` followed by `destroy()`, so no node ever reconnects during it. The new test drives a real reconnection using the same mechanism as the reproduction above, and waits for the events rather than for a fixed delay.

### Verification

- New test added to the `clusterEvents` suite, exercised in both directions on `./lib/cluster/index.spec.ts`: **156 passing** on this branch, including `✔ should fire node-connect and node-ready again after a node reconnects`; with `cluster-slots.ts` reverted to `origin/master`, **155 passing, 1 failing** — that test, on its `assert.deepEqual`. The pre-existing `should fire events` passes either way, so the startup sequence it pins is unchanged.
- Held over repeated reconnections, which is the regime this matters in: once a client is configured with `socketTimeout` — the only setting that breaks a blackholed connection, since a command's timeout listener is dropped the moment it is written — reconnections stop being rare. Flapping one node client four times in a row produced exactly four `node-reconnecting`/`node-connect`/`node-ready` triples, no duplicate emissions, and no listener growth on the node client (2 `ready` listeners before and after); the cluster kept serving throughout.
- `npm run test:types` in `packages/client` — passes.
- `node scripts/lint-changed.mjs --base origin/master --head HEAD`, the exact gate CI runs, lints the two changed `.ts` files and exits 0. `eslint --max-warnings=0` on both is clean.
- No consumer inside node-redis listens to any `node-*` event, so this cannot change the library's own behaviour — only what reaches the application.
- One thing this PR does not change: `#emit` is the raw `this.emit.bind(this)`, so a throwing `node-ready` listener has the same exposure as a throwing `node-reconnecting` or `node-error` listener does today. Making cluster surface listener failures as `error` the way #3430 did for sentinel would be a separate change.

---

### Checklist

- [x] Does `npm test` pass with this change (including linting)?
- [x] Is the new or changed code fully tested?
- [x] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?
