### PR TITLE
feat(client): improve client instantiation error messages

### DIFF
--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -227,6 +227,13 @@ describe('Client', () => {
 
     })
 
+    it('Invalid URL', () => {
+      assert.throws(
+        () => RedisClient.parseURL('random-string'),
+        TypeError
+      );
+    });
+
     it('Invalid protocol', () => {
       assert.throws(
         () => RedisClient.parseURL('redi://user:secret@localhost:6379/0'),

--- a/packages/client/lib/client/index.spec.ts
+++ b/packages/client/lib/client/index.spec.ts
@@ -227,13 +227,6 @@ describe('Client', () => {
 
     })
 
-    it('Invalid URL', () => {
-      assert.throws(
-        () => RedisClient.parseURL('random-string'),
-        TypeError
-      );
-    });
-
     it('Invalid protocol', () => {
       assert.throws(
         () => RedisClient.parseURL('redi://user:secret@localhost:6379/0'),

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -469,6 +469,10 @@ export default class RedisClient<
       tls: boolean
     }
   } {
+    if(!URL.canParse(url)){
+      throw new TypeError(`URL supplied - ${url} - is not a valid URL`);
+    }
+
     // unix:// URIs use a non-special scheme; WHATWG URL refuses to parse an
     // authority (e.g. `user:pass@`) without a host, so handle it separately.
     if (url.startsWith('unix:')) {
@@ -490,7 +494,7 @@ export default class RedisClient<
       };
 
     if (protocol !== 'redis:' && protocol !== 'rediss:') {
-      throw new TypeError('Invalid protocol');
+      throw new TypeError(`Protocol - ${protocol} - is not a valid Redis protocol. Expected redis: or rediss:`);
     }
 
     parsed.socket.tls = protocol === 'rediss:';

--- a/packages/client/lib/client/index.ts
+++ b/packages/client/lib/client/index.ts
@@ -469,10 +469,6 @@ export default class RedisClient<
       tls: boolean
     }
   } {
-    if(!URL.canParse(url)){
-      throw new TypeError(`URL supplied - ${url} - is not a valid URL`);
-    }
-
     // unix:// URIs use a non-special scheme; WHATWG URL refuses to parse an
     // authority (e.g. `user:pass@`) without a host, so handle it separately.
     if (url.startsWith('unix:')) {


### PR DESCRIPTION
### Description
We are using this module and have found that the errors could be a bit better. 

This PR adds a check that the URL is actually a url, and improves the TypeError - invalid protocol - to include the protocol that it does see.

**Please note that upon `npm i` and then `npm t` the tests fail to run with a number of `MODULE_NOT_FOUND` messages. The `npm run build:tests-tools && npm test` listed in the [Contributing guide](https://github.com/redis/node-redis/blob/master/CONTRIBUTING.md) result in `Missing script: "build:tests-tools"`.** Hopefully this PR is small enough to easily pass tests running on CI etc. 

Thank you in advance
---

### Checklist

<!-- Please make sure to review and check all of these items: -->

- [ ] Does `npm test` pass with this change (including linting)?
- [ ] Is the new or changed code fully tested?


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only change to a validation error path in URL parsing; no connection or auth behavior changes.
> 
> **Overview**
> When `createClient` (or `parseURL`) is given a connection URL whose scheme is not `redis:` or `rediss:`, the client now throws a **`TypeError`** that **includes the actual protocol** from the URL and states that **`redis:` or `rediss:`** are expected.
> 
> Previously the message was the generic **`Invalid protocol`**, which made mis-typed schemes (e.g. `redi://`) harder to diagnose at instantiation time.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b02620bc8bb4f80dd5eafa6231862e0260e19b16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->