### PR TITLE
fix(bloom): handle new cell size field in CMS.INFO reply

### DIFF
--- a/packages/bloom/lib/commands/count-min-sketch/INFO.spec.ts
+++ b/packages/bloom/lib/commands/count-min-sketch/INFO.spec.ts
@@ -19,11 +19,13 @@ describe('CMS.INFO', () => {
         client.cms.info('key')
       ]);
 
-    const expected = {};
-    expected['width'] = width;
-    expected['depth'] = depth;
-    expected['count'] = 0;
-
-    assert.deepEqual(reply, expected);
+    assert.equal(reply.width, width);
+    assert.equal(reply.depth, depth);
+    assert.equal(reply.count, 0);
+    // Newer server builds also report the counter byte width (uint32 => 4);
+    // older builds omit the field entirely.
+    if ('cell size' in reply) {
+      assert.equal(reply['cell size'], 4);
+    }
   }, GLOBAL.SERVERS.OPEN);
 });

--- a/packages/bloom/lib/commands/count-min-sketch/INFO.ts
+++ b/packages/bloom/lib/commands/count-min-sketch/INFO.ts
@@ -5,13 +5,15 @@ import { transformInfoV2Reply } from '../bloom';
 export type CmsInfoReplyMap = TuplesToMapReply<[
   [SimpleStringReply<'width'>, NumberReply],
   [SimpleStringReply<'depth'>, NumberReply],
-  [SimpleStringReply<'count'>, NumberReply]
+  [SimpleStringReply<'count'>, NumberReply],
+  [SimpleStringReply<'cell size'>, NumberReply]
 ]>;
 
 export interface CmsInfoReply {
   width: NumberReply;
   depth: NumberReply;
   count: NumberReply;
+  'cell size'?: NumberReply;
 }
  
 export default {


### PR DESCRIPTION
Newer Redis server builds add a `cell size` field to the CMS.INFO reply (the uint32 counter byte width, always 4). The command's pass-through transform surfaced the extra key, breaking the spec's exact-match assertion. Declare the optional field in the reply types and assert known fields individually, validating `cell size == 4` only when the server reports it (older builds omit it).

### Description

<!-- Please provide a description of the change below, e.g What was the purpose? -->
<!-- Why does it matter to you? What problem are you trying to solve? -->
<!-- Tag in any linked issues. -->

> Describe your pull request here

---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?
- [ ] Is a documentation update included (if this change modifies existing APIs, or introduces new ones)?

<!-- NOTE: these things are not required to open a PR and can be done
afterwards / while the PR is open. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow typing and test-only assertion changes for an optional CMS.INFO field; no auth, data migration, or runtime behavior change beyond acknowledging server output.
> 
> **Overview**
> **CMS.INFO** client types and integration tests are updated for newer Redis builds that add an optional **`cell size`** field (counter width in bytes, expected **4** for uint32).
> 
> `CmsInfoReply` / `CmsInfoReplyMap` now declare **`cell size`** as optional so the pass-through transform stays typed without breaking callers on older servers that omit it. The spec no longer uses **`deepEqual`** on the full reply (which failed when the extra key appeared); it asserts **`width`**, **`depth`**, and **`count`** explicitly and checks **`cell size === 4`** only when present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 354a3fe1d45407831bb906add5fc83db46cfe2f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->